### PR TITLE
feat: acceptance tests for US-1..US-4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,11 @@ jobs:
           PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
             -f tests/run_all.sql
 
+      - name: Run acceptance tests
+        run: |
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
+            -f tests/acceptance/run_acceptance.sql
+
       - name: Test install idempotency
         run: |
           # Re-run install -- should produce no errors

--- a/tests/acceptance/run_acceptance.sql
+++ b/tests/acceptance/run_acceptance.sql
@@ -1,0 +1,16 @@
+\set ON_ERROR_STOP on
+\echo '=== pgque acceptance tests ==='
+\echo ''
+\echo 'Running: US-1 Basic produce/consume cycle'
+\i tests/acceptance/us1_basic_produce_consume.sql
+\echo ''
+\echo 'Running: US-2 Multiple consumers (fan-out)'
+\i tests/acceptance/us2_fan_out.sql
+\echo ''
+\echo 'Running: US-3 Retry and DLQ flow'
+\i tests/acceptance/us3_retry_dlq.sql
+\echo ''
+\echo 'Running: US-4 Delayed delivery'
+\i tests/acceptance/us4_delayed_delivery.sql
+\echo ''
+\echo '=== ALL ACCEPTANCE TESTS PASSED ==='

--- a/tests/acceptance/us1_basic_produce_consume.sql
+++ b/tests/acceptance/us1_basic_produce_consume.sql
@@ -1,0 +1,71 @@
+\set ON_ERROR_STOP on
+
+-- US-1: Basic produce/consume cycle
+-- As a developer, I want to send a JSON message and receive it
+-- SPECx.md section 13.3
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+-- Setup
+do $$ begin
+  perform pgque.create_queue('us1_orders');
+  perform pgque.subscribe('us1_orders', 'app');
+end $$;
+
+-- Action: send a message using the modern API
+do $$ begin
+  perform pgque.send('us1_orders', '{"id":1}'::jsonb);
+end $$;
+
+-- Tick (force_tick bypasses throttle; separate transaction for snapshot visibility)
+do $$ begin
+  perform pgque.force_tick('us1_orders');
+  perform pgque.ticker();
+end $$;
+
+-- Verify: receive returns exactly 1 message with correct fields
+do $$
+declare
+  v_msg pgque.message;
+  v_count int := 0;
+  v_batch_id bigint;
+begin
+  for v_msg in select * from pgque.receive('us1_orders', 'app', 10)
+  loop
+    v_count := v_count + 1;
+    assert v_msg.payload::jsonb = '{"id":1}'::jsonb, 'payload should match, got ' || coalesce(v_msg.payload, 'NULL');
+    assert v_msg.type = 'default', 'type should be default, got ' || coalesce(v_msg.type, 'NULL');
+    assert v_msg.batch_id is not null, 'batch_id should be set';
+    assert v_msg.msg_id is not null, 'msg_id should be set';
+    assert v_msg.created_at is not null, 'created_at should be set';
+    v_batch_id := v_msg.batch_id;
+  end loop;
+
+  assert v_count = 1, 'should receive exactly 1 message, got ' || v_count;
+
+  -- Ack the batch
+  perform pgque.ack(v_batch_id);
+
+  raise notice 'PASS: US-1 send + receive + ack';
+end $$;
+
+-- Verify: subsequent receive is empty (batch was acked)
+do $$
+declare
+  v_count int := 0;
+  v_msg pgque.message;
+begin
+  for v_msg in select * from pgque.receive('us1_orders', 'app', 10)
+  loop
+    v_count := v_count + 1;
+  end loop;
+  assert v_count = 0, 'subsequent receive should be empty, got ' || v_count;
+  raise notice 'PASS: US-1 subsequent receive empty';
+end $$;
+
+-- Teardown
+do $$ begin
+  perform pgque.unsubscribe('us1_orders', 'app');
+  perform pgque.drop_queue('us1_orders');
+end $$;
+
+\echo 'US-1: PASSED'

