### PR TITLE
feat: implement observability functions

### DIFF
--- a/sql/pgque-api/observability.sql
+++ b/sql/pgque-api/observability.sql
@@ -86,7 +86,7 @@ returns table (
     consumer_name   text,
     lag             interval,
     pending_events  bigint,
-    last_seen       timestamptz,
+    last_batch_start timestamptz,
     batch_active    boolean,
     batch_id        bigint
 ) as $$
@@ -133,20 +133,21 @@ begin
     where not q.queue_ticker_paused
     group by q.queue_name;
 
-    -- Check: consumer lag
+    -- Consumer lag check: handle consumers that never processed (sub_last_tick is NULL)
     return query
     select q.queue_name,
         ('consumer_lag:' || c.co_name)::text,
         case
+            when t.tick_time is null then 'warning'  -- never consumed
             when now() - t.tick_time > q.queue_rotation_period then 'critical'
             when now() - t.tick_time > q.queue_rotation_period / 2 then 'warning'
             else 'ok'
         end,
-        c.co_name || ' lag: ' || (now() - t.tick_time)::text
+        c.co_name || ' lag: ' || coalesce((now() - t.tick_time)::text, 'never consumed')
     from pgque.subscription s
     join pgque.queue q on q.queue_id = s.sub_queue
     join pgque.consumer c on c.co_id = s.sub_consumer
-    join pgque.tick t on t.tick_queue = s.sub_queue and t.tick_id = s.sub_last_tick;
+    left join pgque.tick t on t.tick_queue = s.sub_queue and t.tick_id = s.sub_last_tick;
 
     -- Check: rotation overdue
     return query

