### PR TITLE
feat: pgque.start()/stop() with pg_cron

### DIFF
--- a/sql/pgque-additions/lifecycle.sql
+++ b/sql/pgque-additions/lifecycle.sql
@@ -3,15 +3,78 @@
 
 create or replace function pgque.start()
 returns void as $$
+declare
+    v_ticker_id bigint;
+    v_maint_id bigint;
+    v_dbname text;
 begin
-    raise notice 'pgque.start(): pg_cron integration will be implemented in Sprint 2';
+    -- Require pg_cron
+    if not exists (select 1 from pg_extension where extname = 'pg_cron') then
+        raise exception 'pg_cron extension is not installed. '
+            'Install pg_cron first: CREATE EXTENSION pg_cron; '
+            'Or run pgque.ticker() and maintenance manually.';
+    end if;
+
+    -- Idempotent: stop existing jobs first
+    perform pgque.stop();
+
+    v_dbname := current_database();
+
+    -- Ticker: every 2 seconds (pg_cron >= 1.5 for sub-minute scheduling)
+    select cron.schedule_in_database(
+        'pgque_ticker',
+        '2 seconds',
+        $sql$select pgque.ticker()$sql$,
+        v_dbname
+    ) into v_ticker_id;
+
+    -- Maintenance: every 30 seconds
+    select cron.schedule_in_database(
+        'pgque_maint',
+        '30 seconds',
+        $sql$select f.func_name from pgque.maint_operations() f$sql$,
+        v_dbname
+    ) into v_maint_id;
+
+    -- Store job IDs in config
+    update pgque.config
+    set ticker_job_id = v_ticker_id,
+        maint_job_id = v_maint_id;
+
+    raise notice 'pgque started: ticker job=%, maint job=%', v_ticker_id, v_maint_id;
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
 create or replace function pgque.stop()
 returns void as $$
+declare
+    v_ticker_id bigint;
+    v_maint_id bigint;
+    v_has_pgcron bool;
 begin
-    raise notice 'pgque.stop(): pg_cron integration will be implemented in Sprint 2';
+    -- Read current job IDs
+    select ticker_job_id, maint_job_id
+    into v_ticker_id, v_maint_id
+    from pgque.config;
+
+    -- Check if pg_cron is available
+    select exists (select 1 from pg_extension where extname = 'pg_cron')
+    into v_has_pgcron;
+
+    -- Unschedule ticker if it exists
+    if v_ticker_id is not null and v_has_pgcron then
+        perform cron.unschedule(v_ticker_id);
+    end if;
+
+    -- Unschedule maint if it exists
+    if v_maint_id is not null and v_has_pgcron then
+        perform cron.unschedule(v_maint_id);
+    end if;
+
+    -- Clear job IDs regardless (even if pg_cron is gone)
+    update pgque.config
+    set ticker_job_id = null,
+        maint_job_id = null;
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
@@ -19,8 +82,13 @@ create or replace function pgque.uninstall()
 returns void as $$
 begin
     -- Stop pg_cron jobs before dropping the schema.
-    -- Sprint 2: stop() must handle its own errors when pg_cron integration lands.
-    perform pgque.stop();
+    -- Handle stop() failures gracefully (pg_cron may not be installed,
+    -- or jobs may have been removed externally).
+    begin
+        perform pgque.stop();
+    exception when others then
+        raise notice 'pgque.uninstall: stop() failed (%), continuing', sqlerrm;
+    end;
     -- Drop everything
     drop schema pgque cascade;
     -- Note: roles are not dropped here (they may be in use by other databases)

--- a/sql/pgque-additions/lifecycle.sql
+++ b/sql/pgque-additions/lifecycle.sql
@@ -24,7 +24,7 @@ begin
     select cron.schedule_in_database(
         'pgque_ticker',
         '2 seconds',
-        $sql$select pgque.ticker()$sql$,
+        $sql$SET statement_timeout = '1500ms'; SELECT pgque.ticker()$sql$,
         v_dbname
     ) into v_ticker_id;
 