--- a/tests/acceptance/us2_fan_out.sql
+++ b/tests/acceptance/us2_fan_out.sql
@@ -1,0 +1,122 @@
+\set ON_ERROR_STOP on
+
+-- US-2: Multiple consumers (fan-out)
+-- As a platform team, I want multiple independent consumers on one queue,
+-- so that analytics, notifications, and audit each process the same events
+-- at their own pace.
+-- SPECx.md section 13.3
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+-- Setup: create queue and subscribe 3 consumers
+do $$ begin
+  perform pgque.create_queue('us2_events');
+  perform pgque.subscribe('us2_events', 'analytics');
+  perform pgque.subscribe('us2_events', 'notifier');
+  perform pgque.subscribe('us2_events', 'audit');
+end $$;
+
+-- Action: send 5 events
+do $$ begin
+  perform pgque.send('us2_events', 'user.signup', '{"user":1}'::jsonb);
+  perform pgque.send('us2_events', 'user.signup', '{"user":2}'::jsonb);
+  perform pgque.send('us2_events', 'user.signup', '{"user":3}'::jsonb);
+  perform pgque.send('us2_events', 'user.signup', '{"user":4}'::jsonb);
+  perform pgque.send('us2_events', 'user.signup', '{"user":5}'::jsonb);
+end $$;
+
+-- Tick (force_tick bypasses throttle)
+do $$ begin
+  perform pgque.force_tick('us2_events');
+  perform pgque.ticker();
+end $$;
+
+-- Verify: analytics receives all 5
+do $$
+declare
+  v_msg pgque.message;
+  v_count int := 0;
+  v_batch_id bigint;
+begin
+  for v_msg in select * from pgque.receive('us2_events', 'analytics', 100)
+  loop
+    v_count := v_count + 1;
+    v_batch_id := v_msg.batch_id;
+  end loop;
+
+  assert v_count = 5, 'analytics should receive 5 events, got ' || v_count;
+  perform pgque.ack(v_batch_id);
+  raise notice 'PASS: US-2 analytics receives all 5 events';
+end $$;
+
+-- Verify: notifier also receives all 5 (independent consumer)
+do $$
+declare
+  v_msg pgque.message;
+  v_count int := 0;
+  v_batch_id bigint;
+begin
+  for v_msg in select * from pgque.receive('us2_events', 'notifier', 100)
+  loop
+    v_count := v_count + 1;
+    v_batch_id := v_msg.batch_id;
+  end loop;
+
+  assert v_count = 5, 'notifier should receive 5 events, got ' || v_count;
+  perform pgque.ack(v_batch_id);
+  raise notice 'PASS: US-2 notifier receives all 5 events';
+end $$;
+
+-- Verify: audit also receives all 5 (independent consumer)
+do $$
+declare
+  v_msg pgque.message;
+  v_count int := 0;
+  v_batch_id bigint;
+begin
+  for v_msg in select * from pgque.receive('us2_events', 'audit', 100)
+  loop
+    v_count := v_count + 1;
+    v_batch_id := v_msg.batch_id;
+  end loop;
+
+  assert v_count = 5, 'audit should receive 5 events, got ' || v_count;
+  perform pgque.ack(v_batch_id);
+  raise notice 'PASS: US-2 audit receives all 5 events';
+end $$;
+
+-- Verify: all consumers are now caught up (no more messages)
+do $$
+declare
+  v_msg pgque.message;
+  v_count int := 0;
+begin
+  for v_msg in select * from pgque.receive('us2_events', 'analytics', 100)
+  loop
+    v_count := v_count + 1;
+  end loop;
+  assert v_count = 0, 'analytics should have no more messages';
+
+  for v_msg in select * from pgque.receive('us2_events', 'notifier', 100)
+  loop
+    v_count := v_count + 1;
+  end loop;
+  assert v_count = 0, 'notifier should have no more messages';
+
+  for v_msg in select * from pgque.receive('us2_events', 'audit', 100)
+  loop
+    v_count := v_count + 1;
+  end loop;
+  assert v_count = 0, 'audit should have no more messages';
+
+  raise notice 'PASS: US-2 all consumers caught up';
+end $$;
+
+-- Teardown
+do $$ begin
+  perform pgque.unsubscribe('us2_events', 'analytics');
+  perform pgque.unsubscribe('us2_events', 'notifier');
+  perform pgque.unsubscribe('us2_events', 'audit');
+  perform pgque.drop_queue('us2_events');
+end $$;
+
+\echo 'US-2: PASSED'

