### PR TITLE
feat: add pgque-specific schema additions

### DIFF
--- a/sql/pgque-additions/config.sql
+++ b/sql/pgque-additions/config.sql
@@ -1,0 +1,13 @@
+-- pgque.config — singleton configuration table
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+create table if not exists pgque.config (
+    singleton       bool primary key default true check (singleton),
+    ticker_job_id   bigint,
+    maint_job_id    bigint,
+    installed_at    timestamptz not null default clock_timestamp()
+);
+
+-- Idempotent insert
+insert into pgque.config (singleton) values (true)
+on conflict (singleton) do nothing;

--- a/sql/pgque-additions/lifecycle.sql
+++ b/sql/pgque-additions/lifecycle.sql
@@ -18,12 +18,9 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 create or replace function pgque.uninstall()
 returns void as $$
 begin
-    -- Stop pg_cron jobs if possible
-    begin
-        perform pgque.stop();
-    exception when others then
-        null;
-    end;
+    -- Stop pg_cron jobs before dropping the schema.
+    -- Sprint 2: stop() must handle its own errors when pg_cron integration lands.
+    perform pgque.stop();
     -- Drop everything
     drop schema pgque cascade;
     -- Note: roles are not dropped here (they may be in use by other databases)

--- a/sql/pgque-additions/lifecycle.sql
+++ b/sql/pgque-additions/lifecycle.sql
@@ -1,0 +1,39 @@
+-- pgque lifecycle functions
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+create or replace function pgque.start()
+returns void as $$
+begin
+    raise notice 'pgque.start(): pg_cron integration will be implemented in Sprint 2';
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+create or replace function pgque.stop()
+returns void as $$
+begin
+    raise notice 'pgque.stop(): pg_cron integration will be implemented in Sprint 2';
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+create or replace function pgque.uninstall()
+returns void as $$
+begin
+    -- Stop pg_cron jobs if possible
+    begin
+        perform pgque.stop();
+    exception when others then
+        null;
+    end;
+    -- Drop everything
+    drop schema pgque cascade;
+    -- Note: roles are not dropped here (they may be in use by other databases)
+    raise notice 'pgque uninstalled. Run DROP ROLE IF EXISTS pgque_reader, pgque_writer, pgque_admin; manually if needed.';
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+create or replace function pgque.version()
+returns text as $$
+begin
+    return '1.0.0-dev';
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;

--- a/sql/pgque-additions/notify.sql
+++ b/sql/pgque-additions/notify.sql
@@ -1,0 +1,11 @@
+-- LISTEN/NOTIFY integration for pgque ticker
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- The ticker function (pgque.ticker) will emit:
+--   perform pg_notify('pgque_' || queue_name, tick_id::text);
+-- after each tick.
+--
+-- This is applied as a post-transform patch to the ticker function
+-- in build/transform.sh or during install script assembly.
+--
+-- Consumers can: LISTEN pgque_<queue_name>;

--- a/sql/pgque-additions/queue_max_retries.sql
+++ b/sql/pgque-additions/queue_max_retries.sql
@@ -1,0 +1,16 @@
+-- Add queue_max_retries column to pgque.queue
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- The queue table is defined in PgQ's tables.sql.  After the transformed
+-- PgQ schema is installed, we add this pgque-specific column.
+
+do $$
+begin
+    if not exists (
+        select 1 from information_schema.columns
+        where table_schema = 'pgque' and table_name = 'queue'
+        and column_name = 'queue_max_retries'
+    ) then
+        alter table pgque.queue add column queue_max_retries int4;
+    end if;
+end $$;

--- a/sql/pgque-additions/roles.sql
+++ b/sql/pgque-additions/roles.sql
@@ -7,8 +7,16 @@ do $$ begin create role pgque_writer; exception when duplicate_object then null;
 do $$ begin create role pgque_admin;  exception when duplicate_object then null; end $$;
 
 -- Inheritance: admin > writer > reader