--- a/sql/pgque-api/observability.sql
+++ b/sql/pgque-api/observability.sql
@@ -1,0 +1,412 @@
+-- pgque-api/observability.sql -- Observability functions
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- Implements SPECx.md sections 5.1 and 5.2:
+--   pgque.queue_stats()        -- real-time queue health
+--   pgque.consumer_stats()     -- per-consumer metrics
+--   pgque.queue_health()       -- operational diagnostics
+--   pgque.otel_metrics()       -- OTel-compatible metric export
+--   pgque.stuck_consumers()    -- consumers that haven't processed
+--   pgque.in_flight()          -- messages currently being processed
+--   pgque.throughput()         -- throughput over time (bucketed)
+--   pgque.error_rate()         -- error rate over time (bucketed)
+
+-- pgque.queue_stats() -- real-time queue health
+create or replace function pgque.queue_stats()
+returns table (
+    queue_name          text,
+    queue_id            int4,
+    depth               bigint,
+    oldest_msg_age      interval,
+    consumers           int4,
+    events_per_sec      numeric,
+    cur_table           int4,
+    rotation_age        interval,
+    rotation_period     interval,
+    ticker_paused       boolean,
+    last_tick_time      timestamptz,
+    last_tick_id        bigint,
+    dlq_count           bigint
+) as $$
+begin
+    return query
+    select
+        q.queue_name,
+        q.queue_id,
+        coalesce(
+            (select max(t_cur.tick_event_seq) - min(t_sub.tick_event_seq)
+             from pgque.subscription s
+             join pgque.tick t_sub on t_sub.tick_queue = q.queue_id
+                 and t_sub.tick_id = s.sub_last_tick
+             cross join lateral (
+                 select tick_event_seq from pgque.tick
+                 where tick_queue = q.queue_id
+                 order by tick_id desc limit 1
+             ) t_cur
+             where s.sub_queue = q.queue_id
+            ), 0)::bigint as depth,
+        (select now() - min(t.tick_time)
+         from pgque.subscription s
+         join pgque.tick t on t.tick_queue = q.queue_id
+             and t.tick_id = s.sub_last_tick
+         where s.sub_queue = q.queue_id
+        ) as oldest_msg_age,
+        (select count(*)::int4 from pgque.subscription
+         where sub_queue = q.queue_id) as consumers,
+        (select case
+            when t2.tick_time = t1.tick_time then 0
+            else (t2.tick_event_seq - t1.tick_event_seq)::numeric
+                / extract(epoch from t2.tick_time - t1.tick_time)
+         end
+         from pgque.tick t1, pgque.tick t2
+         where t1.tick_queue = q.queue_id and t2.tick_queue = q.queue_id
+           and t2.tick_id = (select max(tick_id) from pgque.tick
+                             where tick_queue = q.queue_id)
+           and t1.tick_id = t2.tick_id - 1
+        ) as events_per_sec,
+        q.queue_cur_table,
+        now() - q.queue_switch_time as rotation_age,
+        q.queue_rotation_period,
+        q.queue_ticker_paused,
+        (select max(tick_time) from pgque.tick
+         where tick_queue = q.queue_id) as last_tick_time,
+        (select max(tick_id) from pgque.tick
+         where tick_queue = q.queue_id) as last_tick_id,
+        (select count(*) from pgque.dead_letter
+         where dl_queue_id = q.queue_id)::bigint as dlq_count
+    from pgque.queue q
+    order by q.queue_name;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.consumer_stats() -- per-consumer metrics
+create or replace function pgque.consumer_stats()
+returns table (
+    queue_name      text,
+    consumer_name   text,
+    lag             interval,
+    pending_events  bigint,
+    last_seen       timestamptz,
+    batch_active    boolean,
+    batch_id        bigint
+) as $$
+begin
+    return query
+    select
+        q.queue_name,
+        c.co_name,
+        now() - t.tick_time as lag,
+        coalesce(
+            (select max(t2.tick_event_seq) from pgque.tick t2
+             where t2.tick_queue = q.queue_id) - t.tick_event_seq,
+            0)::bigint as pending_events,
+        s.sub_active,
+        s.sub_batch is not null,
+        s.sub_batch
+    from pgque.subscription s
+    join pgque.queue q on q.queue_id = s.sub_queue
+    join pgque.consumer c on c.co_id = s.sub_consumer
+    left join pgque.tick t on t.tick_queue = s.sub_queue
+        and t.tick_id = s.sub_last_tick
+    order by q.queue_name, c.co_name;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.queue_health() -- operational diagnostics
+create or replace function pgque.queue_health()
+returns table (
+    queue_name  text,
+    check_name  text,
+    status      text,
+    detail      text
+) as $$
+begin
+    -- Check: ticker is running (handle queues with no ticks yet)
+    return query
+    select q.queue_name, 'ticker_running'::text,
+        case when max(t.tick_time) is null then 'critical'
+             when now() - max(t.tick_time) > interval '10 seconds'
+             then 'critical' else 'ok' end,
+        'Last tick: ' || coalesce(max(t.tick_time)::text, 'never')
+    from pgque.queue q
+    left join pgque.tick t on t.tick_queue = q.queue_id
+    where not q.queue_ticker_paused
+    group by q.queue_name;
+
+    -- Check: consumer lag
+    return query
+    select q.queue_name,
+        ('consumer_lag:' || c.co_name)::text,
+        case
+            when now() - t.tick_time > q.queue_rotation_period then 'critical'
+            when now() - t.tick_time > q.queue_rotation_period / 2 then 'warning'
+            else 'ok'
+        end,
+        c.co_name || ' lag: ' || (now() - t.tick_time)::text
+    from pgque.subscription s
+    join pgque.queue q on q.queue_id = s.sub_queue
+    join pgque.consumer c on c.co_id = s.sub_consumer
+    join pgque.tick t on t.tick_queue = s.sub_queue and t.tick_id = s.sub_last_tick;
+
+    -- Check: rotation overdue
+    return query
+    select q.queue_name, 'rotation_health'::text,
+        case
+            when q.queue_switch_step2 is null then 'warning'
+            when now() - q.queue_switch_time > q.queue_rotation_period * 2
+                then 'warning'
+            else 'ok'
+        end,
+        case
+            when q.queue_switch_step2 is null then 'mid-rotation (step2 pending)'
+            else 'last rotation: ' || q.queue_switch_time::text
+        end
+    from pgque.queue q;
+
+    -- Check: DLQ growing
+    return query
+    select q.queue_name, 'dlq_health'::text,
+        case
+            when count(dl.*) > 1000 then 'warning'
+            when count(dl.*) > 0 then 'ok'
+            else 'ok'
+        end,
+        count(dl.*)::text || ' dead letter events'
+    from pgque.queue q
+    left join pgque.dead_letter dl on dl.dl_queue_id = q.queue_id
+    group by q.queue_name;
+
+    -- Check: pg_cron jobs
+    return query
+    select 'system'::text, 'pg_cron_ticker'::text,
+        case when cfg.ticker_job_id is null then 'critical'
+             else 'ok' end,
+        case when cfg.ticker_job_id is null
+             then 'ticker job not scheduled'
+             else 'job_id=' || cfg.ticker_job_id::text end
+    from pgque.config cfg;
+
+    return query
+    select 'system'::text, 'pg_cron_maint'::text,
+        case when cfg.maint_job_id is null then 'critical'
+             else 'ok' end,
+        case when cfg.maint_job_id is null
+             then 'maint job not scheduled'
+             else 'job_id=' || cfg.maint_job_id::text end
+    from pgque.config cfg;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.otel_metrics() -- OTel-compatible metric export
+create or replace function pgque.otel_metrics()
+returns table (
+    metric_name text,
+    metric_type text,
+    value       numeric,
+    labels      jsonb
+) as $$
+begin
+    -- Queue depth gauges
+    return query
+    select 'pgque.queue.depth'::text, 'gauge'::text,
+           qs.depth::numeric,
+           jsonb_build_object('queue', qs.queue_name)
+    from pgque.queue_stats() qs;
+
+    -- Oldest message age gauges
+    return query
+    select 'pgque.queue.oldest_message_age_seconds'::text, 'gauge'::text,
+           coalesce(extract(epoch from qs.oldest_msg_age), 0)::numeric,
+           jsonb_build_object('queue', qs.queue_name)
+    from pgque.queue_stats() qs;
+
+    -- Consumer lag gauges
+    return query
+    select 'pgque.consumer.lag_seconds'::text, 'gauge'::text,
+           extract(epoch from cs.lag)::numeric,
+           jsonb_build_object('queue', cs.queue_name,
+                              'consumer', cs.consumer_name)
+    from pgque.consumer_stats() cs;
+
+    -- Consumer pending events gauges
+    return query
+    select 'pgque.consumer.pending_events'::text, 'gauge'::text,
+           cs.pending_events::numeric,
+           jsonb_build_object('queue', cs.queue_name,
+                              'consumer', cs.consumer_name)
+    from pgque.consumer_stats() cs;
+
+    -- DLQ gauges
+    return query
+    select 'pgque.message.dead_lettered'::text, 'gauge'::text,
+           qs.dlq_count::numeric,
+           jsonb_build_object('queue', qs.queue_name)
+    from pgque.queue_stats() qs;
+
+    -- Events per sec gauges
+    return query
+    select 'pgque.queue.throughput'::text, 'gauge'::text,
+           coalesce(qs.events_per_sec, 0),
+           jsonb_build_object('queue', qs.queue_name)
+    from pgque.queue_stats() qs;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.stuck_consumers() -- consumers that haven't processed in a long time
+create or replace function pgque.stuck_consumers(
+    i_threshold interval default '1 hour')
+returns table (
+    queue_name      text,
+    consumer_name   text,
+    lag             interval,
+    last_active     timestamptz
+) as $$
+begin
+    return query
+    select
+        q.queue_name,
+        c.co_name,
+        now() - t.tick_time as lag,
+        s.sub_active
+    from pgque.subscription s
+    join pgque.queue q on q.queue_id = s.sub_queue
+    join pgque.consumer c on c.co_id = s.sub_consumer
+    left join pgque.tick t on t.tick_queue = s.sub_queue
+        and t.tick_id = s.sub_last_tick
+    where now() - coalesce(t.tick_time, s.sub_active) > i_threshold
+    order by lag desc nulls first;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.in_flight() -- messages currently being processed
+create or replace function pgque.in_flight(i_queue_name text)
+returns table (
+    consumer_name   text,
+    batch_id        bigint,
+    batch_age       interval,
+    estimated_events bigint
+) as $$
+begin
+    return query
+    select
+        c.co_name,
+        s.sub_batch,
+        now() - s.sub_active as batch_age,
+        coalesce(
+            (select t_next.tick_event_seq - t_cur.tick_event_seq
+             from pgque.tick t_cur
+             join pgque.tick t_next on t_next.tick_queue = t_cur.tick_queue
+                 and t_next.tick_id = s.sub_next_tick
+             where t_cur.tick_queue = q.queue_id
+               and t_cur.tick_id = s.sub_last_tick
+            ), 0)::bigint as estimated_events
+    from pgque.subscription s
+    join pgque.queue q on q.queue_id = s.sub_queue
+    join pgque.consumer c on c.co_id = s.sub_consumer
+    where q.queue_name = i_queue_name
+      and s.sub_batch is not null
+    order by c.co_name;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.throughput() -- throughput over time (bucketed from tick history)
+create or replace function pgque.throughput(
+    i_queue_name text,
+    i_period interval,
+    i_bucket_size interval)
+returns table (
+    bucket_start    timestamptz,
+    events          bigint,
+    events_per_sec  numeric
+) as $$
+declare
+    v_queue_id int4;
+begin
+    select q.queue_id into v_queue_id
+    from pgque.queue q where q.queue_name = i_queue_name;
+
+    if not found then
+        raise exception 'queue not found: %', i_queue_name;
+    end if;
+
+    return query
+    with ticks as (
+        select
+            t.tick_time,
+            t.tick_event_seq,
+            lag(t.tick_event_seq) over (order by t.tick_id) as prev_event_seq
+        from pgque.tick t
+        where t.tick_queue = v_queue_id
+          and t.tick_time >= now() - i_period
+    ),
+    bucketed as (
+        select
+            date_trunc('minute', tk.tick_time)
+                - (extract(minute from date_trunc('minute', tk.tick_time))::int
+                   % (extract(epoch from i_bucket_size)::int / 60))
+                  * interval '1 minute' as bucket,
+            sum(coalesce(tk.tick_event_seq - tk.prev_event_seq, 0))::bigint as events
+        from ticks tk
+        where tk.prev_event_seq is not null
+        group by 1
+    )
+    select
+        b.bucket as bucket_start,
+        b.events,
+        case when extract(epoch from i_bucket_size) > 0
+            then b.events::numeric / extract(epoch from i_bucket_size)
+            else 0 end as events_per_sec
+    from bucketed b
+    order by b.bucket;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.error_rate() -- error rate over time (retries + DLQ per time period)
+create or replace function pgque.error_rate(
+    i_queue_name text,
+    i_period interval,
+    i_bucket_size interval)
+returns table (
+    bucket_start    timestamptz,
+    retries         bigint,
+    dead_letters    bigint
+) as $$
+declare
+    v_queue_id int4;
+begin
+    select q.queue_id into v_queue_id
+    from pgque.queue q where q.queue_name = i_queue_name;
+
+    if not found then
+        raise exception 'queue not found: %', i_queue_name;
+    end if;
+
+    -- Generate time buckets and count retry_queue and dead_letter entries
+    return query
+    with buckets as (
+        select generate_series(
+            date_trunc('minute', now() - i_period),
+            date_trunc('minute', now()),
+            i_bucket_size
+        ) as bucket
+    )
+    select
+        b.bucket as bucket_start,
+        coalesce((
+            select count(*)
+            from pgque.retry_queue rq
+            where rq.ev_queue = v_queue_id
+              and rq.ev_retry_after >= b.bucket
+              and rq.ev_retry_after < b.bucket + i_bucket_size
+        ), 0)::bigint as retries,
+        coalesce((
+            select count(*)
+            from pgque.dead_letter dl
+            where dl.dl_queue_id = v_queue_id
+              and dl.dl_time >= b.bucket
+              and dl.dl_time < b.bucket + i_bucket_size
+        ), 0)::bigint as dead_letters
+    from buckets b
+    order by b.bucket;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;