--- a/tests/acceptance/us3_retry_dlq.sql
+++ b/tests/acceptance/us3_retry_dlq.sql
@@ -18,6 +18,9 @@
 --   5. Verify: event in dead_letter, dlq_inspect shows it
 --   6. dlq_replay -> ticker -> receive (event is back)
 
+-- Temp table to pass batch_id between DO blocks
+create temporary table if not exists _us3_state (batch_id bigint);
+
 -- ==============================
 -- Setup: queue with max_retries=2
 -- ==============================
@@ -43,11 +46,13 @@ end $$;
 do $$
 declare
   v_msg pgque.message;
+  v_batch_id bigint;
   v_count int := 0;
 begin
   for v_msg in select * from pgque.receive('us3_jobs', 'worker', 10)
   loop
     v_count := v_count + 1;
+    v_batch_id := v_msg.batch_id;
     assert coalesce(v_msg.retry_count, 0) = 0,
       'initial retry_count should be 0 (or NULL), got ' || coalesce(v_msg.retry_count::text, 'NULL');
     assert v_msg.payload::jsonb = '{"task":"test"}'::jsonb,
@@ -58,6 +63,11 @@ begin
   end loop;
 
   assert v_count = 1, 'should receive exactly 1 message, got ' || v_count;
+
+  -- Save batch_id for ack in next DO block
+  delete from _us3_state;
+  insert into _us3_state values (v_batch_id);
+
   raise notice 'PASS: US-3 initial receive (retry_count=0)';
 end $$;
 
@@ -66,16 +76,9 @@ do $$
 declare
   v_batch_id bigint;
 begin
-  -- Get the current batch from subscription
-  select sub_batch into v_batch_id
-  from pgque.subscription s
-  join pgque.queue q on q.queue_id = s.sub_queue
-  where q.queue_name = 'us3_jobs'
-  and s.sub_batch is not null;
-
-  if v_batch_id is not null then
-    perform pgque.ack(v_batch_id);
-  end if;
+  select batch_id into v_batch_id from _us3_state;
+  assert v_batch_id is not null, 'batch_id should not be null';
+  perform pgque.ack(v_batch_id);
 end $$;
 
 -- ==============================
@@ -97,11 +100,13 @@ end $$;
 do $$
 declare
   v_msg pgque.message;
+  v_batch_id bigint;
   v_count int := 0;
 begin
   for v_msg in select * from pgque.receive('us3_jobs', 'worker', 10)
   loop
     v_count := v_count + 1;
+    v_batch_id := v_msg.batch_id;
     assert v_msg.retry_count = 1,
       'cycle 1: retry_count should be 1, got ' || coalesce(v_msg.retry_count::text, 'NULL');
 
@@ -110,6 +115,11 @@ begin
   end loop;
 
   assert v_count = 1, 'cycle 1: should receive 1 message, got ' || v_count;
+
+  -- Save batch_id for ack in next DO block
+  delete from _us3_state;
+  insert into _us3_state values (v_batch_id);
+
   raise notice 'PASS: US-3 cycle 1 (retry_count=1)';
 end $$;
 
@@ -118,15 +128,9 @@ do $$
 declare
   v_batch_id bigint;
 begin
-  select sub_batch into v_batch_id
-  from pgque.subscription s
-  join pgque.queue q on q.queue_id = s.sub_queue
-  where q.queue_name = 'us3_jobs'
-  and s.sub_batch is not null;
-
-  if v_batch_id is not null then
-    perform pgque.ack(v_batch_id);
-  end if;
+  select batch_id into v_batch_id from _us3_state;
+  assert v_batch_id is not null, 'batch_id should not be null';
+  perform pgque.ack(v_batch_id);
 end $$;
 
 -- ==============================
@@ -148,11 +152,13 @@ end $$;
 do $$
 declare
   v_msg pgque.message;