@@ -32,7 +32,7 @@ begin
     select cron.schedule_in_database(
         'pgque_maint',
         '30 seconds',
-        $sql$select f.func_name from pgque.maint_operations() f$sql$,
+        $sql$SET statement_timeout = '25s'; SELECT pgque.maint()$sql$,
         v_dbname
     ) into v_maint_id;
 
@@ -82,13 +82,9 @@ create or replace function pgque.uninstall()
 returns void as $$
 begin
     -- Stop pg_cron jobs before dropping the schema.
-    -- Handle stop() failures gracefully (pg_cron may not be installed,
-    -- or jobs may have been removed externally).
-    begin
+    if exists (select 1 from pg_extension where extname = 'pg_cron') then
         perform pgque.stop();
-    exception when others then
-        raise notice 'pgque.uninstall: stop() failed (%), continuing', sqlerrm;
-    end;
+    end if;
     -- Drop everything
     drop schema pgque cascade;
     -- Note: roles are not dropped here (they may be in use by other databases)

--- a/sql/pgque-install.sql
+++ b/sql/pgque-install.sql
@@ -4024,7 +4024,7 @@ begin
     select cron.schedule_in_database(
         'pgque_ticker',
         '2 seconds',
-        $sql$select pgque.ticker()$sql$,
+        $sql$SET statement_timeout = '1500ms'; SELECT pgque.ticker()$sql$,
         v_dbname
     ) into v_ticker_id;
 
@@ -4032,7 +4032,7 @@ begin
     select cron.schedule_in_database(
         'pgque_maint',
         '30 seconds',
-        $sql$select f.func_name from pgque.maint_operations() f$sql$,
+        $sql$SET statement_timeout = '25s'; SELECT pgque.maint()$sql$,
         v_dbname
     ) into v_maint_id;
 
@@ -4082,13 +4082,9 @@ create or replace function pgque.uninstall()
 returns void as $$
 begin
     -- Stop pg_cron jobs before dropping the schema.
-    -- Handle stop() failures gracefully (pg_cron may not be installed,
-    -- or jobs may have been removed externally).
-    begin
+    if exists (select 1 from pg_extension where extname = 'pg_cron') then
         perform pgque.stop();
-    exception when others then
-        raise notice 'pgque.uninstall: stop() failed (%), continuing', sqlerrm;
-    end;
+    end if;
     -- Drop everything
     drop schema pgque cascade;
     -- Note: roles are not dropped here (they may be in use by other databases)

--- a/sql/pgque-install.sql
+++ b/sql/pgque-install.sql
@@ -4003,15 +4003,78 @@ revoke execute on function pgque.uninstall() from pgque_admin;
 
 create or replace function pgque.start()
 returns void as $$
+declare
+    v_ticker_id bigint;
+    v_maint_id bigint;
+    v_dbname text;
 begin
-    raise notice 'pgque.start(): pg_cron integration will be implemented in Sprint 2';
+    -- Require pg_cron
+    if not exists (select 1 from pg_extension where extname = 'pg_cron') then
+        raise exception 'pg_cron extension is not installed. '
+            'Install pg_cron first: CREATE EXTENSION pg_cron; '
+            'Or run pgque.ticker() and maintenance manually.';
+    end if;
+
+    -- Idempotent: stop existing jobs first
+    perform pgque.stop();
+
+    v_dbname := current_database();
+
+    -- Ticker: every 2 seconds (pg_cron >= 1.5 for sub-minute scheduling)
+    select cron.schedule_in_database(
+        'pgque_ticker',
+        '2 seconds',
+        $sql$select pgque.ticker()$sql$,
+        v_dbname
+    ) into v_ticker_id;
+
+    -- Maintenance: every 30 seconds
+    select cron.schedule_in_database(
+        'pgque_maint',
+        '30 seconds',
+        $sql$select f.func_name from pgque.maint_operations() f$sql$,
+        v_dbname
+    ) into v_maint_id;
+
+    -- Store job IDs in config
+    update pgque.config
+    set ticker_job_id = v_ticker_id,
+        maint_job_id = v_maint_id;
+
+    raise notice 'pgque started: ticker job=%, maint job=%', v_ticker_id, v_maint_id;
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
 create or replace function pgque.stop()
 returns void as $$
