### PR TITLE
feat: CI pipeline and regression tests (PG 14-17)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,111 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pg_version: ['14', '15', '16', '17']
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Start PostgreSQL ${{ matrix.pg_version }}
+        run: |
+          docker run -d --name pgque-test \
+            -e POSTGRES_PASSWORD=pgque_test \
+            -e POSTGRES_DB=pgque_test \
+            -p 5432:5432 \
+            postgres:${{ matrix.pg_version }}
+
+          # Wait for PG to be ready
+          for i in $(seq 1 30); do
+            docker exec pgque-test pg_isready -U postgres && break
+            sleep 1
+          done
+
+      - name: Build pgque
+        run: bash build/transform.sh
+
+      - name: Install pgque
+        run: |
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
+            -f sql/pgque-install.sql
+
+      - name: Run regression tests
+        run: |
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
+            -f tests/run_all.sql
+
+      - name: Test install idempotency
+        run: |
+          # Re-run install -- should produce no errors
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
+            -f sql/pgque-install.sql
+          # Verify everything still works
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
+            -f tests/test_install_idempotency.sql
+
+      - name: Test uninstall
+        run: |
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
+            -f sql/pgque-uninstall.sql
+          # Verify schema is gone
+          result=$(PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
+            -tAc "select count(*) from pg_namespace where nspname = 'pgque'")
+          if [ "$result" != "0" ]; then
+            echo "FAIL: pgque schema still exists after uninstall"
+            exit 1
+          fi
+          echo "PASS: pgque schema removed after uninstall"
+
+      - name: Cleanup
+        if: always()
+        run: docker rm -f pgque-test
+
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build
+        run: bash build/transform.sh
+
+      - name: Verify SECURITY DEFINER search_path
+        run: |
+          # Check that no SECURITY DEFINER function lacks SET search_path
+          if grep -rn -i 'security definer' build/output/ \
+             | grep -iv 'set search_path'; then
+            echo "FAIL: SECURITY DEFINER functions missing SET search_path"
+            exit 1
+          fi
+          echo "PASS: All SECURITY DEFINER functions have SET search_path"
+
+      - name: Verify no remaining pgq references
+        run: |
+          if grep -rn 'pgq\.[a-zA-Z_]' build/output/ \
+             | grep -v '^\s*--' \
+             | grep -v '^[^:]*:[0-9]*:\s*--'; then
+            echo "FAIL: Remaining pgq. references in output"
+            exit 1
+          fi
+          echo "PASS: No remaining pgq. references"
+
+      - name: Verify no remaining txid references
+        run: |
+          if grep -rn -E 'txid_(current|snapshot|visible)' build/output/; then
+            echo "FAIL: Remaining txid_ references"
+            exit 1
+          fi
+          echo "PASS: No remaining txid_ references"

--- a/build/transform.sh
+++ b/build/transform.sh
@@ -447,6 +447,25 @@ sed -i 's/ -- unsure about access//' "${OUTPUT_DIR}/functions/pgque.ticker.sql"
 
 echo "PASS: debug comments removed from ticker"
 
+# Fix xid8 comparisons in batch_event_sql dynamic SQL.
+# After the bigint->xid8 transform, ev_txid is xid8 but the dynamic SQL
+# builds comparisons like "ev.ev_txid >= 12345" where 12345 is a plain
+# integer literal. PostgreSQL has no >= operator for (xid8, integer).
+# Fix: wrap values in single-quote text literals with ::xid8 cast,
+# e.g. ev.ev_txid >= '12345'::xid8
+BATCH_SQL_FILE="${OUTPUT_DIR}/functions/pgque.batch_event_sql.sql"
+sed -i "s/|| ' and ev.ev_txid >= ' || batch.tx_start::text/|| ' and ev.ev_txid >= ''' || batch.tx_start::text || '''::xid8'/" \
+  "${BATCH_SQL_FILE}"
+sed -i "s/|| ' and ev.ev_txid <= ' || batch.tx_end::text/|| ' and ev.ev_txid <= ''' || batch.tx_end::text || '''::xid8'/" \
+  "${BATCH_SQL_FILE}"
+# Also fix the IN() list for older tx-es: each value needs ::xid8 cast.
+sed -i "s/arr := rec.id1::text;/arr := '''' || rec.id1::text || '''::xid8';/" \
+  "${BATCH_SQL_FILE}"
+sed -i "s/arr := arr || ',' || rec.id1::text;/arr := arr || ',''' || rec.id1::text || '''::xid8';/" \
+  "${BATCH_SQL_FILE}"
+
+echo "PASS: xid8 casts added to batch_event_sql dynamic SQL"
+
 # -- Assembly: build sql/pgque-install.sql ------------------------------------
 
 echo ""