+  v_batch_id bigint;
   v_count int := 0;
 begin
   for v_msg in select * from pgque.receive('us3_jobs', 'worker', 10)
   loop
     v_count := v_count + 1;
+    v_batch_id := v_msg.batch_id;
     assert v_msg.retry_count = 2,
       'cycle 2: retry_count should be 2, got ' || coalesce(v_msg.retry_count::text, 'NULL');
 
@@ -161,6 +167,11 @@ begin
   end loop;
 
   assert v_count = 1, 'cycle 2: should receive 1 message, got ' || v_count;
+
+  -- Save batch_id for ack in next DO block
+  delete from _us3_state;
+  insert into _us3_state values (v_batch_id);
+
   raise notice 'PASS: US-3 cycle 2 (retry_count=2, nack routes to DLQ)';
 end $$;
 
@@ -169,15 +180,9 @@ do $$
 declare
   v_batch_id bigint;
 begin
-  select sub_batch into v_batch_id
-  from pgque.subscription s
-  join pgque.queue q on q.queue_id = s.sub_queue
-  where q.queue_name = 'us3_jobs'
-  and s.sub_batch is not null;
-
-  if v_batch_id is not null then
-    perform pgque.ack(v_batch_id);
-  end if;
+  select batch_id into v_batch_id from _us3_state;
+  assert v_batch_id is not null, 'batch_id should not be null';
+  perform pgque.ack(v_batch_id);
 end $$;
 
 -- ==============================
@@ -266,6 +271,8 @@ end $$;
 -- ==============================
 -- Teardown
 -- ==============================
+drop table if exists _us3_state;
+
 do $$ begin
   -- Clean up any remaining DLQ entries
   delete from pgque.dead_letter

