### PR TITLE
feat: implement pgque-py Python client

### DIFF
--- a/clients/python/pgque/__init__.py
+++ b/clients/python/pgque/__init__.py
@@ -1,0 +1,11 @@
+# Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+# PgQue includes code derived from PgQ (ISC license,
+# Marko Kreen / Skype Technologies OU).
+
+"""pgque -- Python client for PgQue (PgQ Universal Edition)."""
+
+from .client import PgqueClient
+from .consumer import Consumer
+from .types import Message
+
+__all__ = ["PgqueClient", "Consumer", "Message"]

--- a/clients/python/pgque/client.py
+++ b/clients/python/pgque/client.py
@@ -1,0 +1,7 @@
+# Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+# PgQue includes code derived from PgQ (ISC license,
+# Marko Kreen / Skype Technologies OU).
+
+"""PgqueClient -- thin Python wrapper over pgque SQL API."""
+
+raise NotImplementedError("TDD red phase -- client not yet implemented")

--- a/clients/python/pgque/client.py
+++ b/clients/python/pgque/client.py
@@ -4,4 +4,195 @@
 
 """PgqueClient -- thin Python wrapper over pgque SQL API."""
 
-raise NotImplementedError("TDD red phase -- client not yet implemented")
+import json
+from typing import Optional
+
+import psycopg
+
+from .types import Message
+
+
+class PgqueClient:
+    """Thin wrapper around pgque SQL functions.
+
+    All methods execute SQL against the provided psycopg connection.
+    Transaction management (commit/rollback) is the caller's
+    responsibility unless autocommit is enabled on the connection.
+    """
+
+    def __init__(self, conn: psycopg.Connection):
+        self.conn = conn
+
+    def send(
+        self,
+        queue: str,
+        payload=None,
+        *,
+        type: str = "default",
+    ) -> int:
+        """Send a single message to a queue.
+
+        Maps to ``pgque.send(queue, payload)`` or
+        ``pgque.send(queue, type, payload)``.
+
+        Args:
+            queue: Target queue name.
+            payload: Message payload (dict serialized to JSON, or str).
+            type: Event type (default ``"default"``).
+
+        Returns:
+            The event ID assigned by pgque.
+        """
+        if isinstance(payload, dict):
+            payload = json.dumps(payload)
+
+        if type != "default":
+            row = self.conn.execute(
+                "select pgque.send(%s, %s, %s::jsonb)",
+                (queue, type, payload),
+            ).fetchone()
+        else:
+            row = self.conn.execute(
+                "select pgque.send(%s, %s::jsonb)",
+                (queue, payload),
+            ).fetchone()
+
+        self.conn.commit()
+        return row[0]
+
+    def send_batch(
+        self,
+        queue: str,
+        type: str,
+        payloads: list,
+    ) -> list[int]:
+        """Send multiple messages in a single transaction.
+
+        Maps to ``pgque.send_batch(queue, type, payloads[])``.
+
+        Args:
+            queue: Target queue name.
+            type: Event type for all messages.
+            payloads: List of payloads (dicts or strings).
+
+        Returns:
+            List of event IDs.
+        """
+        json_payloads = [
+            json.dumps(p) if isinstance(p, dict) else p for p in payloads
+        ]
+        row = self.conn.execute(
+            "select pgque.send_batch(%s, %s, %s::jsonb[])",
+            (queue, type, json_payloads),
+        ).fetchone()
+        self.conn.commit()
+        return list(row[0])
+
+    def receive(
+        self,
+        queue: str,
+        consumer: str,
+        max_messages: int = 100,
+    ) -> list[Message]:
+        """Receive messages from a queue.
+
+        Maps to ``pgque.receive(queue, consumer, max_messages)``.
+        Opens a batch via ``next_batch()`` internally. The caller must
+        ``ack()`` the batch after processing to advance the consumer.
+
+        Args:
+            queue: Queue name.
+            consumer: Consumer name.
+            max_messages: Maximum number of messages to return from the
+                current batch.
+
+        Returns:
+            List of ``Message`` objects (may be empty if no batch is
+            available).
+        """
+        rows = self.conn.execute(
+            "select * from pgque.receive(%s, %s, %s)",
+            (queue, consumer, max_messages),
+        ).fetchall()
+
+        return [
+            Message(
+                msg_id=r[0],
+                batch_id=r[1],
+                type=r[2],
+                payload=r[3],
+                retry_count=r[4],
+                created_at=r[5],
+                extra1=r[6],
+                extra2=r[7],
+                extra3=r[8],
+                extra4=r[9],
+            )
+            for r in rows
+        ]
+
+    def ack(self, batch_id: int) -> int:
+        """Acknowledge (finish) a batch.
+
+        Maps to ``pgque.ack(batch_id)`` which calls
+        ``pgque.finish_batch()``.  This advances the consumer past
+        the entire batch.
+
+        Args:
+            batch_id: Batch ID returned in received messages.
+
+        Returns:
+            Result from ``pgque.ack()``.
+        """
+        row = self.conn.execute(
+            "select pgque.ack(%s)", (batch_id,)
+        ).fetchone()
+        return row[0]
+
+    def nack(
+        self,
+        batch_id: int,
+        msg: Message,
+        retry_after: int = 60,
+        reason: Optional[str] = None,
+    ) -> None:
+        """Negatively acknowledge a single message for retry.
+
+        Maps to ``pgque.nack(batch_id, msg, retry_after, reason)``.
+        The message is copied to the retry queue. If the retry count
+        exceeds ``queue_max_retries``, the message is moved to the
+        dead-letter table instead.
+
+        After nacking individual messages, the caller should still
+        call ``ack()`` to finish the batch.
+
+        Args:
+            batch_id: Batch ID.
+            msg: The ``Message`` to retry.
+            retry_after: Seconds before retry (default 60).
+            reason: Optional reason string (stored in DLQ if max
+                retries exceeded).
+        """
+        self.conn.execute(
+            "select pgque.nack("
+            "  %s,"
+            "  ROW(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)::pgque.message,"
+            "  %s::interval,"
+            "  %s"
+            ")",
+            (
+                batch_id,
+                msg.msg_id,
+                msg.batch_id,
+                msg.type,
+                msg.payload,
+                msg.retry_count,
+                msg.created_at,
+                msg.extra1,
+                msg.extra2,
+                msg.extra3,
+                msg.extra4,
+                f"{retry_after} seconds",
+                reason,
+            ),
+        )