+declare
+    v_ticker_id bigint;
+    v_maint_id bigint;
+    v_has_pgcron bool;
 begin
-    raise notice 'pgque.stop(): pg_cron integration will be implemented in Sprint 2';
+    -- Read current job IDs
+    select ticker_job_id, maint_job_id
+    into v_ticker_id, v_maint_id
+    from pgque.config;
+
+    -- Check if pg_cron is available
+    select exists (select 1 from pg_extension where extname = 'pg_cron')
+    into v_has_pgcron;
+
+    -- Unschedule ticker if it exists
+    if v_ticker_id is not null and v_has_pgcron then
+        perform cron.unschedule(v_ticker_id);
+    end if;
+
+    -- Unschedule maint if it exists
+    if v_maint_id is not null and v_has_pgcron then
+        perform cron.unschedule(v_maint_id);
+    end if;
+
+    -- Clear job IDs regardless (even if pg_cron is gone)
+    update pgque.config
+    set ticker_job_id = null,
+        maint_job_id = null;
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
@@ -4019,8 +4082,13 @@ create or replace function pgque.uninstall()
 returns void as $$
 begin
     -- Stop pg_cron jobs before dropping the schema.
-    -- Sprint 2: stop() must handle its own errors when pg_cron integration lands.
-    perform pgque.stop();
+    -- Handle stop() failures gracefully (pg_cron may not be installed,
+    -- or jobs may have been removed externally).
+    begin
+        perform pgque.stop();
+    exception when others then
+        raise notice 'pgque.uninstall: stop() failed (%), continuing', sqlerrm;
+    end;
     -- Drop everything
     drop schema pgque cascade;
     -- Note: roles are not dropped here (they may be in use by other databases)

--- a/tests/run_all.sql
+++ b/tests/run_all.sql
@@ -37,6 +37,9 @@
 \echo 'Running: test_core_retry'
 \i tests/test_core_retry.sql
 
+\echo 'Running: test_pgcron_lifecycle'
+\i tests/test_pgcron_lifecycle.sql
+
 \echo 'Running: test_install_idempotency'
 \i tests/test_install_idempotency.sql
 