--- a/tests/acceptance/us3_retry_dlq.sql
+++ b/tests/acceptance/us3_retry_dlq.sql
@@ -1,0 +1,277 @@
+\set ON_ERROR_STOP on
+
+-- US-3: Retry and DLQ flow (integration test)
+-- As a developer, I want failed messages to retry automatically and
+-- land in a dead letter queue after max retries, so that transient
+-- failures are handled without manual intervention.
+-- SPECx.md section 13.3
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- CRITICAL: Each step (nack, ack, maint_retry_events, ticker, receive)
+-- must be in a SEPARATE DO block for PgQ's snapshot isolation to work.
+--
+-- Flow:
+--   1. Create queue with max_retries=2, send event, ticker, receive
+--   2. Cycle 1: nack -> ack -> maint_retry_events -> force_tick+ticker -> receive (retry_count=1)
+--   3. Cycle 2: nack -> ack -> maint_retry_events -> force_tick+ticker -> receive (retry_count=2, >= max_retries)
+--   4. Cycle 3: nack -> event goes to DLQ -> ack
+--   5. Verify: event in dead_letter, dlq_inspect shows it
+--   6. dlq_replay -> ticker -> receive (event is back)
+
+-- ==============================
+-- Setup: queue with max_retries=2
+-- ==============================
+do $$ begin
+  perform pgque.create_queue('us3_jobs', '{"max_retries": 2}'::jsonb);
+  perform pgque.subscribe('us3_jobs', 'worker');
+end $$;
+
+-- Send event
+do $$ begin
+  perform pgque.send('us3_jobs', 'job.process', '{"task":"test"}'::jsonb);
+end $$;
+
+-- Ticker (force_tick bypasses throttle)
+do $$ begin
+  perform pgque.force_tick('us3_jobs');
+  perform pgque.ticker();
+end $$;
+
+-- ==============================
+-- Initial receive: retry_count should be NULL (coalesced to 0)
+-- ==============================
+do $$
+declare
+  v_msg pgque.message;
+  v_count int := 0;
+begin
+  for v_msg in select * from pgque.receive('us3_jobs', 'worker', 10)
+  loop
+    v_count := v_count + 1;
+    assert coalesce(v_msg.retry_count, 0) = 0,
+      'initial retry_count should be 0 (or NULL), got ' || coalesce(v_msg.retry_count::text, 'NULL');
+    assert v_msg.payload::jsonb = '{"task":"test"}'::jsonb,
+      'payload should match, got ' || coalesce(v_msg.payload, 'NULL');
+
+    -- Nack: schedule for retry (0 seconds delay for testing)
+    perform pgque.nack(v_msg.batch_id, v_msg, '0 seconds'::interval, 'transient failure');
+  end loop;
+
+  assert v_count = 1, 'should receive exactly 1 message, got ' || v_count;
+  raise notice 'PASS: US-3 initial receive (retry_count=0)';
+end $$;
+
+-- Ack the batch (separate transaction)
+do $$
+declare
+  v_batch_id bigint;
+begin
+  -- Get the current batch from subscription
+  select sub_batch into v_batch_id
+  from pgque.subscription s
+  join pgque.queue q on q.queue_id = s.sub_queue
+  where q.queue_name = 'us3_jobs'
+  and s.sub_batch is not null;
+
+  if v_batch_id is not null then
+    perform pgque.ack(v_batch_id);
+  end if;
+end $$;
+
+-- ==============================
+-- Cycle 1: move retry event back to queue
+-- ==============================
+
+-- maint_retry_events: move from retry_queue back to event table
+do $$ begin
+  perform pgque.maint_retry_events();
+end $$;
+
+-- force_tick + ticker: create a new tick covering the re-inserted event
+do $$ begin
+  perform pgque.force_tick('us3_jobs');
+  perform pgque.ticker();
+end $$;
+
+-- Receive: retry_count should be 1
+do $$
+declare
+  v_msg pgque.message;
+  v_count int := 0;
+begin
+  for v_msg in select * from pgque.receive('us3_jobs', 'worker', 10)
+  loop
+    v_count := v_count + 1;
+    assert v_msg.retry_count = 1,
+      'cycle 1: retry_count should be 1, got ' || coalesce(v_msg.retry_count::text, 'NULL');
+
+    -- Nack again
+    perform pgque.nack(v_msg.batch_id, v_msg, '0 seconds'::interval, 'still failing');
+  end loop;
+
+  assert v_count = 1, 'cycle 1: should receive 1 message, got ' || v_count;
+  raise notice 'PASS: US-3 cycle 1 (retry_count=1)';
+end $$;
+
+-- Ack batch after cycle 1
+do $$
+declare
+  v_batch_id bigint;
+begin
+  select sub_batch into v_batch_id
+  from pgque.subscription s
+  join pgque.queue q on q.queue_id = s.sub_queue
+  where q.queue_name = 'us3_jobs'
+  and s.sub_batch is not null;
+
+  if v_batch_id is not null then
+    perform pgque.ack(v_batch_id);
+  end if;
+end $$;
+
+-- ==============================
+-- Cycle 2: retry again
+-- ==============================
+
+-- maint_retry_events
+do $$ begin
+  perform pgque.maint_retry_events();
+end $$;
+
+-- force_tick + ticker
+do $$ begin
+  perform pgque.force_tick('us3_jobs');
+  perform pgque.ticker();
+end $$;
+
+-- Receive: retry_count should be 2 (now >= max_retries)
+do $$
+declare
+  v_msg pgque.message;
+  v_count int := 0;
+begin
+  for v_msg in select * from pgque.receive('us3_jobs', 'worker', 10)
+  loop
+    v_count := v_count + 1;
+    assert v_msg.retry_count = 2,
+      'cycle 2: retry_count should be 2, got ' || coalesce(v_msg.retry_count::text, 'NULL');
+
+    -- Nack: retry_count=2 >= max_retries=2, so this should go to DLQ
+    perform pgque.nack(v_msg.batch_id, v_msg, '0 seconds'::interval, 'permanent failure');
+  end loop;
+
+  assert v_count = 1, 'cycle 2: should receive 1 message, got ' || v_count;
+  raise notice 'PASS: US-3 cycle 2 (retry_count=2, nack routes to DLQ)';
+end $$;
+
+-- Ack batch after cycle 2 (event is now in DLQ, not retry_queue)
+do $$
+declare
+  v_batch_id bigint;
+begin
+  select sub_batch into v_batch_id
+  from pgque.subscription s
+  join pgque.queue q on q.queue_id = s.sub_queue
+  where q.queue_name = 'us3_jobs'
+  and s.sub_batch is not null;
+
+  if v_batch_id is not null then
+    perform pgque.ack(v_batch_id);
+  end if;
+end $$;
+
+-- ==============================
+-- Verify: event is in dead_letter
+-- ==============================
+do $$
+declare
+  v_dlq_count bigint;
+  v_dl record;
+begin
+  select count(*) into v_dlq_count
+  from pgque.dead_letter dl
+  join pgque.queue q on q.queue_id = dl.dl_queue_id
+  where q.queue_name = 'us3_jobs';
+
+  assert v_dlq_count = 1, 'should have 1 DLQ entry, got ' || v_dlq_count;
+
+  -- Verify dlq_inspect shows the event
+  select * into v_dl from pgque.dlq_inspect('us3_jobs', 100) limit 1;
+  assert v_dl.dl_id is not null, 'dlq_inspect should return an entry';
+  assert v_dl.dl_reason = 'permanent failure',
+    'DLQ reason should be permanent failure, got ' || coalesce(v_dl.dl_reason, 'NULL');
+  assert v_dl.ev_type = 'job.process',
+    'DLQ event type should be job.process, got ' || coalesce(v_dl.ev_type, 'NULL');
+  assert v_dl.ev_data::jsonb = '{"task":"test"}'::jsonb,
+    'DLQ event data should match, got ' || coalesce(v_dl.ev_data, 'NULL');
+
+  raise notice 'PASS: US-3 event in DLQ with correct reason';
+end $$;
+
+-- ==============================
+-- dlq_replay: re-insert event from DLQ back into queue
+-- ==============================
+do $$
+declare
+  v_dl_id bigint;
+  v_new_eid bigint;
+begin
+  select dl_id into v_dl_id
+  from pgque.dead_letter dl
+  join pgque.queue q on q.queue_id = dl.dl_queue_id
+  where q.queue_name = 'us3_jobs'
+  limit 1;
+
+  v_new_eid := pgque.dlq_replay(v_dl_id);
+  assert v_new_eid is not null, 'dlq_replay should return new event id';
+
+  -- Verify DLQ is now empty for this queue
+  assert not exists (
+    select 1 from pgque.dead_letter dl
+    join pgque.queue q on q.queue_id = dl.dl_queue_id
+    where q.queue_name = 'us3_jobs'
+  ), 'DLQ should be empty after replay';
+
+  raise notice 'PASS: US-3 dlq_replay re-inserted event';
+end $$;
+
+-- Ticker after replay (force_tick bypasses throttle)
+do $$ begin
+  perform pgque.force_tick('us3_jobs');
+  perform pgque.ticker();
+end $$;
+
+-- Receive the replayed event (retry_count should be reset/NULL)
+do $$
+declare
+  v_msg pgque.message;
+  v_count int := 0;
+begin
+  for v_msg in select * from pgque.receive('us3_jobs', 'worker', 10)
+  loop
+    v_count := v_count + 1;
+    assert v_msg.type = 'job.process',
+      'replayed event type should be job.process, got ' || coalesce(v_msg.type, 'NULL');
+    assert v_msg.payload::jsonb = '{"task":"test"}'::jsonb,
+      'replayed event payload should match, got ' || coalesce(v_msg.payload, 'NULL');
+
+    -- Ack the replayed event
+    perform pgque.ack(v_msg.batch_id);
+  end loop;
+
+  assert v_count = 1, 'should receive 1 replayed event, got ' || v_count;
+  raise notice 'PASS: US-3 replayed event received successfully';
+end $$;
+
+-- ==============================
+-- Teardown
+-- ==============================
+do $$ begin
+  -- Clean up any remaining DLQ entries
+  delete from pgque.dead_letter
+  where dl_queue_id = (select queue_id from pgque.queue where queue_name = 'us3_jobs');
+  perform pgque.unsubscribe('us3_jobs', 'worker');
+  perform pgque.drop_queue('us3_jobs');
+end $$;
+
+\echo 'US-3: PASSED'