--- a/sql/pgque-install.sql
+++ b/sql/pgque-install.sql
@@ -4541,7 +4541,7 @@ returns table (
     consumer_name   text,
     lag             interval,
     pending_events  bigint,
-    last_seen       timestamptz,
+    last_batch_start timestamptz,
     batch_active    boolean,
     batch_id        bigint
 ) as $$
@@ -4588,20 +4588,21 @@ begin
     where not q.queue_ticker_paused
     group by q.queue_name;
 
-    -- Check: consumer lag
+    -- Consumer lag check: handle consumers that never processed (sub_last_tick is NULL)
     return query
     select q.queue_name,
         ('consumer_lag:' || c.co_name)::text,
         case
+            when t.tick_time is null then 'warning'  -- never consumed
             when now() - t.tick_time > q.queue_rotation_period then 'critical'
             when now() - t.tick_time > q.queue_rotation_period / 2 then 'warning'
             else 'ok'
         end,
-        c.co_name || ' lag: ' || (now() - t.tick_time)::text
+        c.co_name || ' lag: ' || coalesce((now() - t.tick_time)::text, 'never consumed')
     from pgque.subscription s
     join pgque.queue q on q.queue_id = s.sub_queue
     join pgque.consumer c on c.co_id = s.sub_consumer
-    join pgque.tick t on t.tick_queue = s.sub_queue and t.tick_id = s.sub_last_tick;
+    left join pgque.tick t on t.tick_queue = s.sub_queue and t.tick_id = s.sub_last_tick;
 
     -- Check: rotation overdue
     return query