-grant pgque_reader to pgque_writer;
-grant pgque_writer to pgque_admin;
+-- Wrapped in exception handlers for PG14/15 compatibility (no IF NOT EXISTS
+-- for role grants until PG16).
+do $$ begin
+    grant pgque_reader to pgque_writer;
+exception when duplicate_object then null;
+end $$;
+do $$ begin
+    grant pgque_writer to pgque_admin;
+exception when duplicate_object then null;
+end $$;
 
 -- ---------------------------------------------------------------------------
 -- Reader: read-only access to schema and information functions
@@ -62,3 +70,6 @@ grant all on schema pgque to pgque_admin;
 grant all on all tables in schema pgque to pgque_admin;
 grant all on all sequences in schema pgque to pgque_admin;
 grant execute on all functions in schema pgque to pgque_admin;
+
+-- uninstall() drops the entire schema — only superuser / schema owner should run it
+revoke execute on function pgque.uninstall() from pgque_admin;

--- a/sql/pgque-additions/roles.sql
+++ b/sql/pgque-additions/roles.sql
@@ -1,0 +1,64 @@
+-- pgque security roles
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+-- Create roles idempotently
+do $$ begin create role pgque_reader; exception when duplicate_object then null; end $$;
+do $$ begin create role pgque_writer; exception when duplicate_object then null; end $$;
+do $$ begin create role pgque_admin;  exception when duplicate_object then null; end $$;
+
+-- Inheritance: admin > writer > reader
+grant pgque_reader to pgque_writer;
+grant pgque_writer to pgque_admin;
+
+-- ---------------------------------------------------------------------------
+-- Reader: read-only access to schema and information functions
+-- ---------------------------------------------------------------------------
+grant usage on schema pgque to pgque_reader;
+grant select on all tables in schema pgque to pgque_reader;
+
+-- get_queue_info — 0-arg (all queues) and 1-arg (single queue)
+grant execute on function pgque.get_queue_info() to pgque_reader;
+grant execute on function pgque.get_queue_info(text) to pgque_reader;
+
+-- get_consumer_info — 0-arg, 1-arg, 2-arg overloads
+grant execute on function pgque.get_consumer_info() to pgque_reader;
+grant execute on function pgque.get_consumer_info(text) to pgque_reader;
+grant execute on function pgque.get_consumer_info(text, text) to pgque_reader;
+
+-- get_batch_info(bigint)
+grant execute on function pgque.get_batch_info(bigint) to pgque_reader;
+
+-- version
+grant execute on function pgque.version() to pgque_reader;
+
+-- ---------------------------------------------------------------------------
+-- Writer: can produce events and manage consumer lifecycle
+-- ---------------------------------------------------------------------------
+
+-- insert_event — 3-arg and 7-arg overloads
+grant execute on function pgque.insert_event(text, text, text) to pgque_writer;
+grant execute on function pgque.insert_event(text, text, text, text, text, text, text) to pgque_writer;
+
+-- consumer registration
+grant execute on function pgque.register_consumer(text, text) to pgque_writer;
+grant execute on function pgque.register_consumer_at(text, text, bigint) to pgque_writer;
+grant execute on function pgque.unregister_consumer(text, text) to pgque_writer;
+
+-- batch processing
+grant execute on function pgque.next_batch(text, text) to pgque_writer;
+grant execute on function pgque.next_batch_info(text, text) to pgque_writer;
+grant execute on function pgque.next_batch_custom(text, text, interval, int4, interval) to pgque_writer;
+grant execute on function pgque.get_batch_events(bigint) to pgque_writer;
+grant execute on function pgque.finish_batch(bigint) to pgque_writer;
+
+-- event retry — timestamptz and integer overloads
+grant execute on function pgque.event_retry(bigint, bigint, timestamptz) to pgque_writer;
+grant execute on function pgque.event_retry(bigint, bigint, integer) to pgque_writer;
+
+-- ---------------------------------------------------------------------------
+-- Admin: full access to everything in the pgque schema
+-- ---------------------------------------------------------------------------
+grant all on schema pgque to pgque_admin;
+grant all on all tables in schema pgque to pgque_admin;
+grant all on all sequences in schema pgque to pgque_admin;
+grant execute on all functions in schema pgque to pgque_admin;