--- a/tests/acceptance/us4_delayed_delivery.sql
+++ b/tests/acceptance/us4_delayed_delivery.sql
@@ -1,0 +1,118 @@
+\set ON_ERROR_STOP on
+
+-- US-4: Delayed delivery
+-- As a developer, I want to schedule a message for future delivery,
+-- so that I can implement reminders and scheduled tasks.
+-- SPECx.md section 13.3
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+-- Setup
+do $$ begin
+  perform pgque.create_queue('us4_reminders');
+  perform pgque.subscribe('us4_reminders', 'sender');
+end $$;
+
+-- Action: schedule a message for 2 seconds in the future
+do $$
+declare
+  v_id bigint;
+  v_de_count bigint;
+begin
+  v_id := pgque.send_at('us4_reminders', 'remind', '{"remind":"call back"}'::jsonb,
+    now() + interval '2 seconds');
+
+  assert v_id is not null, 'send_at should return an id';
+
+  -- Verify event is in delayed_events, not in main queue
+  select count(*) into v_de_count
+  from pgque.delayed_events
+  where de_queue_name = 'us4_reminders';
+  assert v_de_count = 1, 'should have 1 delayed event, got ' || v_de_count;
+
+  raise notice 'PASS: US-4 send_at stored in delayed_events';
+end $$;
+
+-- Ticker (should produce no events yet -- delayed event not due)
+do $$ begin
+  perform pgque.force_tick('us4_reminders');
+  perform pgque.ticker();
+end $$;
+
+-- Verify: receive returns empty (event is still delayed)
+do $$
+declare
+  v_count int := 0;
+  v_msg pgque.message;
+begin
+  for v_msg in select * from pgque.receive('us4_reminders', 'sender', 10)
+  loop
+    v_count := v_count + 1;
+  end loop;
+  -- Count may be 0 (no batch) -- that is correct
+  assert v_count = 0, 'should receive 0 messages before delay, got ' || v_count;
+  raise notice 'PASS: US-4 receive empty before delay';
+end $$;
+
+-- Ack any empty batch that was opened
+do $$
+declare
+  v_batch_id bigint;
+begin
+  select sub_batch into v_batch_id
+  from pgque.subscription s
+  join pgque.queue q on q.queue_id = s.sub_queue
+  where q.queue_name = 'us4_reminders'
+  and s.sub_batch is not null;
+
+  if v_batch_id is not null then
+    perform pgque.ack(v_batch_id);
+  end if;
+end $$;
+
+-- Wait for the delay to pass (2 seconds)
+-- pg_sleep in a DO block to wait for the delayed event to become due
+do $$ begin
+  perform pg_sleep(3);
+end $$;
+
+-- Run maint (which calls maint_deliver_delayed) to move due events
+do $$ begin
+  perform pgque.maint();
+end $$;
+
+-- Ticker to capture the now-delivered event (force_tick bypasses throttle)
+do $$ begin
+  perform pgque.force_tick('us4_reminders');
+  perform pgque.ticker();
+end $$;
+
+-- Verify: receive now returns the event
+do $$
+declare
+  v_msg pgque.message;
+  v_count int := 0;
+begin
+  for v_msg in select * from pgque.receive('us4_reminders', 'sender', 10)
+  loop
+    v_count := v_count + 1;
+    assert v_msg.type = 'remind',
+      'type should be remind, got ' || coalesce(v_msg.type, 'NULL');
+    assert v_msg.payload::jsonb = '{"remind":"call back"}'::jsonb,
+      'payload should match, got ' || coalesce(v_msg.payload, 'NULL');
+
+    perform pgque.ack(v_msg.batch_id);
+  end loop;
+
+  assert v_count = 1, 'should receive 1 delayed message, got ' || v_count;
+  raise notice 'PASS: US-4 delayed event delivered after delay';
+end $$;
+
+-- Teardown
+do $$ begin
+  -- Clean up any leftover delayed events
+  delete from pgque.delayed_events where de_queue_name = 'us4_reminders';
+  perform pgque.unsubscribe('us4_reminders', 'sender');
+  perform pgque.drop_queue('us4_reminders');
+end $$;
+
+\echo 'US-4: PASSED'