--- a/sql/pgque-install.sql
+++ b/sql/pgque-install.sql
@@ -4452,6 +4452,420 @@ begin
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
+-- pgque-api/observability.sql
+-- pgque-api/observability.sql -- Observability functions
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- Implements SPECx.md sections 5.1 and 5.2:
+--   pgque.queue_stats()        -- real-time queue health
+--   pgque.consumer_stats()     -- per-consumer metrics
+--   pgque.queue_health()       -- operational diagnostics
+--   pgque.otel_metrics()       -- OTel-compatible metric export
+--   pgque.stuck_consumers()    -- consumers that haven't processed
+--   pgque.in_flight()          -- messages currently being processed
+--   pgque.throughput()         -- throughput over time (bucketed)
+--   pgque.error_rate()         -- error rate over time (bucketed)
+
+-- pgque.queue_stats() -- real-time queue health
+create or replace function pgque.queue_stats()
+returns table (
+    queue_name          text,
+    queue_id            int4,
+    depth               bigint,
+    oldest_msg_age      interval,
+    consumers           int4,
+    events_per_sec      numeric,
+    cur_table           int4,
+    rotation_age        interval,
+    rotation_period     interval,
+    ticker_paused       boolean,
+    last_tick_time      timestamptz,
+    last_tick_id        bigint,
+    dlq_count           bigint
+) as $$
+begin
+    return query
+    select
+        q.queue_name,
+        q.queue_id,
+        coalesce(
+            (select max(t_cur.tick_event_seq) - min(t_sub.tick_event_seq)
+             from pgque.subscription s
+             join pgque.tick t_sub on t_sub.tick_queue = q.queue_id
+                 and t_sub.tick_id = s.sub_last_tick
+             cross join lateral (
+                 select tick_event_seq from pgque.tick
+                 where tick_queue = q.queue_id
+                 order by tick_id desc limit 1
+             ) t_cur
+             where s.sub_queue = q.queue_id
+            ), 0)::bigint as depth,
+        (select now() - min(t.tick_time)
+         from pgque.subscription s
+         join pgque.tick t on t.tick_queue = q.queue_id
+             and t.tick_id = s.sub_last_tick
+         where s.sub_queue = q.queue_id
+        ) as oldest_msg_age,
+        (select count(*)::int4 from pgque.subscription
+         where sub_queue = q.queue_id) as consumers,
+        (select case
+            when t2.tick_time = t1.tick_time then 0
+            else (t2.tick_event_seq - t1.tick_event_seq)::numeric
+                / extract(epoch from t2.tick_time - t1.tick_time)
+         end
+         from pgque.tick t1, pgque.tick t2
+         where t1.tick_queue = q.queue_id and t2.tick_queue = q.queue_id
+           and t2.tick_id = (select max(tick_id) from pgque.tick
+                             where tick_queue = q.queue_id)
+           and t1.tick_id = t2.tick_id - 1
+        ) as events_per_sec,
+        q.queue_cur_table,
+        now() - q.queue_switch_time as rotation_age,
+        q.queue_rotation_period,
+        q.queue_ticker_paused,
+        (select max(tick_time) from pgque.tick
+         where tick_queue = q.queue_id) as last_tick_time,
+        (select max(tick_id) from pgque.tick
+         where tick_queue = q.queue_id) as last_tick_id,
+        (select count(*) from pgque.dead_letter
+         where dl_queue_id = q.queue_id)::bigint as dlq_count
+    from pgque.queue q
+    order by q.queue_name;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.consumer_stats() -- per-consumer metrics
+create or replace function pgque.consumer_stats()
+returns table (
+    queue_name      text,
+    consumer_name   text,
+    lag             interval,
+    pending_events  bigint,
+    last_seen       timestamptz,
+    batch_active    boolean,
+    batch_id        bigint
+) as $$
+begin
+    return query
+    select
+        q.queue_name,
+        c.co_name,
+        now() - t.tick_time as lag,
+        coalesce(
+            (select max(t2.tick_event_seq) from pgque.tick t2
+             where t2.tick_queue = q.queue_id) - t.tick_event_seq,
+            0)::bigint as pending_events,
+        s.sub_active,
+        s.sub_batch is not null,
+        s.sub_batch
+    from pgque.subscription s
+    join pgque.queue q on q.queue_id = s.sub_queue
+    join pgque.consumer c on c.co_id = s.sub_consumer
+    left join pgque.tick t on t.tick_queue = s.sub_queue
+        and t.tick_id = s.sub_last_tick
+    order by q.queue_name, c.co_name;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.queue_health() -- operational diagnostics
+create or replace function pgque.queue_health()
+returns table (
+    queue_name  text,
+    check_name  text,
+    status      text,
+    detail      text
+) as $$
+begin
+    -- Check: ticker is running (handle queues with no ticks yet)
+    return query
+    select q.queue_name, 'ticker_running'::text,
+        case when max(t.tick_time) is null then 'critical'
+             when now() - max(t.tick_time) > interval '10 seconds'
+             then 'critical' else 'ok' end,
+        'Last tick: ' || coalesce(max(t.tick_time)::text, 'never')
+    from pgque.queue q
+    left join pgque.tick t on t.tick_queue = q.queue_id
+    where not q.queue_ticker_paused
+    group by q.queue_name;
+
+    -- Check: consumer lag
+    return query
+    select q.queue_name,
+        ('consumer_lag:' || c.co_name)::text,
+        case
+            when now() - t.tick_time > q.queue_rotation_period then 'critical'
+            when now() - t.tick_time > q.queue_rotation_period / 2 then 'warning'
+            else 'ok'
+        end,
+        c.co_name || ' lag: ' || (now() - t.tick_time)::text
+    from pgque.subscription s
+    join pgque.queue q on q.queue_id = s.sub_queue
+    join pgque.consumer c on c.co_id = s.sub_consumer
+    join pgque.tick t on t.tick_queue = s.sub_queue and t.tick_id = s.sub_last_tick;
+
+    -- Check: rotation overdue
+    return query
+    select q.queue_name, 'rotation_health'::text,
+        case
+            when q.queue_switch_step2 is null then 'warning'
+            when now() - q.queue_switch_time > q.queue_rotation_period * 2
+                then 'warning'
+            else 'ok'
+        end,
+        case
+            when q.queue_switch_step2 is null then 'mid-rotation (step2 pending)'
+            else 'last rotation: ' || q.queue_switch_time::text
+        end
+    from pgque.queue q;
+
+    -- Check: DLQ growing
+    return query
+    select q.queue_name, 'dlq_health'::text,
+        case
+            when count(dl.*) > 1000 then 'warning'
+            when count(dl.*) > 0 then 'ok'
+            else 'ok'
+        end,
+        count(dl.*)::text || ' dead letter events'
+    from pgque.queue q
+    left join pgque.dead_letter dl on dl.dl_queue_id = q.queue_id
+    group by q.queue_name;
+
+    -- Check: pg_cron jobs
+    return query
+    select 'system'::text, 'pg_cron_ticker'::text,
+        case when cfg.ticker_job_id is null then 'critical'
+             else 'ok' end,
+        case when cfg.ticker_job_id is null
+             then 'ticker job not scheduled'
+             else 'job_id=' || cfg.ticker_job_id::text end
+    from pgque.config cfg;
+
+    return query
+    select 'system'::text, 'pg_cron_maint'::text,
+        case when cfg.maint_job_id is null then 'critical'
+             else 'ok' end,
+        case when cfg.maint_job_id is null
+             then 'maint job not scheduled'
+             else 'job_id=' || cfg.maint_job_id::text end
+    from pgque.config cfg;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.otel_metrics() -- OTel-compatible metric export
+create or replace function pgque.otel_metrics()
+returns table (
+    metric_name text,
+    metric_type text,
+    value       numeric,
+    labels      jsonb
+) as $$
+begin
+    -- Queue depth gauges
+    return query
+    select 'pgque.queue.depth'::text, 'gauge'::text,
+           qs.depth::numeric,
+           jsonb_build_object('queue', qs.queue_name)
+    from pgque.queue_stats() qs;
+
+    -- Oldest message age gauges
+    return query
+    select 'pgque.queue.oldest_message_age_seconds'::text, 'gauge'::text,
+           coalesce(extract(epoch from qs.oldest_msg_age), 0)::numeric,
+           jsonb_build_object('queue', qs.queue_name)
+    from pgque.queue_stats() qs;
+
+    -- Consumer lag gauges
+    return query
+    select 'pgque.consumer.lag_seconds'::text, 'gauge'::text,
+           extract(epoch from cs.lag)::numeric,
+           jsonb_build_object('queue', cs.queue_name,
+                              'consumer', cs.consumer_name)
+    from pgque.consumer_stats() cs;
+
+    -- Consumer pending events gauges
+    return query
+    select 'pgque.consumer.pending_events'::text, 'gauge'::text,
+           cs.pending_events::numeric,
+           jsonb_build_object('queue', cs.queue_name,
+                              'consumer', cs.consumer_name)
+    from pgque.consumer_stats() cs;
+
+    -- DLQ gauges
+    return query
+    select 'pgque.message.dead_lettered'::text, 'gauge'::text,
+           qs.dlq_count::numeric,
+           jsonb_build_object('queue', qs.queue_name)
+    from pgque.queue_stats() qs;
+
+    -- Events per sec gauges
+    return query
+    select 'pgque.queue.throughput'::text, 'gauge'::text,
+           coalesce(qs.events_per_sec, 0),
+           jsonb_build_object('queue', qs.queue_name)
+    from pgque.queue_stats() qs;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.stuck_consumers() -- consumers that haven't processed in a long time
+create or replace function pgque.stuck_consumers(
+    i_threshold interval default '1 hour')
+returns table (
+    queue_name      text,
+    consumer_name   text,
+    lag             interval,
+    last_active     timestamptz
+) as $$
+begin
+    return query
+    select
+        q.queue_name,
+        c.co_name,
+        now() - t.tick_time as lag,
+        s.sub_active
+    from pgque.subscription s
+    join pgque.queue q on q.queue_id = s.sub_queue
+    join pgque.consumer c on c.co_id = s.sub_consumer
+    left join pgque.tick t on t.tick_queue = s.sub_queue
+        and t.tick_id = s.sub_last_tick
+    where now() - coalesce(t.tick_time, s.sub_active) > i_threshold
+    order by lag desc nulls first;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.in_flight() -- messages currently being processed
+create or replace function pgque.in_flight(i_queue_name text)
+returns table (
+    consumer_name   text,
+    batch_id        bigint,
+    batch_age       interval,
+    estimated_events bigint
+) as $$
+begin
+    return query
+    select
+        c.co_name,
+        s.sub_batch,
+        now() - s.sub_active as batch_age,
+        coalesce(
+            (select t_next.tick_event_seq - t_cur.tick_event_seq
+             from pgque.tick t_cur
+             join pgque.tick t_next on t_next.tick_queue = t_cur.tick_queue
+                 and t_next.tick_id = s.sub_next_tick
+             where t_cur.tick_queue = q.queue_id
+               and t_cur.tick_id = s.sub_last_tick
+            ), 0)::bigint as estimated_events
+    from pgque.subscription s
+    join pgque.queue q on q.queue_id = s.sub_queue
+    join pgque.consumer c on c.co_id = s.sub_consumer
+    where q.queue_name = i_queue_name
+      and s.sub_batch is not null
+    order by c.co_name;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.throughput() -- throughput over time (bucketed from tick history)
+create or replace function pgque.throughput(
+    i_queue_name text,
+    i_period interval,
+    i_bucket_size interval)
+returns table (
+    bucket_start    timestamptz,
+    events          bigint,
+    events_per_sec  numeric
+) as $$
+declare
+    v_queue_id int4;
+begin
+    select q.queue_id into v_queue_id
+    from pgque.queue q where q.queue_name = i_queue_name;
+
+    if not found then
+        raise exception 'queue not found: %', i_queue_name;
+    end if;
+
+    return query
+    with ticks as (
+        select
+            t.tick_time,
+            t.tick_event_seq,
+            lag(t.tick_event_seq) over (order by t.tick_id) as prev_event_seq
+        from pgque.tick t
+        where t.tick_queue = v_queue_id
+          and t.tick_time >= now() - i_period
+    ),
+    bucketed as (
+        select
+            date_trunc('minute', tk.tick_time)
+                - (extract(minute from date_trunc('minute', tk.tick_time))::int
+                   % (extract(epoch from i_bucket_size)::int / 60))
+                  * interval '1 minute' as bucket,
+            sum(coalesce(tk.tick_event_seq - tk.prev_event_seq, 0))::bigint as events
+        from ticks tk
+        where tk.prev_event_seq is not null
+        group by 1
+    )
+    select
+        b.bucket as bucket_start,
+        b.events,
+        case when extract(epoch from i_bucket_size) > 0
+            then b.events::numeric / extract(epoch from i_bucket_size)
+            else 0 end as events_per_sec
+    from bucketed b
+    order by b.bucket;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.error_rate() -- error rate over time (retries + DLQ per time period)
+create or replace function pgque.error_rate(
+    i_queue_name text,
+    i_period interval,
+    i_bucket_size interval)
+returns table (
+    bucket_start    timestamptz,
+    retries         bigint,
+    dead_letters    bigint
+) as $$
+declare
+    v_queue_id int4;
+begin
+    select q.queue_id into v_queue_id
+    from pgque.queue q where q.queue_name = i_queue_name;
+
+    if not found then
+        raise exception 'queue not found: %', i_queue_name;
+    end if;
+
+    -- Generate time buckets and count retry_queue and dead_letter entries
+    return query
+    with buckets as (
+        select generate_series(
+            date_trunc('minute', now() - i_period),
+            date_trunc('minute', now()),
+            i_bucket_size
+        ) as bucket
+    )
+    select
+        b.bucket as bucket_start,
+        coalesce((
+            select count(*)
+            from pgque.retry_queue rq
+            where rq.ev_queue = v_queue_id
+              and rq.ev_retry_after >= b.bucket
+              and rq.ev_retry_after < b.bucket + i_bucket_size
+        ), 0)::bigint as retries,
+        coalesce((
+            select count(*)
+            from pgque.dead_letter dl
+            where dl.dl_queue_id = v_queue_id
+              and dl.dl_time >= b.bucket
+              and dl.dl_time < b.bucket + i_bucket_size
+        ), 0)::bigint as dead_letters
+    from buckets b
+    order by b.bucket;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
 -- pgque-api/receive.sql
 -- pgque.receive(), pgque.ack(), pgque.nack() -- modern consume API
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.