--- a/tests/test_pgque_additions.sql
+++ b/tests/test_pgque_additions.sql
@@ -1,0 +1,40 @@
+-- Test pgque-specific additions
+-- Run against a database with pgque installed
+
+-- Test 1: config table
+do $$
+begin
+    assert (select count(*) from pgque.config) = 1, 'config should have exactly 1 row';
+    assert (select singleton from pgque.config) = true, 'singleton should be true';
+    raise notice 'PASS: config table';
+end $$;
+
+-- Test 2: queue_max_retries column exists
+do $$
+begin
+    assert exists (
+        select 1 from information_schema.columns
+        where table_schema = 'pgque' and table_name = 'queue'
+        and column_name = 'queue_max_retries'
+    ), 'queue_max_retries column should exist';
+    raise notice 'PASS: queue_max_retries column';
+end $$;
+
+-- Test 3: roles exist
+do $$
+begin
+    assert exists (select 1 from pg_roles where rolname = 'pgque_reader'), 'pgque_reader role should exist';
+    assert exists (select 1 from pg_roles where rolname = 'pgque_writer'), 'pgque_writer role should exist';
+    assert exists (select 1 from pg_roles where rolname = 'pgque_admin'), 'pgque_admin role should exist';
+    raise notice 'PASS: roles exist';
+end $$;
+
+-- Test 4: lifecycle functions exist
+do $$
+begin
+    perform pgque.version();
+    raise notice 'PASS: version() works, returned %', pgque.version();
+end $$;
+
+-- Test 5: idempotency - re-running additions should not error
+-- (This will be tested as part of install idempotency in Issue #4)


### PR DESCRIPTION
## Summary

- Add `sql/pgque-additions/` with pgque-specific schema objects layered on top of transformed PgQ core
- **config.sql**: `pgque.config` singleton table storing `ticker_job_id`, `maint_job_id`, `installed_at` (for pg_cron integration)
- **queue_max_retries.sql**: idempotently adds `queue_max_retries int4` column to `pgque.queue`
- **roles.sql**: creates `pgque_reader`, `pgque_writer`, `pgque_admin` roles with granular function-level grants matching actual PgQ function signatures
- **lifecycle.sql**: `pgque.start()`, `pgque.stop()`, `pgque.uninstall()`, `pgque.version()` stubs (Sprint 2 pg_cron integration); all `SECURITY DEFINER` with pinned `search_path`
- **notify.sql**: documents LISTEN/NOTIFY ticker integration plan
- **tests/test_pgque_additions.sql**: acceptance tests for all additions

## Design notes

- Role grants use exact function signatures from `vendor/pgq/functions/` (e.g., `pgque.insert_event(text, text, text)`, `pgque.next_batch_custom(text, text, interval, int4, interval)`) rather than wildcards for reader/writer; admin uses `grant execute on all functions` as catch-all
- All schema additions are idempotent (`create table if not exists`, `do $$ ... if not exists ...`, `on conflict do nothing`)
- Follows CLAUDE.md style: lowercase SQL keywords, `SECURITY DEFINER` functions pin `search_path`

## Test plan

- [ ] Run `tests/test_pgque_additions.sql` against a database with pgque installed (requires Issue #2 transform + Issue #4 install script)
- [ ] Verify config table has exactly 1 row with `singleton = true`
- [ ] Verify `queue_max_retries` column exists on `pgque.queue`
- [ ] Verify all three roles exist in `pg_roles`
- [ ] Verify `pgque.version()` returns `'1.0.0-dev'`
- [ ] Verify re-running all addition scripts is idempotent (no errors)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)