--- a/tests/acceptance/us4_delayed_delivery.sql
+++ b/tests/acceptance/us4_delayed_delivery.sql
@@ -12,14 +12,14 @@ do $$ begin
   perform pgque.subscribe('us4_reminders', 'sender');
 end $$;
 
--- Action: schedule a message for 2 seconds in the future
+-- Action: schedule a message for 5 seconds in the future (per spec)
 do $$
 declare
   v_id bigint;
   v_de_count bigint;
 begin
   v_id := pgque.send_at('us4_reminders', 'remind', '{"remind":"call back"}'::jsonb,
-    now() + interval '2 seconds');
+    now() + interval '5 seconds');
 
   assert v_id is not null, 'send_at should return an id';
 
@@ -69,10 +69,9 @@ begin
   end if;
 end $$;
 
--- Wait for the delay to pass (2 seconds)
--- pg_sleep in a DO block to wait for the delayed event to become due
+-- Wait for the delay to pass (5 seconds per spec)
 do $$ begin
-  perform pg_sleep(3);
+  perform pg_sleep(5);
 end $$;
 
 -- Run maint (which calls maint_deliver_delayed) to move due events


### PR DESCRIPTION
## Summary

- Add end-to-end acceptance tests from SPECx.md section 13.3 covering all four core user stories
- US-1: Basic produce/consume cycle (send/receive/ack using modern API)
- US-2: Fan-out to 3 independent consumers (analytics, notifier, audit)
- US-3: Full retry cycle with DLQ integration (nack with retry_count tracking through 2 retries, DLQ routing on max_retries, dlq_inspect verification, dlq_replay back to queue)
- US-4: Delayed delivery via send_at() with pg_sleep wait and maint() delivery
- CI updated to run acceptance tests after regression suite on PG 14-17 matrix

