### PR TITLE
feat: pgque.status() + verify LISTEN/NOTIFY

### DIFF
--- a/build/transform.sh
+++ b/build/transform.sh
@@ -703,7 +703,7 @@ else
 fi
 
 # Verify pgque additions are at the end
-if tail -20 "${INSTALL_FILE}" | grep -q 'lifecycle.sql\|pgque.version\|pgque.start\|pgque.stop'; then
+if tail -60 "${INSTALL_FILE}" | grep -q 'lifecycle.sql\|pgque.version\|pgque.start\|pgque.stop'; then
   echo "PASS: pgque additions are at the end of the script"
 else
   echo "FAIL: pgque additions not found at end of script"

--- a/sql/pgque-additions/lifecycle.sql
+++ b/sql/pgque-additions/lifecycle.sql
@@ -34,3 +34,50 @@ begin
     return '1.0.0-dev';
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+create or replace function pgque.status()
+returns table (
+    component text,
+    status text,
+    detail text
+) as $$
+begin
+    -- PostgreSQL version
+    return query select 'postgresql'::text, 'info'::text, pg_catalog.version()::text;
+
+    -- pgque version
+    return query select 'pgque'::text, 'info'::text, pgque.version();
+
+    -- pg_cron status
+    if exists (select 1 from pg_extension where extname = 'pg_cron') then
+        return query
+        select 'ticker'::text,
+            case when c.ticker_job_id is not null then 'running' else 'stopped' end,
+            case when c.ticker_job_id is not null
+                then 'job_id=' || c.ticker_job_id::text
+                else 'not scheduled'
+            end
+        from pgque.config c;
+
+        return query
+        select 'maintenance'::text,
+            case when c.maint_job_id is not null then 'running' else 'stopped' end,
+            case when c.maint_job_id is not null
+                then 'job_id=' || c.maint_job_id::text
+                else 'not scheduled'
+            end
+        from pgque.config c;
+    else
+        return query select 'pg_cron'::text, 'unavailable'::text,
+            'pg_cron not installed -- call pgque.ticker() and pgque.maint() manually'::text;
+    end if;
+
+    -- Queue count
+    return query select 'queues'::text, 'info'::text,
+        (select count(*)::text from pgque.queue) || ' queues configured';
+
+    -- Consumer count
+    return query select 'consumers'::text, 'info'::text,
+        (select count(*)::text from pgque.subscription) || ' active subscriptions';
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;

--- a/sql/pgque-additions/lifecycle.sql
+++ b/sql/pgque-additions/lifecycle.sql
@@ -52,7 +52,7 @@ begin
     if exists (select 1 from pg_extension where extname = 'pg_cron') then
         return query
         select 'ticker'::text,
-            case when c.ticker_job_id is not null then 'running' else 'stopped' end,
+            case when c.ticker_job_id is not null then 'scheduled' else 'stopped' end,
             case when c.ticker_job_id is not null
                 then 'job_id=' || c.ticker_job_id::text
                 else 'not scheduled'
@@ -61,7 +61,7 @@ begin
 
         return query
         select 'maintenance'::text,
-            case when c.maint_job_id is not null then 'running' else 'stopped' end,
+            case when c.maint_job_id is not null then 'scheduled' else 'stopped' end,
             case when c.maint_job_id is not null
                 then 'job_id=' || c.maint_job_id::text
                 else 'not scheduled'

--- a/sql/pgque-install.sql
+++ b/sql/pgque-install.sql
@@ -4035,3 +4035,50 @@ begin
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
+create or replace function pgque.status()
+returns table (
+    component text,
+    status text,
+    detail text
+) as $$
+begin
+    -- PostgreSQL version
+    return query select 'postgresql'::text, 'info'::text, pg_catalog.version()::text;
+
+    -- pgque version
+    return query select 'pgque'::text, 'info'::text, pgque.version();
+
+    -- pg_cron status
+    if exists (select 1 from pg_extension where extname = 'pg_cron') then
+        return query
+        select 'ticker'::text,
+            case when c.ticker_job_id is not null then 'running' else 'stopped' end,
+            case when c.ticker_job_id is not null
+                then 'job_id=' || c.ticker_job_id::text
+                else 'not scheduled'
+            end
+        from pgque.config c;
+
+        return query
+        select 'maintenance'::text,
+            case when c.maint_job_id is not null then 'running' else 'stopped' end,
+            case when c.maint_job_id is not null
+                then 'job_id=' || c.maint_job_id::text
+                else 'not scheduled'
+            end
+        from pgque.config c;
+    else
+        return query select 'pg_cron'::text, 'unavailable'::text,
+            'pg_cron not installed -- call pgque.ticker() and pgque.maint() manually'::text;
+    end if;
+
+    -- Queue count
+    return query select 'queues'::text, 'info'::text,
+        (select count(*)::text from pgque.queue) || ' queues configured';
+
+    -- Consumer count
+    return query select 'consumers'::text, 'info'::text,
+        (select count(*)::text from pgque.subscription) || ' active subscriptions';
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+

--- a/sql/pgque-install.sql
+++ b/sql/pgque-install.sql
@@ -4052,7 +4052,7 @@ begin
     if exists (select 1 from pg_extension where extname = 'pg_cron') then
         return query
         select 'ticker'::text,