--- a/tests/acceptance/run_acceptance.sql
+++ b/tests/acceptance/run_acceptance.sql
@@ -13,4 +13,7 @@
 \echo 'Running: US-4 Delayed delivery'
 \i tests/acceptance/us4_delayed_delivery.sql
 \echo ''
+\echo 'Running: US-9 Observability and health monitoring'
+\i tests/acceptance/us9_observability.sql
+\echo ''
 \echo '=== ALL ACCEPTANCE TESTS PASSED ==='

--- a/tests/acceptance/us9_observability.sql
+++ b/tests/acceptance/us9_observability.sql
@@ -1,0 +1,224 @@
+-- US-9: Observability and health monitoring
+-- As an operator, I want to quickly diagnose queue health and consumer lag
+-- SPECx.md section 13.3
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+\set ON_ERROR_STOP on
+
+-- Setup: create 3 queues with varying load patterns
+-- Queue 1: healthy (consumer keeps up)
+-- Queue 2: lagging consumer
+-- Queue 3: has DLQ entries
+
+do $$ begin
+  perform pgque.create_queue('us9_healthy');
+  perform pgque.create_queue('us9_lagging');
+  perform pgque.create_queue('us9_dlq');
+
+  perform pgque.register_consumer('us9_healthy', 'fast_worker');
+  perform pgque.register_consumer('us9_lagging', 'slow_worker');
+  perform pgque.register_consumer('us9_dlq', 'dlq_worker');
+
+  -- Insert events into all queues
+  perform pgque.insert_event('us9_healthy', 'order.created', '{"id":1}');
+  perform pgque.insert_event('us9_lagging', 'order.created', '{"id":2}');
+  perform pgque.insert_event('us9_lagging', 'order.created', '{"id":3}');
+  perform pgque.insert_event('us9_dlq', 'order.created', '{"id":4}');
+end $$;
+
+-- Tick all queues
+do $$ begin
+  perform pgque.force_tick('us9_healthy');
+  perform pgque.force_tick('us9_lagging');
+  perform pgque.force_tick('us9_dlq');
+  perform pgque.ticker();
+end $$;
+
+-- Consume us9_healthy fully (fast worker keeps up)
+do $$
+declare
+  v_batch_id bigint;
+begin
+  select pgque.next_batch('us9_healthy', 'fast_worker') into v_batch_id;
+  if v_batch_id is not null then
+    perform pgque.finish_batch(v_batch_id);
+  end if;
+end $$;
+
+-- Add a DLQ entry for us9_dlq
+do $$
+declare
+  v_batch_id bigint;
+  v_ev record;
+begin
+  select pgque.next_batch('us9_dlq', 'dlq_worker') into v_batch_id;
+  if v_batch_id is not null then
+    -- Get first event and send it to DLQ
+    for v_ev in select * from pgque.get_batch_events(v_batch_id)
+    loop
+      perform pgque.event_dead(
+        v_batch_id, v_ev.ev_id, 'max retries exceeded',
+        v_ev.ev_time, v_ev.ev_txid, v_ev.ev_retry,
+        v_ev.ev_type, v_ev.ev_data);
+      exit;  -- just one event
+    end loop;
+    perform pgque.finish_batch(v_batch_id);
+  end if;
+end $$;
+
+-- Verify: queue_stats() shows correct depth, throughput, DLQ count
+do $$
+declare
+  v_row record;
+  v_found_healthy bool := false;
+  v_found_lagging bool := false;
+  v_found_dlq bool := false;
+begin
+  for v_row in select * from pgque.queue_stats()
+  loop
+    if v_row.queue_name = 'us9_healthy' then
+      v_found_healthy := true;
+      assert v_row.depth = 0, 'healthy queue depth should be 0, got ' || v_row.depth;
+      assert v_row.consumers = 1, 'should have 1 consumer';
+      assert v_row.dlq_count = 0, 'no DLQ entries for healthy queue';
+    end if;
+    if v_row.queue_name = 'us9_lagging' then
+      v_found_lagging := true;
+      assert v_row.depth >= 0, 'lagging queue depth should be >= 0';
+      assert v_row.consumers = 1, 'should have 1 consumer';
+    end if;
+    if v_row.queue_name = 'us9_dlq' then
+      v_found_dlq := true;
+      assert v_row.dlq_count = 1, 'DLQ queue should have 1 dead letter, got ' || v_row.dlq_count;
+    end if;
+  end loop;
+  assert v_found_healthy, 'queue_stats should include us9_healthy';
+  assert v_found_lagging, 'queue_stats should include us9_lagging';
+  assert v_found_dlq, 'queue_stats should include us9_dlq';
+  raise notice 'PASS: US-9 queue_stats() shows correct depth and DLQ counts';
+end $$;
+
+-- Verify: consumer_stats() shows correct lag per consumer
+do $$
+declare
+  v_row record;
+  v_found_fast bool := false;
+  v_found_slow bool := false;
+begin
+  for v_row in select * from pgque.consumer_stats()
+  loop
+    if v_row.queue_name = 'us9_healthy' and v_row.consumer_name = 'fast_worker' then
+      v_found_fast := true;
+      assert v_row.pending_events = 0,
+        'fast_worker should have 0 pending, got ' || v_row.pending_events;
+    end if;
+    if v_row.queue_name = 'us9_lagging' and v_row.consumer_name = 'slow_worker' then
+      v_found_slow := true;
+      assert v_row.pending_events >= 0,
+        'slow_worker should have >= 0 pending, got ' || v_row.pending_events;
+      assert v_row.lag is not null, 'slow_worker should have lag';
+    end if;
+  end loop;
+  assert v_found_fast, 'consumer_stats should include fast_worker';
+  assert v_found_slow, 'consumer_stats should include slow_worker';
+  raise notice 'PASS: US-9 consumer_stats() shows correct lag per consumer';
+end $$;
+
+-- Verify: queue_health() returns 'ok', 'warning', 'critical' appropriately
+do $$
+declare
+  v_row record;
+  v_ticker_checks int := 0;
+  v_lag_checks int := 0;
+  v_rotation_checks int := 0;
+  v_dlq_checks int := 0;
+begin
+  for v_row in select * from pgque.queue_health()
+  loop
+    -- All statuses must be valid
+    if v_row.check_name not in ('pg_cron_ticker', 'pg_cron_maint') then
+      assert v_row.status in ('ok', 'warning', 'critical'),
+        'invalid status: ' || v_row.status || ' for check ' || v_row.check_name;
+    end if;
+
+    if v_row.check_name = 'ticker_running' then
+      v_ticker_checks := v_ticker_checks + 1;
+    end if;
+    if v_row.check_name like 'consumer_lag:%' then
+      v_lag_checks := v_lag_checks + 1;
+    end if;
+    if v_row.check_name = 'rotation_health' then
+      v_rotation_checks := v_rotation_checks + 1;
+    end if;
+    if v_row.check_name = 'dlq_health' then
+      v_dlq_checks := v_dlq_checks + 1;
+    end if;
+  end loop;
+
+  assert v_ticker_checks >= 3, 'should have ticker checks for all 3 queues, got ' || v_ticker_checks;
+  assert v_lag_checks >= 3, 'should have lag checks for all 3 consumers, got ' || v_lag_checks;
+  assert v_rotation_checks >= 3, 'should have rotation checks for all 3 queues, got ' || v_rotation_checks;
+  assert v_dlq_checks >= 3, 'should have DLQ checks for all 3 queues, got ' || v_dlq_checks;
+  raise notice 'PASS: US-9 queue_health() returns correct status values';
+end $$;
+
+-- Verify: otel_metrics() returns rows with correct metric names and types
+do $$
+declare
+  v_row record;
+  v_depth_count int := 0;
+  v_lag_count int := 0;
+  v_dlq_count int := 0;
+begin
+  for v_row in select * from pgque.otel_metrics()
+  loop
+    if v_row.metric_name = 'pgque.queue.depth' then
+      v_depth_count := v_depth_count + 1;
+      assert v_row.metric_type = 'gauge', 'depth should be gauge';
+      assert v_row.labels ? 'queue', 'depth should have queue label';
+    end if;
+    if v_row.metric_name = 'pgque.consumer.lag_seconds' then
+      v_lag_count := v_lag_count + 1;
+      assert v_row.metric_type = 'gauge', 'lag should be gauge';
+      assert v_row.labels ? 'consumer', 'lag should have consumer label';
+    end if;
+    if v_row.metric_name = 'pgque.message.dead_lettered' then
+      v_dlq_count := v_dlq_count + 1;
+      assert v_row.metric_type = 'gauge', 'dead_lettered should be gauge';
+    end if;
+  end loop;
+  assert v_depth_count >= 3, 'should have depth metrics for all queues, got ' || v_depth_count;
+  assert v_lag_count >= 3, 'should have lag metrics for all consumers, got ' || v_lag_count;
+  assert v_dlq_count >= 3, 'should have DLQ metrics for all queues, got ' || v_dlq_count;
+  raise notice 'PASS: US-9 otel_metrics() returns correct metric names and types';
+end $$;
+
+-- Verify: stuck_consumers() identifies the lagging consumer
+do $$
+declare
+  v_found_slow bool := false;
+  v_row record;
+begin
+  for v_row in select * from pgque.stuck_consumers('0 seconds'::interval)
+  loop
+    if v_row.queue_name = 'us9_lagging' and v_row.consumer_name = 'slow_worker' then
+      v_found_slow := true;
+    end if;
+  end loop;
+  assert v_found_slow, 'stuck_consumers should identify slow_worker';
+  raise notice 'PASS: US-9 stuck_consumers() identifies lagging consumer';
+end $$;
+
+-- Teardown: purge DLQ entries before unregistering consumers
+-- (dead_letter has FK to consumer, so DLQ must be cleaned first)
+do $$ begin
+  perform pgque.dlq_purge('us9_dlq', '0 seconds'::interval);
+  perform pgque.unregister_consumer('us9_healthy', 'fast_worker');
+  perform pgque.unregister_consumer('us9_lagging', 'slow_worker');
+  perform pgque.unregister_consumer('us9_dlq', 'dlq_worker');
+  perform pgque.drop_queue('us9_healthy');
+  perform pgque.drop_queue('us9_lagging');
+  perform pgque.drop_queue('us9_dlq');
+end $$;
+
+\echo 'US-9: PASSED'

