### PR TITLE
feat: receive/ack/nack with DLQ routing

### DIFF
--- a/build/transform.sh
+++ b/build/transform.sh
@@ -735,6 +735,14 @@ else
   asm_errors=$((asm_errors + 1))
 fi
 
+# Verify pgque-api receive/ack/DLQ functions are in the script
+if grep -q 'pgque.receive\|pgque.ack\|pgque.nack' "${INSTALL_FILE}"; then
+  echo "PASS: pgque-api receive/ack/nack present in install script"
+else
+  echo "FAIL: pgque-api receive/ack/nack not found in install script"
+  asm_errors=$((asm_errors + 1))
+fi
+
 # Verify pgque-api section is present (if api files exist)
 if [[ -d "${API_DIR}" ]] && ls "${API_DIR}"/*.sql >/dev/null 2>&1; then
   if grep -q 'Section 7: pgque-api' "${INSTALL_FILE}"; then

--- a/sql/pgque-additions/queue_max_retries.sql
+++ b/sql/pgque-additions/queue_max_retries.sql
@@ -14,3 +14,45 @@ begin
         alter table pgque.queue add column queue_max_retries int4;
     end if;
 end $$;
+
+-- Override set_queue_config to also accept queue_max_retries
+create or replace function pgque.set_queue_config(
+    x_queue_name    text,
+    x_param_name    text,
+    x_param_value   text)
+returns integer as $$
+declare
+    v_param_name    text;
+begin
+    -- discard NULL input
+    if x_queue_name is null or x_param_name is null then
+        raise exception 'Invalid NULL value';
+    end if;
+
+    -- check if queue exists
+    perform 1 from pgque.queue where queue_name = x_queue_name;
+    if not found then
+        raise exception 'No such event queue';
+    end if;
+
+    -- check if valid parameter name
+    v_param_name := 'queue_' || x_param_name;
+    if v_param_name not in (
+        'queue_ticker_max_count',
+        'queue_ticker_max_lag',
+        'queue_ticker_idle_period',
+        'queue_ticker_paused',
+        'queue_rotation_period',
+        'queue_external_ticker',
+        'queue_max_retries')
+    then
+        raise exception 'cannot change parameter "%s"', x_param_name;
+    end if;
+
+    execute 'update pgque.queue set '
+        || v_param_name || ' = ' || quote_literal(x_param_value)
+        || ' where queue_name = ' || quote_literal(x_queue_name);
+
+    return 1;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;

--- a/sql/pgque-api/dlq.sql
+++ b/sql/pgque-api/dlq.sql
@@ -1,0 +1,151 @@
+-- pgque dead letter queue (DLQ) -- table + helper functions
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- PgQ has a retry queue but no dead letter queue. pgque adds one.
+-- See SPECx.md section 4.5.
+
+-- pgque.dead_letter table
+create table if not exists pgque.dead_letter (
+    dl_id           bigserial primary key,
+    dl_queue_id     int4 not null references pgque.queue(queue_id),
+    dl_consumer_id  int4 not null references pgque.consumer(co_id),
+    dl_time         timestamptz not null default now(),
+    dl_reason       text,
+
+    -- Original event fields (copied from event at time of death)
+    ev_id           bigint not null,
+    ev_time         timestamptz not null,
+    ev_txid         xid8,
+    ev_retry        int4,
+    ev_type         text,
+    ev_data         text,
+    ev_extra1       text,
+    ev_extra2       text,
+    ev_extra3       text,
+    ev_extra4       text
+);
+
+create index if not exists dl_queue_time_idx
+    on pgque.dead_letter (dl_queue_id, dl_time);
+
+-- pgque.event_dead() -- move event to DLQ (called by nack() when max retries exceeded)
+create or replace function pgque.event_dead(
+    i_batch_id bigint,
+    i_event_id bigint,
+    i_reason text,
+    i_ev_time timestamptz,
+    i_ev_txid xid8,
+    i_ev_retry int4,
+    i_ev_type text,
+    i_ev_data text,
+    i_ev_extra1 text default null,
+    i_ev_extra2 text default null,
+    i_ev_extra3 text default null,
+    i_ev_extra4 text default null)
+returns integer as $$
+declare
+    v_sub record;
+begin
+    -- Look up subscription from batch
+    select sub_queue, sub_consumer into v_sub
+    from pgque.subscription where sub_batch = i_batch_id;
+    if not found then
+        raise exception 'batch not found: %', i_batch_id;
+    end if;
+
+    -- Insert into dead letter table (no re-query of batch events)
+    insert into pgque.dead_letter (
+        dl_queue_id, dl_consumer_id, dl_reason,
+        ev_id, ev_time, ev_txid, ev_retry, ev_type, ev_data,
+        ev_extra1, ev_extra2, ev_extra3, ev_extra4)
+    values (
+        v_sub.sub_queue, v_sub.sub_consumer, i_reason,
+        i_event_id, i_ev_time, i_ev_txid, i_ev_retry, i_ev_type, i_ev_data,
+        i_ev_extra1, i_ev_extra2, i_ev_extra3, i_ev_extra4);
+
+    return 1;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.dlq_inspect() -- inspect DLQ entries for a queue
+create or replace function pgque.dlq_inspect(
+    i_queue_name text, i_limit_count int default 100)
+returns setof pgque.dead_letter as $$
+begin
+    return query
+    select dl.*
+    from pgque.dead_letter dl
+    join pgque.queue q on q.queue_id = dl.dl_queue_id
+    where q.queue_name = i_queue_name
+    order by dl.dl_time desc
+    limit i_limit_count;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.dlq_replay() -- replay a single dead letter event back into the queue
+create or replace function pgque.dlq_replay(i_dead_letter_id bigint)
+returns bigint as $$
+declare
+    v_dl record;
+    v_queue_name text;
+    v_new_eid bigint;
+begin
+    select dl.*, q.queue_name into v_dl
+    from pgque.dead_letter dl
+    join pgque.queue q on q.queue_id = dl.dl_queue_id
+    where dl.dl_id = i_dead_letter_id;
+
+    if not found then
+        raise exception 'dead letter entry not found: %', i_dead_letter_id;
+    end if;
+
+    -- Re-insert into the queue
+    v_new_eid := pgque.insert_event(v_dl.queue_name, v_dl.ev_type, v_dl.ev_data,
+        v_dl.ev_extra1, v_dl.ev_extra2, v_dl.ev_extra3, v_dl.ev_extra4);
+
+    -- Remove from DLQ
+    delete from pgque.dead_letter where dl_id = i_dead_letter_id;
+
+    return v_new_eid;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.dlq_replay_all() -- replay all DLQ events for a queue
+create or replace function pgque.dlq_replay_all(i_queue_name text)
+returns integer as $$
+declare
+    v_dl record;
+    v_cnt integer := 0;
+begin
+    for v_dl in
+        select dl.dl_id, dl.ev_type, dl.ev_data,
+               dl.ev_extra1, dl.ev_extra2, dl.ev_extra3, dl.ev_extra4,
+               q.queue_name
+        from pgque.dead_letter dl
+        join pgque.queue q on q.queue_id = dl.dl_queue_id
+        where q.queue_name = i_queue_name
+    loop
+        perform pgque.insert_event(v_dl.queue_name, v_dl.ev_type, v_dl.ev_data,
+            v_dl.ev_extra1, v_dl.ev_extra2, v_dl.ev_extra3, v_dl.ev_extra4);
+        delete from pgque.dead_letter where dl_id = v_dl.dl_id;
+        v_cnt := v_cnt + 1;
+    end loop;
+
+    return v_cnt;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.dlq_purge() -- purge old DLQ entries
+create or replace function pgque.dlq_purge(
+    i_queue_name text, i_older_than interval default '30 days')
+returns integer as $$
+declare
+    v_cnt integer;
+begin
+    delete from pgque.dead_letter
+    where dl_queue_id = (select queue_id from pgque.queue where queue_name = i_queue_name)
+      and dl_time < now() - i_older_than;
+    get diagnostics v_cnt = row_count;
+    return v_cnt;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;

--- a/sql/pgque-api/receive.sql
+++ b/sql/pgque-api/receive.sql
@@ -80,6 +80,10 @@ begin
     join pgque.queue q on q.queue_id = s.sub_queue
     where s.sub_batch = i_batch_id;
 
+    if not found then
+        raise exception 'batch not found: %', i_batch_id;
+    end if;
+
     if coalesce(i_msg.retry_count, 0) >= v_max_retries then
         -- Move to dead letter queue (pass event fields, no re-query)
         perform pgque.event_dead(i_batch_id, i_msg.msg_id,

--- a/sql/pgque-api/receive.sql
+++ b/sql/pgque-api/receive.sql
@@ -1,0 +1,97 @@
+-- pgque.receive(), pgque.ack(), pgque.nack() -- modern consume API
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+-- Includes code derived from PgQ (ISC license, Marko Kreen / Skype Technologies OU).
+--
+-- These functions wrap PgQ primitives (next_batch, get_batch_events,
+-- finish_batch, event_retry) into a simpler receive/ack/nack interface.
+-- See SPECx.md sections 4.2 and 4.3.
+
+-- pgque.message type (idempotent creation)
+do $$ begin
+    create type pgque.message as (
+        msg_id      bigint,
+        batch_id    bigint,
+        type        text,
+        payload     text,
+        retry_count int4,
+        created_at  timestamptz,
+        extra1      text,
+        extra2      text,
+        extra3      text,
+        extra4      text
+    );
+exception when duplicate_object then null;
+end $$;
+
+-- pgque.receive() -- wraps next_batch + get_batch_events
+create or replace function pgque.receive(
+    i_queue text, i_consumer text, i_max_return int default 100)
+returns setof pgque.message as $$
+declare
+    v_batch_id bigint;
+    ev record;
+    cnt int := 0;
+begin
+    -- Get next batch (may return NULL if no events)
+    v_batch_id := pgque.next_batch(i_queue, i_consumer);
+    if v_batch_id is null then
+        return;
+    end if;
+
+    -- Yield messages from the batch
+    for ev in
+        select ev_id, ev_type, ev_data, ev_retry, ev_time,
+               ev_extra1, ev_extra2, ev_extra3, ev_extra4
+        from pgque.get_batch_events(v_batch_id)
+    loop
+        return next row(
+            ev.ev_id, v_batch_id, ev.ev_type, ev.ev_data,
+            ev.ev_retry, ev.ev_time,
+            ev.ev_extra1, ev.ev_extra2, ev.ev_extra3, ev.ev_extra4
+        )::pgque.message;
+        cnt := cnt + 1;
+        exit when cnt >= i_max_return;
+    end loop;
+    return;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.ack() -- finishes the batch, advances consumer position
+create or replace function pgque.ack(i_batch_id bigint)
+returns integer as $$
+begin
+    return pgque.finish_batch(i_batch_id);
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.nack() -- retry or route to DLQ based on retry_count vs max_retries
+create or replace function pgque.nack(
+    i_batch_id bigint,
+    i_msg pgque.message,
+    i_retry_after interval default '60 seconds',
+    i_reason text default null)
+returns integer as $$
+declare
+    v_max_retries int4;
+begin
+    -- Single lookup: subscription -> queue config
+    select coalesce(q.queue_max_retries, 5) into v_max_retries
+    from pgque.subscription s
+    join pgque.queue q on q.queue_id = s.sub_queue
+    where s.sub_batch = i_batch_id;
+
+    if coalesce(i_msg.retry_count, 0) >= v_max_retries then
+        -- Move to dead letter queue (pass event fields, no re-query)
+        perform pgque.event_dead(i_batch_id, i_msg.msg_id,
+            coalesce(i_reason, 'max retries exceeded'),
+            i_msg.created_at, null::xid8, i_msg.retry_count,
+            i_msg.type, i_msg.payload,
+            i_msg.extra1, i_msg.extra2, i_msg.extra3, i_msg.extra4);
+    else
+        -- Retry after delay
+        perform pgque.event_retry(i_batch_id, i_msg.msg_id,
+            extract(epoch from i_retry_after)::integer);
+    end if;
+    return 1;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;

--- a/sql/pgque-install.sql
+++ b/sql/pgque-install.sql
@@ -3920,6 +3920,48 @@ begin
     end if;
 end $$;
 
+-- Override set_queue_config to also accept queue_max_retries
+create or replace function pgque.set_queue_config(
+    x_queue_name    text,
+    x_param_name    text,
+    x_param_value   text)
+returns integer as $$
+declare
+    v_param_name    text;
+begin
+    -- discard NULL input
+    if x_queue_name is null or x_param_name is null then
+        raise exception 'Invalid NULL value';
+    end if;
+
+    -- check if queue exists
+    perform 1 from pgque.queue where queue_name = x_queue_name;
+    if not found then
+        raise exception 'No such event queue';
+    end if;
+
+    -- check if valid parameter name
+    v_param_name := 'queue_' || x_param_name;
+    if v_param_name not in (
+        'queue_ticker_max_count',
+        'queue_ticker_max_lag',
+        'queue_ticker_idle_period',
+        'queue_ticker_paused',
+        'queue_rotation_period',
+        'queue_external_ticker',
+        'queue_max_retries')
+    then
+        raise exception 'cannot change parameter "%s"', x_param_name;
+    end if;
+
+    execute 'update pgque.queue set '
+        || v_param_name || ' = ' || quote_literal(x_param_value)
+        || ' where queue_name = ' || quote_literal(x_queue_name);
+
+    return 1;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
 -- pgque-additions/roles.sql
 -- pgque security roles
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
@@ -4254,6 +4296,262 @@ begin
     total := total + r;
 
     return total;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque-api/dlq.sql
+-- pgque dead letter queue (DLQ) -- table + helper functions
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- PgQ has a retry queue but no dead letter queue. pgque adds one.
+-- See SPECx.md section 4.5.
+
+-- pgque.dead_letter table
+create table if not exists pgque.dead_letter (
+    dl_id           bigserial primary key,
+    dl_queue_id     int4 not null references pgque.queue(queue_id),
+    dl_consumer_id  int4 not null references pgque.consumer(co_id),
+    dl_time         timestamptz not null default now(),
+    dl_reason       text,
+
+    -- Original event fields (copied from event at time of death)
+    ev_id           bigint not null,
+    ev_time         timestamptz not null,
+    ev_txid         xid8,
+    ev_retry        int4,
+    ev_type         text,
+    ev_data         text,
+    ev_extra1       text,
+    ev_extra2       text,
+    ev_extra3       text,
+    ev_extra4       text
+);
+
+create index if not exists dl_queue_time_idx
+    on pgque.dead_letter (dl_queue_id, dl_time);
+
+-- pgque.event_dead() -- move event to DLQ (called by nack() when max retries exceeded)
+create or replace function pgque.event_dead(
+    i_batch_id bigint,
+    i_event_id bigint,
+    i_reason text,
+    i_ev_time timestamptz,
+    i_ev_txid xid8,
+    i_ev_retry int4,
+    i_ev_type text,
+    i_ev_data text,
+    i_ev_extra1 text default null,
+    i_ev_extra2 text default null,
+    i_ev_extra3 text default null,
+    i_ev_extra4 text default null)
+returns integer as $$
+declare
+    v_sub record;
+begin
+    -- Look up subscription from batch
+    select sub_queue, sub_consumer into v_sub
+    from pgque.subscription where sub_batch = i_batch_id;
+    if not found then
+        raise exception 'batch not found: %', i_batch_id;
+    end if;
+
+    -- Insert into dead letter table (no re-query of batch events)
+    insert into pgque.dead_letter (
+        dl_queue_id, dl_consumer_id, dl_reason,
+        ev_id, ev_time, ev_txid, ev_retry, ev_type, ev_data,
+        ev_extra1, ev_extra2, ev_extra3, ev_extra4)
+    values (
+        v_sub.sub_queue, v_sub.sub_consumer, i_reason,
+        i_event_id, i_ev_time, i_ev_txid, i_ev_retry, i_ev_type, i_ev_data,
+        i_ev_extra1, i_ev_extra2, i_ev_extra3, i_ev_extra4);
+
+    return 1;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.dlq_inspect() -- inspect DLQ entries for a queue
+create or replace function pgque.dlq_inspect(
+    i_queue_name text, i_limit_count int default 100)
+returns setof pgque.dead_letter as $$
+begin
+    return query
+    select dl.*
+    from pgque.dead_letter dl
+    join pgque.queue q on q.queue_id = dl.dl_queue_id
+    where q.queue_name = i_queue_name
+    order by dl.dl_time desc
+    limit i_limit_count;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.dlq_replay() -- replay a single dead letter event back into the queue
+create or replace function pgque.dlq_replay(i_dead_letter_id bigint)
+returns bigint as $$
+declare
+    v_dl record;
+    v_queue_name text;
+    v_new_eid bigint;
+begin
+    select dl.*, q.queue_name into v_dl
+    from pgque.dead_letter dl
+    join pgque.queue q on q.queue_id = dl.dl_queue_id
+    where dl.dl_id = i_dead_letter_id;
+
+    if not found then
+        raise exception 'dead letter entry not found: %', i_dead_letter_id;
+    end if;
+
+    -- Re-insert into the queue
+    v_new_eid := pgque.insert_event(v_dl.queue_name, v_dl.ev_type, v_dl.ev_data,
+        v_dl.ev_extra1, v_dl.ev_extra2, v_dl.ev_extra3, v_dl.ev_extra4);
+
+    -- Remove from DLQ
+    delete from pgque.dead_letter where dl_id = i_dead_letter_id;
+
+    return v_new_eid;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.dlq_replay_all() -- replay all DLQ events for a queue
+create or replace function pgque.dlq_replay_all(i_queue_name text)
+returns integer as $$
+declare
+    v_dl record;
+    v_cnt integer := 0;
+begin
+    for v_dl in
+        select dl.dl_id, dl.ev_type, dl.ev_data,
+               dl.ev_extra1, dl.ev_extra2, dl.ev_extra3, dl.ev_extra4,
+               q.queue_name
+        from pgque.dead_letter dl
+        join pgque.queue q on q.queue_id = dl.dl_queue_id
+        where q.queue_name = i_queue_name
+    loop
+        perform pgque.insert_event(v_dl.queue_name, v_dl.ev_type, v_dl.ev_data,
+            v_dl.ev_extra1, v_dl.ev_extra2, v_dl.ev_extra3, v_dl.ev_extra4);
+        delete from pgque.dead_letter where dl_id = v_dl.dl_id;
+        v_cnt := v_cnt + 1;
+    end loop;
+
+    return v_cnt;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.dlq_purge() -- purge old DLQ entries
+create or replace function pgque.dlq_purge(
+    i_queue_name text, i_older_than interval default '30 days')
+returns integer as $$
+declare
+    v_cnt integer;
+begin
+    delete from pgque.dead_letter
+    where dl_queue_id = (select queue_id from pgque.queue where queue_name = i_queue_name)
+      and dl_time < now() - i_older_than;
+    get diagnostics v_cnt = row_count;
+    return v_cnt;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque-api/receive.sql
+-- pgque.receive(), pgque.ack(), pgque.nack() -- modern consume API
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+-- Includes code derived from PgQ (ISC license, Marko Kreen / Skype Technologies OU).
+--
+-- These functions wrap PgQ primitives (next_batch, get_batch_events,
+-- finish_batch, event_retry) into a simpler receive/ack/nack interface.
+-- See SPECx.md sections 4.2 and 4.3.
+
+-- pgque.message type (idempotent creation)
+do $$ begin
+    create type pgque.message as (
+        msg_id      bigint,
+        batch_id    bigint,
+        type        text,
+        payload     text,
+        retry_count int4,
+        created_at  timestamptz,
+        extra1      text,
+        extra2      text,
+        extra3      text,
+        extra4      text
+    );
+exception when duplicate_object then null;
+end $$;
+
+-- pgque.receive() -- wraps next_batch + get_batch_events
+create or replace function pgque.receive(
+    i_queue text, i_consumer text, i_max_return int default 100)
+returns setof pgque.message as $$
+declare
+    v_batch_id bigint;
+    ev record;
+    cnt int := 0;
+begin
+    -- Get next batch (may return NULL if no events)
+    v_batch_id := pgque.next_batch(i_queue, i_consumer);
+    if v_batch_id is null then
+        return;
+    end if;
+
+    -- Yield messages from the batch
+    for ev in
+        select ev_id, ev_type, ev_data, ev_retry, ev_time,
+               ev_extra1, ev_extra2, ev_extra3, ev_extra4
+        from pgque.get_batch_events(v_batch_id)
+    loop
+        return next row(
+            ev.ev_id, v_batch_id, ev.ev_type, ev.ev_data,
+            ev.ev_retry, ev.ev_time,
+            ev.ev_extra1, ev.ev_extra2, ev.ev_extra3, ev.ev_extra4
+        )::pgque.message;
+        cnt := cnt + 1;
+        exit when cnt >= i_max_return;
+    end loop;
+    return;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.ack() -- finishes the batch, advances consumer position
+create or replace function pgque.ack(i_batch_id bigint)
+returns integer as $$
+begin
+    return pgque.finish_batch(i_batch_id);
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.nack() -- retry or route to DLQ based on retry_count vs max_retries
+create or replace function pgque.nack(
+    i_batch_id bigint,
+    i_msg pgque.message,
+    i_retry_after interval default '60 seconds',
+    i_reason text default null)
+returns integer as $$
+declare
+    v_max_retries int4;
+begin
+    -- Single lookup: subscription -> queue config
+    select coalesce(q.queue_max_retries, 5) into v_max_retries
+    from pgque.subscription s
+    join pgque.queue q on q.queue_id = s.sub_queue
+    where s.sub_batch = i_batch_id;
+
+    if not found then
+        raise exception 'batch not found: %', i_batch_id;
+    end if;
+
+    if coalesce(i_msg.retry_count, 0) >= v_max_retries then
+        -- Move to dead letter queue (pass event fields, no re-query)
+        perform pgque.event_dead(i_batch_id, i_msg.msg_id,
+            coalesce(i_reason, 'max retries exceeded'),
+            i_msg.created_at, null::xid8, i_msg.retry_count,
+            i_msg.type, i_msg.payload,
+            i_msg.extra1, i_msg.extra2, i_msg.extra3, i_msg.extra4);
+    else
+        -- Retry after delay
+        perform pgque.event_retry(i_batch_id, i_msg.msg_id,
+            extract(epoch from i_retry_after)::integer);
+    end if;
+    return 1;
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 

--- a/tests/run_all.sql
+++ b/tests/run_all.sql
@@ -55,5 +55,11 @@
 \echo 'Running: test_api_delayed'
 \i tests/test_api_delayed.sql
 
+\echo 'Running: test_api_receive'
+\i tests/test_api_receive.sql
+
+\echo 'Running: test_api_dlq'
+\i tests/test_api_dlq.sql
+
 \echo ''
 \echo '=== ALL TESTS PASSED ==='

--- a/tests/test_api_dlq.sql
+++ b/tests/test_api_dlq.sql
@@ -1,0 +1,109 @@
+\set ON_ERROR_STOP on
+
+-- Test DLQ (dead letter queue) functionality
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+-- Test 1: nack with retry_count < max_retries -> retry
+do $$
+declare
+  v_msg pgque.message;
+  v_batch_id bigint;
+begin
+  perform pgque.create_queue('test_dlq');
+  perform pgque.set_queue_config('test_dlq', 'queue_max_retries', '2');
+  perform pgque.register_consumer('test_dlq', 'c1');
+
+  perform pgque.insert_event('test_dlq', 'dlq.test', '{"x":1}');
+  perform pgque.ticker();
+
+  -- Receive
+  select * into v_msg from pgque.receive('test_dlq', 'c1', 1) limit 1;
+  assert v_msg.msg_id is not null, 'should receive a message';
+
+  -- Nack (retry_count is NULL/0, max_retries is 2, so should retry)
+  perform pgque.nack(v_msg.batch_id, v_msg, '0 seconds'::interval, 'test failure');
+  perform pgque.ack(v_msg.batch_id);
+
+  -- Event should be in retry queue, not DLQ
+  assert (select count(*) from pgque.dead_letter) = 0, 'should not be in DLQ yet';
+
+  raise notice 'PASS: nack retries when under max_retries';
+
+  perform pgque.unregister_consumer('test_dlq', 'c1');
+  perform pgque.drop_queue('test_dlq');
+end $$;
+
+-- Test 2: nack with retry_count >= max_retries -> DLQ
+do $$
+declare
+  v_msg pgque.message;
+  v_dlq_count bigint;
+begin
+  perform pgque.create_queue('test_dlq2');
+  perform pgque.set_queue_config('test_dlq2', 'queue_max_retries', '2');
+  perform pgque.register_consumer('test_dlq2', 'c1');
+
+  perform pgque.insert_event('test_dlq2', 'dlq.test', '{"x":1}');
+  perform pgque.ticker();
+
+  select * into v_msg from pgque.receive('test_dlq2', 'c1', 1) limit 1;
+
+  -- Forge retry_count to simulate prior retries (unit test approach)
+  v_msg.retry_count := 2;
+
+  -- Nack should route to DLQ (retry_count=2 >= max_retries=2)
+  perform pgque.nack(v_msg.batch_id, v_msg, '0 seconds'::interval, 'max retries');
+  perform pgque.ack(v_msg.batch_id);
+
+  -- Verify event is in DLQ
+  select count(*) into v_dlq_count from pgque.dead_letter
+  where dl_queue_id = (select queue_id from pgque.queue where queue_name = 'test_dlq2');
+  assert v_dlq_count = 1, 'should have 1 DLQ entry, got ' || v_dlq_count;
+
+  raise notice 'PASS: nack routes to DLQ after max retries';
+
+  perform pgque.unregister_consumer('test_dlq2', 'c1');
+  perform pgque.drop_queue('test_dlq2');
+end $$;
+
+-- Test 3: dlq_inspect and dlq_replay
+do $$
+declare
+  v_dl_count bigint;
+  v_new_eid bigint;
+begin
+  -- Setup: create queue with event that goes to DLQ
+  perform pgque.create_queue('test_dlq3');
+  perform pgque.set_queue_config('test_dlq3', 'queue_max_retries', '0');
+  perform pgque.register_consumer('test_dlq3', 'c1');
+
+  perform pgque.insert_event('test_dlq3', 'dlq.replay', '{"replay":true}');
+  perform pgque.ticker();
+
+  declare v_msg pgque.message;
+  begin
+    select * into v_msg from pgque.receive('test_dlq3', 'c1', 1) limit 1;
+    perform pgque.nack(v_msg.batch_id, v_msg, '0 seconds'::interval, 'force dlq');
+    perform pgque.ack(v_msg.batch_id);
+  end;
+
+  -- dlq_inspect
+  select count(*) into v_dl_count from pgque.dlq_inspect('test_dlq3', 100);
+  assert v_dl_count >= 1, 'dlq_inspect should show entries';
+
+  -- dlq_replay
+  select pgque.dlq_replay(dl_id) into v_new_eid
+  from pgque.dead_letter
+  where dl_queue_id = (select queue_id from pgque.queue where queue_name = 'test_dlq3')
+  limit 1;
+  assert v_new_eid is not null, 'dlq_replay should return new event id';
+
+  raise notice 'PASS: dlq_inspect and dlq_replay';
+
+  -- dlq_purge
+  perform pgque.dlq_purge('test_dlq3', '0 seconds'::interval);
+
+  perform pgque.unregister_consumer('test_dlq3', 'c1');
+  perform pgque.drop_queue('test_dlq3');
+  raise notice 'PASS: dlq_purge';
+end $$;

--- a/tests/test_api_dlq.sql
+++ b/tests/test_api_dlq.sql
@@ -2,21 +2,39 @@
 
 -- Test DLQ (dead letter queue) functionality
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- PgQ requires insert, ticker, and receive to be in separate transactions
+-- (snapshot visibility). Each DO block is a separate transaction.
 
+-- ========================================
 -- Test 1: nack with retry_count < max_retries -> retry
+-- ========================================
+
+-- Setup
+do $$
+begin
+  perform pgque.create_queue('test_dlq');
+  perform pgque.set_queue_config('test_dlq', 'max_retries', '2');
+  perform pgque.register_consumer('test_dlq', 'c1');
+end $$;
+
+-- Insert event
+do $$
+begin
+  perform pgque.insert_event('test_dlq', 'dlq.test', '{"x":1}');
+end $$;
+
+-- Ticker
+do $$
+begin
+  perform pgque.ticker();
+end $$;
+
+-- Receive, nack (retry), ack
 do $$
 declare
   v_msg pgque.message;
-  v_batch_id bigint;
 begin
-  perform pgque.create_queue('test_dlq');
-  perform pgque.set_queue_config('test_dlq', 'queue_max_retries', '2');
-  perform pgque.register_consumer('test_dlq', 'c1');
-
-  perform pgque.insert_event('test_dlq', 'dlq.test', '{"x":1}');
-  perform pgque.ticker();
-
-  -- Receive
   select * into v_msg from pgque.receive('test_dlq', 'c1', 1) limit 1;
   assert v_msg.msg_id is not null, 'should receive a message';
 
@@ -26,26 +44,46 @@ begin
 
   -- Event should be in retry queue, not DLQ
   assert (select count(*) from pgque.dead_letter) = 0, 'should not be in DLQ yet';
-
-  raise notice 'PASS: nack retries when under max_retries';
-
-  perform pgque.unregister_consumer('test_dlq', 'c1');
-  perform pgque.drop_queue('test_dlq');
 end $$;
 
+-- Cleanup test 1
+do $$
+begin
+  perform pgque.unregister_consumer('test_dlq', 'c1');
+  perform pgque.drop_queue('test_dlq');
+  raise notice 'PASS: nack retries when under max_retries';
+end $$;
+
+-- ========================================
 -- Test 2: nack with retry_count >= max_retries -> DLQ
+-- ========================================
+
+-- Setup
+do $$
+begin
+  perform pgque.create_queue('test_dlq2');
+  perform pgque.set_queue_config('test_dlq2', 'max_retries', '2');
+  perform pgque.register_consumer('test_dlq2', 'c1');
+end $$;
+
+-- Insert event
+do $$
+begin
+  perform pgque.insert_event('test_dlq2', 'dlq.test', '{"x":1}');
+end $$;
+
+-- Ticker
+do $$
+begin
+  perform pgque.ticker();
+end $$;
+
+-- Receive, forge retry_count, nack -> DLQ
 do $$
 declare
   v_msg pgque.message;
   v_dlq_count bigint;
 begin
-  perform pgque.create_queue('test_dlq2');
-  perform pgque.set_queue_config('test_dlq2', 'queue_max_retries', '2');
-  perform pgque.register_consumer('test_dlq2', 'c1');
-
-  perform pgque.insert_event('test_dlq2', 'dlq.test', '{"x":1}');
-  perform pgque.ticker();
-
   select * into v_msg from pgque.receive('test_dlq2', 'c1', 1) limit 1;
 
   -- Forge retry_count to simulate prior retries (unit test approach)
@@ -59,34 +97,59 @@ begin
   select count(*) into v_dlq_count from pgque.dead_letter
   where dl_queue_id = (select queue_id from pgque.queue where queue_name = 'test_dlq2');
   assert v_dlq_count = 1, 'should have 1 DLQ entry, got ' || v_dlq_count;
-
-  raise notice 'PASS: nack routes to DLQ after max retries';
-
-  perform pgque.unregister_consumer('test_dlq2', 'c1');
-  perform pgque.drop_queue('test_dlq2');
 end $$;
 
--- Test 3: dlq_inspect and dlq_replay
+-- Cleanup test 2
+do $$
+begin
+  -- Delete DLQ entries before unregistering consumer (FK constraint)
+  delete from pgque.dead_letter
+  where dl_queue_id = (select queue_id from pgque.queue where queue_name = 'test_dlq2');
+  perform pgque.unregister_consumer('test_dlq2', 'c1');
+  perform pgque.drop_queue('test_dlq2');
+  raise notice 'PASS: nack routes to DLQ after max retries';
+end $$;
+
+-- ========================================
+-- Test 3: dlq_inspect, dlq_replay, dlq_purge
+-- ========================================
+
+-- Setup
+do $$
+begin
+  perform pgque.create_queue('test_dlq3');
+  perform pgque.set_queue_config('test_dlq3', 'max_retries', '0');
+  perform pgque.register_consumer('test_dlq3', 'c1');
+end $$;
+
+-- Insert event
+do $$
+begin
+  perform pgque.insert_event('test_dlq3', 'dlq.replay', '{"replay":true}');
+end $$;
+
+-- Ticker
+do $$
+begin
+  perform pgque.ticker();
+end $$;
+
+-- Receive and nack -> DLQ (max_retries=0 so any nack goes to DLQ)
+do $$
+declare
+  v_msg pgque.message;
+begin
+  select * into v_msg from pgque.receive('test_dlq3', 'c1', 1) limit 1;
+  perform pgque.nack(v_msg.batch_id, v_msg, '0 seconds'::interval, 'force dlq');
+  perform pgque.ack(v_msg.batch_id);
+end $$;
+
+-- Verify dlq_inspect, dlq_replay, dlq_purge
 do $$
 declare
   v_dl_count bigint;
   v_new_eid bigint;
 begin
-  -- Setup: create queue with event that goes to DLQ
-  perform pgque.create_queue('test_dlq3');
-  perform pgque.set_queue_config('test_dlq3', 'queue_max_retries', '0');
-  perform pgque.register_consumer('test_dlq3', 'c1');
-
-  perform pgque.insert_event('test_dlq3', 'dlq.replay', '{"replay":true}');
-  perform pgque.ticker();
-
-  declare v_msg pgque.message;
-  begin
-    select * into v_msg from pgque.receive('test_dlq3', 'c1', 1) limit 1;
-    perform pgque.nack(v_msg.batch_id, v_msg, '0 seconds'::interval, 'force dlq');
-    perform pgque.ack(v_msg.batch_id);
-  end;
-
   -- dlq_inspect
   select count(*) into v_dl_count from pgque.dlq_inspect('test_dlq3', 100);
   assert v_dl_count >= 1, 'dlq_inspect should show entries';
@@ -103,7 +166,12 @@ begin
   -- dlq_purge
   perform pgque.dlq_purge('test_dlq3', '0 seconds'::interval);
 
+  raise notice 'PASS: dlq_purge';
+end $$;
+
+-- Cleanup test 3
+do $$
+begin
   perform pgque.unregister_consumer('test_dlq3', 'c1');
   perform pgque.drop_queue('test_dlq3');
-  raise notice 'PASS: dlq_purge';
 end $$;

--- a/tests/test_api_receive.sql
+++ b/tests/test_api_receive.sql
@@ -1,0 +1,43 @@
+\set ON_ERROR_STOP on
+
+-- Test receive/ack/nack API
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+-- Test 1: receive() returns messages
+do $$
+declare
+  v_msg pgque.message;
+  v_count int := 0;
+begin
+  perform pgque.create_queue('test_recv');
+  perform pgque.register_consumer('test_recv', 'c1');
+
+  -- Insert event using raw API (send() may not exist yet)
+  perform pgque.insert_event('test_recv', 'test.type', '{"key":"val"}');
+  perform pgque.ticker();
+
+  for v_msg in select * from pgque.receive('test_recv', 'c1', 10)
+  loop
+    v_count := v_count + 1;
+    assert v_msg.type = 'test.type', 'type should be test.type';
+    assert v_msg.payload = '{"key":"val"}', 'payload should match';
+    assert v_msg.batch_id is not null, 'batch_id should be set';
+  end loop;
+
+  assert v_count = 1, 'should receive exactly 1 message, got ' || v_count;
+
+  -- Ack the batch
+  perform pgque.ack(v_msg.batch_id);
+
+  -- Next receive should be empty
+  v_count := 0;
+  for v_msg in select * from pgque.receive('test_recv', 'c1', 10)
+  loop
+    v_count := v_count + 1;
+  end loop;
+  assert v_count = 0, 'should have no more messages after ack';
+
+  perform pgque.unregister_consumer('test_recv', 'c1');
+  perform pgque.drop_queue('test_recv');
+  raise notice 'PASS: receive + ack';
+end $$;

--- a/tests/test_api_receive.sql
+++ b/tests/test_api_receive.sql
@@ -2,20 +2,35 @@
 
 -- Test receive/ack/nack API
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- PgQ requires insert, ticker, and receive to be in separate transactions
+-- (snapshot visibility). Each DO block is a separate transaction.
 
--- Test 1: receive() returns messages
+-- Step 1: setup
+do $$
+begin
+  perform pgque.create_queue('test_recv');
+  perform pgque.register_consumer('test_recv', 'c1');
+end $$;
+
+-- Step 2: insert event (separate transaction)
+do $$
+begin
+  perform pgque.insert_event('test_recv', 'test.type', '{"key":"val"}');
+end $$;
+
+-- Step 3: ticker (separate transaction to capture the insert)
+do $$
+begin
+  perform pgque.ticker();
+end $$;
+
+-- Step 4: receive and verify
 do $$
 declare
   v_msg pgque.message;
   v_count int := 0;
 begin
-  perform pgque.create_queue('test_recv');
-  perform pgque.register_consumer('test_recv', 'c1');
-
-  -- Insert event using raw API (send() may not exist yet)
-  perform pgque.insert_event('test_recv', 'test.type', '{"key":"val"}');
-  perform pgque.ticker();
-
   for v_msg in select * from pgque.receive('test_recv', 'c1', 10)
   loop
     v_count := v_count + 1;
@@ -28,15 +43,24 @@ begin
 
   -- Ack the batch
   perform pgque.ack(v_msg.batch_id);
+end $$;
 
-  -- Next receive should be empty
-  v_count := 0;
+-- Step 5: verify no more messages after ack
+do $$
+declare
+  v_msg pgque.message;
+  v_count int := 0;
+begin
   for v_msg in select * from pgque.receive('test_recv', 'c1', 10)
   loop
     v_count := v_count + 1;
   end loop;
   assert v_count = 0, 'should have no more messages after ack';
+end $$;
 
+-- Cleanup
+do $$
+begin
   perform pgque.unregister_consumer('test_recv', 'c1');
   perform pgque.drop_queue('test_recv');
   raise notice 'PASS: receive + ack';


### PR DESCRIPTION
## Summary
- Implement `pgque.receive()`, `ack()`, `nack()` wrapping PgQ primitives (next_batch, get_batch_events, finish_batch, event_retry) per SPECx sections 4.2--4.3
- Add dead letter queue: `pgque.dead_letter` table, `event_dead()`, `dlq_inspect()`, `dlq_replay()`, `dlq_replay_all()`, `dlq_purge()` per SPECx section 4.5
- `nack()` checks `retry_count` against `queue_max_retries` config and routes to DLQ when max retries exceeded
- Extend `set_queue_config()` to accept `max_retries` parameter
- Update `build/transform.sh` to assemble `sql/pgque-api/*.sql` as Section 7

Closes #19

## Test plan
- [x] `test_api_receive.sql`: receive() returns messages with correct fields; ack() advances consumer position; subsequent receive() is empty
- [x] `test_api_dlq.sql` Test 1: nack() with retry_count < max_retries schedules retry (not DLQ)
- [x] `test_api_dlq.sql` Test 2: nack() with retry_count >= max_retries routes to dead_letter table
- [x] `test_api_dlq.sql` Test 3: dlq_inspect() shows entries; dlq_replay() re-inserts event; dlq_purge() removes entries
- [x] All existing tests continue to pass (full `run_all.sql` suite)
- [x] Build script assembles correctly with new pgque-api section

🤖 Generated with [Claude Code](https://claude.com/claude-code)