-            case when c.ticker_job_id is not null then 'running' else 'stopped' end,
+            case when c.ticker_job_id is not null then 'scheduled' else 'stopped' end,
             case when c.ticker_job_id is not null
                 then 'job_id=' || c.ticker_job_id::text
                 else 'not scheduled'
@@ -4061,7 +4061,7 @@ begin
 
         return query
         select 'maintenance'::text,
-            case when c.maint_job_id is not null then 'running' else 'stopped' end,
+            case when c.maint_job_id is not null then 'scheduled' else 'stopped' end,
             case when c.maint_job_id is not null
                 then 'job_id=' || c.maint_job_id::text
                 else 'not scheduled'

--- a/tests/run_all.sql
+++ b/tests/run_all.sql
@@ -40,5 +40,11 @@
 \echo 'Running: test_install_idempotency'
 \i tests/test_install_idempotency.sql
 
+\echo 'Running: test_status'
+\i tests/test_status.sql
+
+\echo 'Running: test_notify'
+\i tests/test_notify.sql
+
 \echo ''
 \echo '=== ALL TESTS PASSED ==='

--- a/tests/test_notify.sql
+++ b/tests/test_notify.sql
@@ -3,16 +3,23 @@
 do $$
 declare
   v_src text;
+  v_found bool := false;
 begin
-  -- Check that the ticker function contains pg_notify
-  select prosrc into v_src
-  from pg_proc p
-  join pg_namespace n on p.pronamespace = n.oid
-  where n.nspname = 'pgque' and p.proname = 'ticker'
-  limit 1;
+  -- Check that at least one ticker overload contains pg_notify.
+  -- The 1-arg ticker(text) handles individual queues and should emit
+  -- pg_notify; the zero-arg dispatcher just loops over queues.
+  for v_src in
+    select prosrc
+    from pg_proc p
+    join pg_namespace n on p.pronamespace = n.oid
+    where n.nspname = 'pgque' and p.proname = 'ticker'
+  loop
+    if v_src like '%pg_notify%' and v_src like '%pgque_%' then
+      v_found := true;
+    end if;
+  end loop;
 
-  assert v_src like '%pg_notify%', 'ticker function should contain pg_notify call';
-  assert v_src like '%pgque_%', 'ticker should notify on pgque_ channel prefix';
+  assert v_found, 'at least one ticker overload should contain pg_notify on pgque_ channel';
 
   raise notice 'PASS: ticker contains pg_notify for LISTEN/NOTIFY';
 end $$;

--- a/tests/test_notify.sql
+++ b/tests/test_notify.sql
@@ -1,0 +1,18 @@
+-- Test LISTEN/NOTIFY integration in ticker
+-- Verify pg_notify call exists in the ticker function source
+do $$
+declare
+  v_src text;
+begin
+  -- Check that the ticker function contains pg_notify
+  select prosrc into v_src
+  from pg_proc p
+  join pg_namespace n on p.pronamespace = n.oid
+  where n.nspname = 'pgque' and p.proname = 'ticker'
+  limit 1;
+
+  assert v_src like '%pg_notify%', 'ticker function should contain pg_notify call';
+  assert v_src like '%pgque_%', 'ticker should notify on pgque_ channel prefix';
+
+  raise notice 'PASS: ticker contains pg_notify for LISTEN/NOTIFY';
+end $$;

--- a/tests/test_status.sql
+++ b/tests/test_status.sql
@@ -1,0 +1,23 @@
+-- Test pgque.status() diagnostic dashboard
+do $$
+declare
+  v_row record;
+  v_found_pgque bool := false;
+  v_found_pg bool := false;
+begin
+  for v_row in select * from pgque.status()
+  loop
+    if v_row.component = 'pgque' then
+      v_found_pgque := true;
+      assert v_row.detail = '1.0.0-dev', 'pgque version should be 1.0.0-dev, got ' || v_row.detail;
+    end if;
+    if v_row.component = 'postgresql' then
+      v_found_pg := true;
+    end if;
+  end loop;
+
+  assert v_found_pgque, 'should have pgque component';
+  assert v_found_pg, 'should have postgresql component';
+
+  raise notice 'PASS: status() returns diagnostic info';
+end $$;

--- a/tests/test_status.sql
+++ b/tests/test_status.sql
@@ -9,7 +9,7 @@ begin
   loop
     if v_row.component = 'pgque' then
       v_found_pgque := true;
-      assert v_row.detail = '1.0.0-dev', 'pgque version should be 1.0.0-dev, got ' || v_row.detail;
+      assert v_row.detail = pgque.version(), 'pgque version should be ' || pgque.version() || ', got ' || v_row.detail;
     end if;
     if v_row.component = 'postgresql' then
       v_found_pg := true;


### PR DESCRIPTION
## Summary
- Implement `pgque.status()` diagnostic dashboard function that returns component/status/detail rows for PostgreSQL version, pgque version, pg_cron state, queue count, and subscription count (Closes #14)
- Add regression test verifying `pg_notify` is present in the ticker function source, confirming LISTEN/NOTIFY integration from Sprint 1 (Closes #15)
- Follow red/green TDD: tests committed first (failing), then implementation

## Test plan
- [x] `test_status.sql` verifies `pgque.status()` returns `pgque` and `postgresql` components with correct version
- [x] `test_notify.sql` introspects `pg_proc.prosrc` to verify pg_notify calls exist in ticker overloads
- [x] Full regression suite (12 tests) passes: `psql -d pgque_test -f tests/run_all.sql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)