--- a/sql/pgque-install.sql
+++ b/sql/pgque-install.sql
@@ -366,9 +366,9 @@ begin
             batch.tx_start := rec.id1;
         else
             if arr = '' then
-                arr := rec.id1::text;
+                arr := '''' || rec.id1::text || '''::xid8';
             else
-                arr := arr || ',' || rec.id1::text;
+                arr := arr || ',''' || rec.id1::text || '''::xid8';
             end if;
         end if;
     end loop;
@@ -392,8 +392,8 @@ begin
             || ' and cur.tick_queue = ' || batch.sub_queue::text
             || ' and last.tick_id = ' || batch.sub_last_tick::text
             || ' and last.tick_queue = ' || batch.sub_queue::text
-            || ' and ev.ev_txid >= ' || batch.tx_start::text
-            || ' and ev.ev_txid <= ' || batch.tx_end::text
+            || ' and ev.ev_txid >= ''' || batch.tx_start::text || '''::xid8'
+            || ' and ev.ev_txid <= ''' || batch.tx_end::text || '''::xid8'
             || ' and pg_visible_in_snapshot(ev.ev_txid, cur.tick_snapshot)'
             || ' and not pg_visible_in_snapshot(ev.ev_txid, last.tick_snapshot)'
             || retry_expr;

--- a/tests/run_all.sql
+++ b/tests/run_all.sql
@@ -1,0 +1,44 @@
+-- run_all.sql -- pgque regression test suite
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- Usage: psql -d pgque_test -f tests/run_all.sql
+-- Requires: pgque-install.sql already loaded
+
+-- Abort on first error
+\set ON_ERROR_STOP on
+
+\echo '=== pgque regression test suite ==='
+\echo ''
+
+\echo 'Running: test_pgque_config'
+\i tests/test_pgque_config.sql
+
+\echo 'Running: test_pgque_roles'
+\i tests/test_pgque_roles.sql
+
+\echo 'Running: test_pgque_additions'
+\i tests/test_pgque_additions.sql
+
+\echo 'Running: test_security_definer'
+\i tests/test_security_definer.sql
+
+\echo 'Running: test_core_lifecycle'
+\i tests/test_core_lifecycle.sql
+
+\echo 'Running: test_core_events'
+\i tests/test_core_events.sql
+
+\echo 'Running: test_core_ticker'
+\i tests/test_core_ticker.sql
+
+\echo 'Running: test_core_consumer'
+\i tests/test_core_consumer.sql
+
+\echo 'Running: test_core_retry'
+\i tests/test_core_retry.sql
+
+\echo 'Running: test_install_idempotency'
+\i tests/test_install_idempotency.sql
+
+\echo ''
+\echo '=== ALL TESTS PASSED ==='

--- a/tests/test_core_consumer.sql
+++ b/tests/test_core_consumer.sql
@@ -1,0 +1,31 @@
+-- test_core_consumer.sql -- Consumer registration and multiple consumers
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+do $$
+declare
+  v_count int;
+begin
+  perform pgque.create_queue('test_consumer');
+
+  -- Register two consumers
+  perform pgque.register_consumer('test_consumer', 'c1');
+  perform pgque.register_consumer('test_consumer', 'c2');
+
+  -- Verify both exist
+  select count(*) into v_count
+    from pgque.get_consumer_info('test_consumer');
+  assert v_count = 2, 'should have 2 consumers, got ' || v_count;
+
+  -- Unregister one
+  perform pgque.unregister_consumer('test_consumer', 'c1');
+
+  select count(*) into v_count
+    from pgque.get_consumer_info('test_consumer');
+  assert v_count = 1, 'should have 1 consumer after unregister';
+
+  -- Cleanup
+  perform pgque.unregister_consumer('test_consumer', 'c2');
+  perform pgque.drop_queue('test_consumer');
+
+  raise notice 'PASS: core_consumer';
+end $$;

--- a/tests/test_core_events.sql
+++ b/tests/test_core_events.sql
@@ -1,0 +1,61 @@
+-- test_core_events.sql -- Event insertion and retrieval
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- PgQ requires insert and ticker to be in separate transactions
+-- (snapshot visibility). Each DO block here is a separate transaction.
+
+-- Step 1: setup
+do $$
+begin
+  perform pgque.create_queue('test_events');
+  perform pgque.register_consumer('test_events', 'c1');
+end $$;
+
+-- Step 2: insert event (separate transaction)
+do $$
+declare
+  v_eid bigint;
+begin
+  v_eid := pgque.insert_event('test_events', 'test.type', '{"key":"value"}');
+  assert v_eid is not null, 'insert_event should return event id';
+end $$;
+
+-- Step 3: ticker (separate transaction to capture the insert)
+do $$
+begin
+  perform pgque.ticker();
+end $$;
+
+-- Step 4: verify batch events
+do $$
+declare
+  v_batch_id bigint;
+  v_ev record;
+begin
+  v_batch_id := pgque.next_batch('test_events', 'c1');
+  assert v_batch_id is not null, 'should have a batch';
+
+  select * into v_ev from pgque.get_batch_events(v_batch_id) limit 1;
+  assert v_ev.ev_type = 'test.type', 'event type should match';
+  assert v_ev.ev_data = '{"key":"value"}', 'event data should match';
+
+  perform pgque.finish_batch(v_batch_id);
+end $$;
+
+-- Step 5: verify no more batches
+do $$
+declare
+  v_batch_id bigint;
+begin
+  v_batch_id := pgque.next_batch('test_events', 'c1');
+  assert v_batch_id is null, 'no more batches';
+end $$;
+
+-- Cleanup
+do $$
+begin
+  perform pgque.unregister_consumer('test_events', 'c1');
+  perform pgque.drop_queue('test_events');
+
+  raise notice 'PASS: core_events';
+end $$;

--- a/tests/test_core_lifecycle.sql
+++ b/tests/test_core_lifecycle.sql
@@ -1,0 +1,30 @@
+-- test_core_lifecycle.sql -- Queue lifecycle: create, configure, drop
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+do $$
+declare
+  v_qinfo record;
+begin
+  -- Create a queue
+  perform pgque.create_queue('test_lifecycle');
+
+  -- Verify it exists
+  select * into v_qinfo
+    from pgque.get_queue_info('test_lifecycle');
+  assert v_qinfo.queue_name = 'test_lifecycle', 'queue should exist';
+
+  -- Configure it
+  perform pgque.set_queue_config(
+    'test_lifecycle', 'ticker_max_count', '500');
+
+  -- Drop it
+  perform pgque.drop_queue('test_lifecycle');
+
+  -- Verify it's gone
+  assert not exists (
+    select 1 from pgque.get_queue_info()
+    where queue_name = 'test_lifecycle'
+  ), 'queue should be gone after drop';
+
+  raise notice 'PASS: core_lifecycle';
+end $$;

--- a/tests/test_core_retry.sql
+++ b/tests/test_core_retry.sql
@@ -1,0 +1,79 @@
+-- test_core_retry.sql -- Event retry mechanism
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- PgQ requires insert and ticker to be in separate transactions
+-- (snapshot visibility). Each DO block here is a separate transaction.
+
+-- Step 1: setup
+do $$
+begin
+  perform pgque.create_queue('test_retry');
+  perform pgque.register_consumer('test_retry', 'c1');
+end $$;
+
+-- Step 2: insert event
+do $$
+begin
+  perform pgque.insert_event('test_retry', 'retry.test', 'data1');
+end $$;
+
+-- Step 3: ticker
+do $$
+begin
+  perform pgque.ticker();
+end $$;
+
+-- Step 4: get batch and retry the event
+do $$
+declare
+  v_batch_id bigint;
+  v_ev record;
+begin
+  v_batch_id := pgque.next_batch('test_retry', 'c1');
+  select * into v_ev from pgque.get_batch_events(v_batch_id) limit 1;
+
+  -- Retry the event (0 seconds delay for test)
+  perform pgque.event_retry(v_batch_id, v_ev.ev_id, 0);
+  perform pgque.finish_batch(v_batch_id);
+end $$;
+
+-- Step 5: maintenance moves retried events back
+do $$
+begin
+  perform pgque.maint_retry_events();
+end $$;
+
+-- Step 6: force a tick after the re-insert.
+-- force_tick bumps the event sequence so the next ticker() call will
+-- definitely create a tick (bypassing idle period optimization).
+do $$
+begin
+  perform pgque.force_tick('test_retry');
+  perform pgque.ticker();
+end $$;
+
+-- Step 7: verify the retried event appears
+do $$
+declare
+  v_batch_id bigint;
+  v_ev record;
+begin
+  v_batch_id := pgque.next_batch('test_retry', 'c1');
+  assert v_batch_id is not null, 'should have batch with retried event';
+
+  select * into v_ev from pgque.get_batch_events(v_batch_id) limit 1;
+  assert v_ev.ev_retry is not null and v_ev.ev_retry >= 1,
+    'retry count should be >= 1, got '
+    || coalesce(v_ev.ev_retry::text, 'NULL');
+
+  perform pgque.finish_batch(v_batch_id);
+end $$;
+
+-- Cleanup
+do $$
+begin
+  perform pgque.unregister_consumer('test_retry', 'c1');
+  perform pgque.drop_queue('test_retry');
+
+  raise notice 'PASS: core_retry';
+end $$;

--- a/tests/test_core_ticker.sql
+++ b/tests/test_core_ticker.sql
@@ -1,0 +1,28 @@
+-- test_core_ticker.sql -- Ticker generates ticks
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+do $$
+declare
+  v_tick_count bigint;
+begin
+  perform pgque.create_queue('test_ticker');
+
+  -- Run ticker a few times
+  perform pgque.ticker();
+  perform pgque.ticker();
+  perform pgque.ticker();
+
+  -- Verify ticks exist
+  select count(*) into v_tick_count from pgque.tick
+  where tick_queue = (
+    select queue_id from pgque.queue
+    where queue_name = 'test_ticker'
+  );
+  assert v_tick_count >= 1,
+    'should have at least 1 tick, got ' || v_tick_count;
+
+  -- Cleanup
+  perform pgque.drop_queue('test_ticker');
+
+  raise notice 'PASS: core_ticker';
+end $$;

--- a/tests/test_pgque_config.sql
+++ b/tests/test_pgque_config.sql
@@ -1,0 +1,22 @@
+-- test_pgque_config.sql -- Verify pgque.config table
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+do $$
+begin
+  -- Config should have exactly 1 row
+  assert (select count(*) from pgque.config) = 1, 'config should have 1 row';
+
+  -- Singleton constraint works
+  begin
+    insert into pgque.config (singleton) values (true);
+    assert false, 'should not allow second row';
+  exception when unique_violation then
+    null; -- expected
+  end;
+
+  -- Version function works
+  assert pgque.version() = '1.0.0-dev',
+    'version should be 1.0.0-dev, got ' || pgque.version();
+
+  raise notice 'PASS: pgque_config';
+end $$;

--- a/tests/test_pgque_roles.sql
+++ b/tests/test_pgque_roles.sql
@@ -1,0 +1,14 @@
+-- test_pgque_roles.sql -- Verify pgque roles exist
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+do $$
+begin
+  assert exists (select 1 from pg_roles where rolname = 'pgque_reader'),
+    'pgque_reader should exist';
+  assert exists (select 1 from pg_roles where rolname = 'pgque_writer'),
+    'pgque_writer should exist';
+  assert exists (select 1 from pg_roles where rolname = 'pgque_admin'),
+    'pgque_admin should exist';
+
+  raise notice 'PASS: pgque_roles';
+end $$;

--- a/tests/test_security_definer.sql
+++ b/tests/test_security_definer.sql
@@ -1,0 +1,29 @@
+-- test_security_definer.sql -- All SECURITY DEFINER functions have search_path
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+do $$
+declare
+  v_bad record;
+  v_count int := 0;
+begin
+  for v_bad in
+    select p.proname
+    from pg_proc p
+    join pg_namespace n on p.pronamespace = n.oid
+    where n.nspname = 'pgque'
+    and p.prosecdef = true
+    and (p.proconfig is null
+         or not exists (
+           select 1 from unnest(p.proconfig) c
+           where c like 'search_path=%'
+         ))
+  loop
+    raise warning 'SECURITY DEFINER without search_path: %', v_bad.proname;
+    v_count := v_count + 1;
+  end loop;
+
+  assert v_count = 0,
+    v_count || ' SECURITY DEFINER function(s) missing search_path';
+
+  raise notice 'PASS: security_definer - all functions have search_path';
+end $$;


### PR DESCRIPTION
## Summary

- Add GitHub Actions CI workflow (`.github/workflows/ci.yml`) that tests pgque on PostgreSQL 14, 15, 16, and 17 using Docker
- Create regression test suite (`tests/run_all.sql` + 8 test files) covering config, roles, security definer, queue lifecycle, events, ticker, consumers, and retry mechanism
- Fix xid8 cast bug in `batch_event_sql` dynamic SQL that broke event retrieval after the bigint-to-xid8 transform
- CI also verifies install idempotency, uninstall, SECURITY DEFINER search_path, and no stale pgq/txid references

### Bug fix: xid8 casts in batch_event_sql

The `bigint->xid8` transform for `ev_txid` left the dynamic SQL in `batch_event_sql` generating comparisons like `ev.ev_txid >= 12345`, which fail because PostgreSQL has no comparison operator for `(xid8, integer)`. Fixed by emitting `'12345'::xid8` text-cast literals.

### Test suite

All tests verified locally on PostgreSQL 17:

```
=== pgque regression test suite ===
PASS: pgque_config
PASS: pgque_roles
PASS: config table / queue_max_retries / roles / version()
PASS: security_definer - all functions have search_path
PASS: core_lifecycle
PASS: core_events
PASS: core_ticker
PASS: core_consumer
PASS: core_retry
PASS: install idempotency (5 sub-tests)
=== ALL TESTS PASSED ===
```

Closes #5

## Test plan

- [ ] CI runs green on all PG versions (14, 15, 16, 17)
- [ ] `verify` job passes static checks (SECURITY DEFINER, no pgq refs, no txid refs)
- [ ] Install idempotency: running install twice produces no errors
- [ ] Uninstall removes the pgque schema cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)