### PR TITLE
refactor: move pgq submodule to top-level

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "vendor/pgq"]
-	path = vendor/pgq
+[submodule "pgq"]
+	path = pgq
 	url = https://github.com/pgq/pgq.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ set -Eeuo pipefail
 
 ```
 pgque/
-  vendor/pgq/          -- git submodule (github.com/pgq/pgq, pinned tag)
+  pgq/                 -- git submodule (github.com/pgq/pgq, pinned tag)
   build/
     transform.sh       -- mechanical rename + modernization script
   blueprints/          -- specs, design docs, brainstorms

--- a/blueprints/SPECx.md
+++ b/blueprints/SPECx.md
@@ -1856,14 +1856,14 @@ dependency and apply transformations mechanically during the build step.
 
 ```
 pgque/
-  vendor/pgq/          -- git submodule pointing to github.com/pgq/pgq
+  pgq/                 -- git submodule pointing to github.com/pgq/pgq
   sql/
-    pgque-install.sql   -- built from vendor/pgq sources + pgque additions
+    pgque-install.sql   -- built from pgq/ sources + pgque additions
   build/
     transform.sh        -- mechanical rename + modernization script
 ```
 
-The `vendor/pgq/` submodule pins to a specific PgQ release tag (v3.5.1).
+The `pgq/` submodule pins to a specific PgQ release tag (v3.5.1).
 The build script (`transform.sh`) reads PgQ's PL-only source files, applies
 the mechanical transformations (schema rename, `txid_*` -> `pg_*`, `xid8`,
 `search_path` pinning, cleanup), and concatenates the result with pgque's
@@ -1888,7 +1888,7 @@ keeps the upstream relationship clean.
 **Nature:** Mechanical transformation. No new logic.
 
 **Deliverables:**
-1. Set up PgQ as a git submodule (`vendor/pgq/`, pinned to v3.5.1)
+1. Set up PgQ as a git submodule (`pgq/`, pinned to v3.5.1)
 2. Create `build/transform.sh` that reads PL-only source files and applies
    all mechanical transformations (items 3-9 below)
 3. Global rename: `pgq.` -> `pgque.` (schema prefix in ~40 files)


### PR DESCRIPTION
## Summary
- Moved the PgQ git submodule from `vendor/pgq/` to `pgq/` at the repository root for immediate visibility
- Submodule remains pinned to tag `v3.5.1`
- Updated file organization diagrams and path references in `CLAUDE.md` and `blueprints/SPECx.md`

Closes #9

## Test plan
- [x] Verified `pgq/structure/tables.sql` exists after re-add
- [x] Confirmed `.gitmodules` points to `pgq` (not `vendor/pgq`)
- [x] Grep confirmed zero remaining `vendor/pgq` references in the repo
- [ ] Clone fresh and run `git submodule update --init --recursive` to confirm submodule resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)