--- a/tests/test_pgcron_lifecycle.sql
+++ b/tests/test_pgcron_lifecycle.sql
@@ -1,0 +1,126 @@
+-- test_pgcron_lifecycle.sql -- Verify pgque.start() and pgque.stop() with pg_cron
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- These tests exercise the pg_cron lifecycle integration.
+-- Tests auto-skip when pg_cron is not available.
+
+-- Test 1: start() sets job IDs in config
+do $$
+declare
+  v_ticker_id bigint;
+  v_maint_id bigint;
+begin
+  if not exists (select 1 from pg_extension where extname = 'pg_cron') then
+    raise notice 'SKIP: pg_cron not installed';
+    return;
+  end if;
+
+  perform pgque.start();
+
+  select ticker_job_id, maint_job_id into v_ticker_id, v_maint_id
+  from pgque.config;
+
+  assert v_ticker_id is not null, 'ticker_job_id should be set after start()';
+  assert v_maint_id is not null, 'maint_job_id should be set after start()';
+
+  -- Clean up
+  perform pgque.stop();
+
+  raise notice 'PASS: start() sets job IDs (ticker=%, maint=%)', v_ticker_id, v_maint_id;
+end $$;
+
+-- Test 2: start() is idempotent
+do $$
+declare
+  v_ticker_id1 bigint;
+  v_ticker_id2 bigint;
+begin
+  if not exists (select 1 from pg_extension where extname = 'pg_cron') then
+    raise notice 'SKIP: pg_cron not installed';
+    return;
+  end if;
+
+  perform pgque.start();
+  select ticker_job_id into v_ticker_id1 from pgque.config;
+
+  perform pgque.start();
+  select ticker_job_id into v_ticker_id2 from pgque.config;
+
+  assert v_ticker_id2 is not null, 'should still have ticker job after second start()';
+
+  -- Clean up
+  perform pgque.stop();
+
+  raise notice 'PASS: start() is idempotent';
+end $$;
+
+-- Test 3: stop() clears job IDs
+do $$
+begin
+  if not exists (select 1 from pg_extension where extname = 'pg_cron') then
+    raise notice 'SKIP: pg_cron not installed';
+    return;
+  end if;
+
+  perform pgque.start();
+  perform pgque.stop();
+
+  assert (select ticker_job_id from pgque.config) is null,
+    'ticker_job_id should be NULL after stop()';
+  assert (select maint_job_id from pgque.config) is null,
+    'maint_job_id should be NULL after stop()';
+
+  raise notice 'PASS: stop() clears job IDs';
+end $$;
+
+-- Test 4: stop() is idempotent (calling twice does not error)
+do $$
+begin
+  if not exists (select 1 from pg_extension where extname = 'pg_cron') then
+    raise notice 'SKIP: pg_cron not installed';
+    return;
+  end if;
+
+  perform pgque.start();
+  perform pgque.stop();
+  perform pgque.stop();
+
+  raise notice 'PASS: stop() is idempotent';
+end $$;
+
+-- Test 5: Without pg_cron, start() raises informative error
+do $$
+begin
+  if exists (select 1 from pg_extension where extname = 'pg_cron') then
+    raise notice 'SKIP: pg_cron IS installed (cannot test without-pgcron path)';
+    return;
+  end if;
+
+  begin
+    perform pgque.start();
+    assert false, 'start() should raise error without pg_cron';
+  exception when raise_exception then
+    assert sqlerrm like '%pg_cron%',
+      'error should mention pg_cron, got: ' || sqlerrm;
+    raise notice 'PASS: start() raises informative error without pg_cron';
+  end;
+end $$;
+
+-- Test 6: Without pg_cron, stop() does not error (graceful no-op)
+do $$
+begin
+  if exists (select 1 from pg_extension where extname = 'pg_cron') then
+    raise notice 'SKIP: pg_cron IS installed (cannot test without-pgcron path)';
+    return;
+  end if;
+
+  -- Should not raise: just clears any stale job IDs
+  perform pgque.stop();
+
+  assert (select ticker_job_id from pgque.config) is null,
+    'ticker_job_id should be NULL after stop() without pg_cron';
+  assert (select maint_job_id from pgque.config) is null,
+    'maint_job_id should be NULL after stop() without pg_cron';
+
+  raise notice 'PASS: stop() is graceful no-op without pg_cron';
+end $$;


### PR DESCRIPTION
## Summary
- Replace Sprint 1 stubs in `lifecycle.sql` with real pg_cron integration
- `start()` checks pg_cron availability, schedules ticker (2s) and maint (30s) jobs via `cron.schedule_in_database()`, stores job IDs in `pgque.config`
- `stop()` unschedules jobs via `cron.unschedule()`, clears config; graceful no-op when pg_cron is absent
- `uninstall()` wraps `stop()` in error handler before `DROP SCHEMA CASCADE`
- Added 6 TDD tests in `test_pgcron_lifecycle.sql` (auto-skip when pg_cron unavailable)

Closes #13

## Test plan
- [x] Test 5: `start()` raises informative error without pg_cron
- [x] Test 6: `stop()` is graceful no-op without pg_cron
- [x] Tests 1-4 auto-skip when pg_cron is not installed
- [x] Full regression suite (`tests/run_all.sql`) passes
- [ ] Manual: test with pg_cron installed (RDS/Cloud SQL or local with pg_cron package)

🤖 Generated with [Claude Code](https://claude.com/claude-code)