--- a/tests/run_all.sql
+++ b/tests/run_all.sql
@@ -61,5 +61,8 @@
 \echo 'Running: test_api_dlq'
 \i tests/test_api_dlq.sql
 
+\echo 'Running: test_observability'
+\i tests/test_observability.sql
+
 \echo ''
 \echo '=== ALL TESTS PASSED ==='

--- a/tests/test_observability.sql
+++ b/tests/test_observability.sql
@@ -1,0 +1,146 @@
+-- test_observability.sql -- pgque observability functions
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- Red/green TDD: this test file was written BEFORE the implementation.
+-- Tests: queue_stats(), consumer_stats(), queue_health(), otel_metrics(),
+--        stuck_consumers(), in_flight(), throughput(), error_rate()
+
+\set ON_ERROR_STOP on
+
+-- Setup: create a queue with known state
+do $$ begin
+  perform pgque.create_queue('obs_queue');
+  perform pgque.register_consumer('obs_queue', 'obs_consumer');
+
+  -- Insert some events
+  perform pgque.insert_event('obs_queue', 'obs.test', '{"n":1}');
+  perform pgque.insert_event('obs_queue', 'obs.test', '{"n":2}');
+  perform pgque.insert_event('obs_queue', 'obs.test', '{"n":3}');
+end $$;
+
+do $$ begin
+  perform pgque.force_tick('obs_queue');
+  perform pgque.ticker();
+end $$;
+
+-- Test 1: queue_stats() returns rows
+do $$
+declare
+  v_row record;
+  v_found bool := false;
+begin
+  for v_row in select * from pgque.queue_stats()
+  loop
+    if v_row.queue_name = 'obs_queue' then
+      v_found := true;
+      assert v_row.consumers = 1, 'should have 1 consumer, got ' || v_row.consumers;
+      assert v_row.depth >= 0, 'depth should be >= 0';
+      raise notice 'PASS: queue_stats() queue=%, depth=%, consumers=%',
+        v_row.queue_name, v_row.depth, v_row.consumers;
+    end if;
+  end loop;
+  assert v_found, 'queue_stats() should include obs_queue';
+end $$;
+
+-- Test 2: consumer_stats() returns rows
+do $$
+declare
+  v_row record;
+  v_found bool := false;
+begin
+  for v_row in select * from pgque.consumer_stats()
+  loop
+    if v_row.queue_name = 'obs_queue' and v_row.consumer_name = 'obs_consumer' then
+      v_found := true;
+      assert v_row.pending_events >= 0, 'pending_events should be >= 0';
+      raise notice 'PASS: consumer_stats() consumer=%, lag=%, pending=%',
+        v_row.consumer_name, v_row.lag, v_row.pending_events;
+    end if;
+  end loop;
+  assert v_found, 'consumer_stats() should include obs_consumer';
+end $$;
+
+-- Test 3: queue_health() returns diagnostic rows
+do $$
+declare
+  v_row record;
+  v_found_ticker bool := false;
+begin
+  for v_row in select * from pgque.queue_health()
+  loop
+    if v_row.queue_name = 'obs_queue' and v_row.check_name = 'ticker_running' then
+      v_found_ticker := true;
+      assert v_row.status in ('ok', 'warning', 'critical'),
+        'status should be ok/warning/critical, got ' || v_row.status;
+      raise notice 'PASS: queue_health() ticker check: %', v_row.status;
+    end if;
+  end loop;
+  assert v_found_ticker, 'queue_health() should check ticker for obs_queue';
+end $$;
+
+-- Test 4: otel_metrics() returns rows with correct metric names
+do $$
+declare
+  v_row record;
+  v_depth_found bool := false;
+begin
+  for v_row in select * from pgque.otel_metrics()
+  loop
+    if v_row.metric_name = 'pgque.queue.depth' then
+      v_depth_found := true;
+      assert v_row.metric_type = 'gauge', 'depth should be gauge type';
+      assert v_row.labels ? 'queue', 'should have queue label';
+    end if;
+  end loop;
+  assert v_depth_found, 'otel_metrics() should include pgque.queue.depth';
+  raise notice 'PASS: otel_metrics() returns depth gauge';
+end $$;
+
+-- Test 5: stuck_consumers()
+do $$
+declare
+  v_count int;
+begin
+  select count(*) into v_count from pgque.stuck_consumers('0 seconds'::interval);
+  -- Our consumer should be "stuck" since we haven't consumed anything
+  assert v_count >= 1, 'stuck_consumers(0s) should find obs_consumer';
+  raise notice 'PASS: stuck_consumers() finds lagging consumer';
+end $$;
+
+-- Test 6: in_flight() -- no batch open, should return 0 rows
+do $$
+declare
+  v_count int;
+begin
+  select count(*) into v_count from pgque.in_flight('obs_queue');
+  assert v_count = 0, 'in_flight() should return 0 rows when no batch is open, got ' || v_count;
+  raise notice 'PASS: in_flight() returns 0 rows when no batch is open';
+end $$;
+
+-- Test 7: throughput() returns rows
+do $$
+declare
+  v_count int;
+begin
+  select count(*) into v_count
+  from pgque.throughput('obs_queue', '1 hour'::interval, '5 minutes'::interval);
+  assert v_count >= 0, 'throughput() should return >= 0 rows';
+  raise notice 'PASS: throughput() returns % rows', v_count;
+end $$;
+
+-- Test 8: error_rate() returns rows
+do $$
+declare
+  v_count int;
+begin
+  select count(*) into v_count
+  from pgque.error_rate('obs_queue', '1 hour'::interval, '5 minutes'::interval);
+  assert v_count >= 0, 'error_rate() should return >= 0 rows';
+  raise notice 'PASS: error_rate() returns % rows', v_count;
+end $$;
+
+-- Teardown
+do $$ begin
+  perform pgque.unregister_consumer('obs_queue', 'obs_consumer');
+  perform pgque.drop_queue('obs_queue');
+end $$;