## Key implementation details

- Each test step uses a separate `DO` block for PgQ's snapshot isolation
- `force_tick()` is called before `ticker()` to bypass PgQ's ticker throttle (which skips ticks when event count is low and lag is short)
- JSONB payload comparisons use `::jsonb` cast to handle PostgreSQL's normalized spacing
- US-3 calls `maint_retry_events()` directly (not via `maint()`) since PgQ's `maint_operations()` does not include retry event movement

## Test output (local, PostgreSQL 17)

```
=== pgque acceptance tests ===

Running: US-1 Basic produce/consume cycle
NOTICE:  PASS: US-1 send + receive + ack
NOTICE:  PASS: US-1 subsequent receive empty
US-1: PASSED

Running: US-2 Multiple consumers (fan-out)
NOTICE:  PASS: US-2 analytics receives all 5 events
NOTICE:  PASS: US-2 notifier receives all 5 events
NOTICE:  PASS: US-2 audit receives all 5 events
NOTICE:  PASS: US-2 all consumers caught up
US-2: PASSED

Running: US-3 Retry and DLQ flow
NOTICE:  PASS: US-3 initial receive (retry_count=0)
NOTICE:  PASS: US-3 cycle 1 (retry_count=1)
NOTICE:  PASS: US-3 cycle 2 (retry_count=2, nack routes to DLQ)
NOTICE:  PASS: US-3 event in DLQ with correct reason
NOTICE:  PASS: US-3 dlq_replay re-inserted event
NOTICE:  PASS: US-3 replayed event received successfully
US-3: PASSED

Running: US-4 Delayed delivery
NOTICE:  PASS: US-4 send_at stored in delayed_events
NOTICE:  PASS: US-4 receive empty before delay
NOTICE:  PASS: US-4 delayed event delivered after delay
US-4: PASSED

=== ALL ACCEPTANCE TESTS PASSED ===
```

Closes #21

## Test plan

- [x] All 4 acceptance tests pass on fresh install
- [x] All existing regression tests still pass after acceptance tests run
- [x] CI workflow updated with acceptance test step
- [ ] CI matrix (PG 14-17) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)