--- a/clients/python/pgque/client.py
+++ b/clients/python/pgque/client.py
@@ -57,7 +57,6 @@ class PgqueClient:
                 (queue, payload),
             ).fetchone()
 
-        self.conn.commit()
         return row[0]
 
     def send_batch(
@@ -85,7 +84,6 @@ class PgqueClient:
             "select pgque.send_batch(%s, %s, %s::jsonb[])",
             (queue, type, json_payloads),
         ).fetchone()
-        self.conn.commit()
         return list(row[0])
 
     def receive(

--- a/clients/python/pgque/consumer.py
+++ b/clients/python/pgque/consumer.py
@@ -4,4 +4,178 @@
 
 """Consumer -- event-driven message consumer with LISTEN/NOTIFY support."""
 
-raise NotImplementedError("TDD red phase -- consumer not yet implemented")
+import logging
+import signal
+import select
+from typing import Callable, Optional
+
+import psycopg
+
+from .client import PgqueClient
+from .types import Message
+
+logger = logging.getLogger("pgque")
+
+
+class Consumer:
+    """Synchronous polling consumer with LISTEN/NOTIFY wakeup.
+
+    Usage::
+
+        consumer = Consumer(
+            dsn="postgresql://localhost/mydb",
+            queue="orders",
+            name="order_processor",
+        )
+
+        @consumer.on("order.created")
+        def handle_order(msg: Message):
+            process_order(msg.payload)
+
+        consumer.start()  # blocks until SIGTERM/SIGINT
+
+    Handler return semantics:
+        - If the handler returns without exception, the message is
+          considered processed.
+        - If the handler raises an exception, the message is nacked
+          with the default retry_after.
+
+    After all messages in a batch have been dispatched, the batch is
+    acked automatically.
+    """
+
+    def __init__(
+        self,
+        dsn: str,
+        *,
+        queue: str,
+        name: str,
+        poll_interval: int = 30,
+        max_messages: int = 100,
+        retry_after: int = 60,
+    ):
+        self.dsn = dsn
+        self.queue = queue
+        self.name = name
+        self.poll_interval = poll_interval
+        self.max_messages = max_messages
+        self.retry_after = retry_after
+
+        self._handlers: dict[str, Callable] = {}
+        self._default_handler: Optional[Callable] = None
+        self._running = False
+
+    def on(self, event_type: str):
+        """Decorator to register a handler for a given event type.
+
+        Args:
+            event_type: The ``pgque.message.type`` value to match.
+                Use ``"*"`` to register a default/catch-all handler.
+        """
+
+        def decorator(func: Callable):
+            if event_type == "*":
+                self._default_handler = func
+            else:
+                self._handlers[event_type] = func
+            return func
+
+        return decorator
+
+    def start(self) -> None:
+        """Run the consume loop (blocks until SIGTERM/SIGINT).
+
+        Opens its own connection, subscribes to LISTEN, and polls for
+        batches. Each batch is processed and acked in a single
+        transaction.
+        """
+        self._running = True
+
+        # Graceful shutdown on signals
+        original_sigterm = signal.getsignal(signal.SIGTERM)
+        original_sigint = signal.getsignal(signal.SIGINT)
+
+        def _stop(signum, frame):
+            logger.info("received signal %s, shutting down", signum)
+            self._running = False
+
+        signal.signal(signal.SIGTERM, _stop)
+        signal.signal(signal.SIGINT, _stop)
+
+        try:
+            with psycopg.connect(self.dsn, autocommit=True) as conn:
+                # Subscribe for wakeup notifications
+                channel = f"pgque_{self.queue}"
+                conn.execute(f"LISTEN {channel}")
+                logger.info(
+                    "consumer %s listening on %s (poll=%ds)",
+                    self.name,
+                    self.queue,
+                    self.poll_interval,
+                )
+
+                while self._running:
+                    self._poll_once(conn)
+
+                    if not self._running:
+                        break
+
+                    # Wait for NOTIFY or poll_interval timeout
+                    try:
+                        gen = conn.notifies(timeout=self.poll_interval)
+                        for _notify in gen:
+                            # Any notification means new events; break
+                            # to poll immediately.
+                            break
+                    except StopIteration:
+                        pass
+
+        finally:
+            signal.signal(signal.SIGTERM, original_sigterm)
+            signal.signal(signal.SIGINT, original_sigint)
+
+        logger.info("consumer %s stopped", self.name)
+
+    def stop(self) -> None:
+        """Request graceful shutdown (safe to call from another thread)."""
+        self._running = False
+
+    def _poll_once(self, conn: psycopg.Connection) -> None:
+        """Receive one batch and dispatch messages."""
+        # Use a transaction block for receive + ack
+        with conn.transaction():
+            client = PgqueClient(conn)
+            msgs = client.receive(
+                self.queue, self.name, self.max_messages
+            )
+
+            if not msgs:
+                return
+
+            batch_id = msgs[0].batch_id
+            logger.debug(
+                "batch %d: %d message(s)", batch_id, len(msgs)
+            )
+
+            for msg in msgs:
+                handler = self._handlers.get(msg.type, self._default_handler)
+                if handler is None:
+                    logger.warning(
+                        "no handler for type=%r, skipping msg_id=%d",
+                        msg.type,
+                        msg.msg_id,
+                    )
+                    continue
+
+                try:
+                    handler(msg)
+                except Exception:
+                    logger.exception(
+                        "handler failed for msg_id=%d, nacking",
+                        msg.msg_id,
+                    )
+                    client.nack(
+                        batch_id, msg, retry_after=self.retry_after
+                    )
+
+            client.ack(batch_id)

--- a/clients/python/pgque/consumer.py
+++ b/clients/python/pgque/consumer.py
@@ -10,6 +10,7 @@ import select
 from typing import Callable, Optional
 
 import psycopg
+from psycopg import sql
 
 from .client import PgqueClient
 from .types import Message
@@ -106,7 +107,7 @@ class Consumer:
             with psycopg.connect(self.dsn, autocommit=True) as conn:
                 # Subscribe for wakeup notifications
                 channel = f"pgque_{self.queue}"
-                conn.execute(f"LISTEN {channel}")
+                conn.execute(sql.SQL("LISTEN {}").format(sql.Identifier(channel)))
                 logger.info(
                     "consumer %s listening on %s (poll=%ds)",
                     self.name,

--- a/clients/python/pgque/consumer.py
+++ b/clients/python/pgque/consumer.py
@@ -1,0 +1,7 @@
+# Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+# PgQue includes code derived from PgQ (ISC license,
+# Marko Kreen / Skype Technologies OU).
+
+"""Consumer -- event-driven message consumer with LISTEN/NOTIFY support."""
+
+raise NotImplementedError("TDD red phase -- consumer not yet implemented")

--- a/clients/python/pgque/types.py
+++ b/clients/python/pgque/types.py
@@ -1,0 +1,35 @@
+# Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+# PgQue includes code derived from PgQ (ISC license,
+# Marko Kreen / Skype Technologies OU).
+
+"""Message and type definitions for pgque."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class Message:
+    """A message received from a pgque queue.
+
+    Maps to the pgque.message composite type:
+        msg_id      -- ev_id
+        batch_id    -- batch containing this message
+        type        -- ev_type
+        payload     -- ev_data (caller casts to jsonb if needed)
+        retry_count -- ev_retry (None for first delivery)
+        created_at  -- ev_time
+        extra1..4   -- ev_extra1..ev_extra4
+    """
+
+    msg_id: int
+    batch_id: int
+    type: str
+    payload: str
+    retry_count: Optional[int]
+    created_at: datetime
+    extra1: Optional[str] = None
+    extra2: Optional[str] = None
+    extra3: Optional[str] = None
+    extra4: Optional[str] = None

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "pgque"
+version = "0.1.0"
+description = "Python client for PgQue -- PgQ Universal Edition"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+dependencies = [
+    "psycopg[binary]>=3.1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21",
+]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.backends._legacy:_Backend"

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -1,0 +1,24 @@
+import os
+import pytest
+import psycopg
+
+DSN = os.environ.get("PGQUE_TEST_DSN", "postgresql://postgres:pgque_test@localhost/pgque_test")
+
+@pytest.fixture
+def conn():
+    with psycopg.connect(DSN) as c:
+        yield c
+
+@pytest.fixture
+def setup_queue(conn):
+    """Create a test queue and clean up after."""
+    conn.execute("SELECT pgque.create_queue('pytest_queue')")
+    conn.execute("SELECT pgque.register_consumer('pytest_queue', 'pytest_consumer')")
+    conn.commit()
+    yield
+    try:
+        conn.execute("SELECT pgque.unregister_consumer('pytest_queue', 'pytest_consumer')")
+        conn.execute("SELECT pgque.drop_queue('pytest_queue')")
+        conn.commit()
+    except Exception:
+        conn.rollback()

--- a/clients/python/tests/test_consumer.py
+++ b/clients/python/tests/test_consumer.py
@@ -1,0 +1,49 @@
+import pytest
+from pgque import PgqueClient, Consumer, Message
+
+def test_receive_returns_messages(conn, setup_queue):
+    client = PgqueClient(conn)
+    client.send("pytest_queue", {"key": "value"})
+    conn.execute("SELECT pgque.ticker()")
+    conn.commit()
+
+    msgs = client.receive("pytest_queue", "pytest_consumer", max_messages=10)
+    assert len(msgs) == 1
+    assert msgs[0].payload == '{"key": "value"}'
+    assert msgs[0].type == "default"
+    assert msgs[0].batch_id is not None
+
+def test_ack_advances_position(conn, setup_queue):
+    client = PgqueClient(conn)
+    client.send("pytest_queue", {"key": "value"})
+    conn.execute("SELECT pgque.ticker()")
+    conn.commit()
+
+    msgs = client.receive("pytest_queue", "pytest_consumer", max_messages=10)
+    client.ack(msgs[0].batch_id)
+    conn.commit()
+
+    # Next receive should be empty
+    msgs2 = client.receive("pytest_queue", "pytest_consumer", max_messages=10)
+    assert len(msgs2) == 0
+
+def test_nack_retries_event(conn, setup_queue):
+    client = PgqueClient(conn)
+    client.send("pytest_queue", {"key": "retry"})
+    conn.execute("SELECT pgque.ticker()")
+    conn.commit()
+
+    msgs = client.receive("pytest_queue", "pytest_consumer", max_messages=10)
+    client.nack(msgs[0].batch_id, msgs[0], retry_after=0)
+    client.ack(msgs[0].batch_id)
+    conn.commit()
+
+    # Run maintenance and ticker
+    conn.execute("SELECT pgque.maint_retry_events('pytest_queue')")
+    conn.execute("SELECT pgque.force_tick('pytest_queue')")
+    conn.execute("SELECT pgque.ticker()")
+    conn.commit()
+
+    # Should get the event again
+    msgs2 = client.receive("pytest_queue", "pytest_consumer", max_messages=10)
+    assert len(msgs2) >= 1

--- a/clients/python/tests/test_producer.py
+++ b/clients/python/tests/test_producer.py
@@ -1,0 +1,20 @@
+import pytest
+from pgque import PgqueClient, Message
+
+def test_send_returns_event_id(conn, setup_queue):
+    client = PgqueClient(conn)
+    eid = client.send("pytest_queue", {"order_id": 42})
+    assert eid is not None
+    assert isinstance(eid, int)
+
+def test_send_with_type(conn, setup_queue):
+    client = PgqueClient(conn)
+    eid = client.send("pytest_queue", type="order.created", payload={"id": 1})
+    assert eid is not None
+
+def test_send_batch(conn, setup_queue):
+    client = PgqueClient(conn)
+    ids = client.send_batch("pytest_queue", "batch.test", [
+        {"n": 1}, {"n": 2}, {"n": 3}
+    ])
+    assert len(ids) == 3


### PR DESCRIPTION
## Summary

- Implements `pgque-py` Python client library per SPECx section 6.2 and issue #28
- `PgqueClient` wraps pgque SQL functions: `send()`, `send_batch()`, `receive()`, `ack()`, `nack()`
- `Consumer` class provides decorator-based event handlers (`@consumer.on("type")`), LISTEN/NOTIFY wakeup, graceful SIGTERM/SIGINT shutdown, and configurable poll interval
- `Message` dataclass maps to `pgque.message` composite type (10 fields)
- Built on psycopg v3, requires Python 3.10+
- TDD: tests committed first (red phase), then implementation (green phase)

## Test plan

- [ ] Run `pytest tests/ -v` with a PostgreSQL instance that has pgque installed
- [ ] Verify `test_send_returns_event_id` -- `send()` returns an integer event ID
- [ ] Verify `test_send_with_type` -- `send()` with explicit type parameter works
- [ ] Verify `test_send_batch` -- `send_batch()` returns list of 3 IDs for 3 payloads
- [ ] Verify `test_receive_returns_messages` -- `receive()` returns `Message` with correct payload, type, batch_id
- [ ] Verify `test_ack_advances_position` -- after `ack()`, next `receive()` returns empty
- [ ] Verify `test_nack_retries_event` -- nacked message reappears after maintenance + ticker

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)