### PR DESCRIPTION
## Summary
- Implement all observability functions from SPECx.md sections 5.1-5.2: `queue_stats()`, `consumer_stats()`, `queue_health()`, `otel_metrics()`, `stuck_consumers()`, `in_flight()`, `throughput()`, `error_rate()`
- Add TDD unit tests (`test_observability.sql`) and US-9 acceptance test (`us9_observability.sql`)
- Rebuild `pgque-install.sql` with all new functions included

## Test plan
- [x] `tests/test_observability.sql` -- 8 unit tests for all observability functions
- [x] `tests/acceptance/us9_observability.sql` -- US-9 acceptance test with 3 queues in varying states
- [x] Full `run_all.sql` test suite passes
- [x] Full `run_acceptance.sql` suite passes (US-1 through US-9)

## Test output evidence

All 8 unit tests pass:
```
PASS: queue_stats() queue=obs_queue, depth=2003, consumers=1
PASS: consumer_stats() consumer=obs_consumer, lag=00:00:00.015018, pending=2003
PASS: queue_health() ticker check: ok
PASS: otel_metrics() returns depth gauge
PASS: stuck_consumers() finds lagging consumer
PASS: in_flight() returns 0 rows when no batch is open
PASS: throughput() returns 1 rows
PASS: error_rate() returns 13 rows
```

US-9 acceptance test passes:
```
PASS: US-9 queue_stats() shows correct depth and DLQ counts
PASS: US-9 consumer_stats() shows correct lag per consumer
PASS: US-9 queue_health() returns correct status values
PASS: US-9 otel_metrics() returns correct metric names and types
PASS: US-9 stuck_consumers() identifies lagging consumer
```

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)