### PR TITLE
test/docs: tighten API semantics coverage and warn that ticker is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,13 +164,13 @@ begin;
 commit;
 ```
 
-With `pg_cron` installed, start the built-in ticker and maintenance jobs:
+With `pg_cron` installed, `pgque.start()` creates the default ticker and maintenance jobs:
 
 ```sql
 select pgque.start();
 ```
 
-Without `pg_cron`, installation still works. You just drive ticking and maintenance from an external scheduler or your app:
+Without `pg_cron`, installation still works, but PgQue is not self-running. You must drive ticking and maintenance from an external scheduler or application process:
 
 ```bash
 # every 1-2 seconds
@@ -185,7 +185,7 @@ psql -c "select pgque.ticker()"
 psql -c "select pgque.maint()"
 ```
 
-**Important:** `pgque.ticker()` is required for message delivery. PgQue only makes events visible to consumers after ticks are created. If no ticker is running, producers can enqueue events, but consumers will not see new batches. `pgque.maint()` should also run regularly for retries, cleanup, and rotation.
+**Important:** PgQue does not deliver messages without a working ticker. By default, `pgque.start()` sets this up with `pg_cron`. If the cron job is absent, disabled, or broken, enqueueing still works, but consumers will see nothing new because ticks are not being created. If you do not use `pg_cron`, run `pgque.ticker()` yourself from an external scheduler or application process. Run `pgque.maint()` regularly as well for retries, cleanup, and rotation.
 
 For now, treat installation as initial setup. Upgrade/reinstall guarantees are still being tightened.
 
@@ -226,6 +226,7 @@ select pgque.ack(1);
 ```
 
 Important: send/tick/receive should be separate transactions. That's not a PgQue quirk so much as PgQ's snapshot-based design doing exactly what it is supposed to do.
+In normal operation, a scheduler or `pg_cron` job should be driving `pgque.ticker()`. `force_tick()` is mainly useful for demos, tests, and manual operation.
 
 ## Usage examples
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ psql -c "select pgque.ticker()"
 psql -c "select pgque.maint()"
 ```
 
+**Important:** `pgque.ticker()` is required for message delivery. PgQue only makes events visible to consumers after ticks are created. If no ticker is running, producers can enqueue events, but consumers will not see new batches. `pgque.maint()` should also run regularly for retries, cleanup, and rotation.
+
 For now, treat installation as initial setup. Upgrade/reinstall guarantees are still being tightened.
 
 To uninstall:

--- a/tests/run_all.sql
+++ b/tests/run_all.sql
@@ -58,5 +58,6 @@
 \echo 'Running: test_api_receive'
 \i tests/test_api_receive.sql
 
+
 \echo ''
 \echo '=== ALL TESTS PASSED ==='

--- a/tests/test_api_receive.sql
+++ b/tests/test_api_receive.sql
@@ -58,10 +58,64 @@ begin
   assert v_count = 0, 'should have no more messages after ack';
 end $$;
 
+-- Step 6: partial receive still acks the whole underlying batch
+do $$
+begin
+  perform pgque.create_queue('test_recv_partial');
+  perform pgque.register_consumer('test_recv_partial', 'c1');
+end $$;
+
+do $$
+begin
+  perform pgque.insert_event('test_recv_partial', 'test.type', '{"n":1}');
+  perform pgque.insert_event('test_recv_partial', 'test.type', '{"n":2}');
+  perform pgque.insert_event('test_recv_partial', 'test.type', '{"n":3}');
+end $$;
+
+do $$
+begin
+  perform pgque.force_tick('test_recv_partial');
+  perform pgque.ticker();
+end $$;
+
+do $$
+declare
+  v_msg pgque.message;
+  v_count int := 0;
+  v_batch_id bigint;
+begin
+  for v_msg in select * from pgque.receive('test_recv_partial', 'c1', 1)
+  loop
+    v_count := v_count + 1;
+    v_batch_id := v_msg.batch_id;
+  end loop;
+
+  assert v_count = 1, 'receive(..., 1) should return exactly 1 row';
+  assert v_batch_id is not null, 'batch_id should be set for partial receive';
+
+  perform pgque.ack(v_batch_id);
+end $$;
+
+do $$
+declare
+  v_msg pgque.message;
+  v_count int := 0;
+begin
+  for v_msg in select * from pgque.receive('test_recv_partial', 'c1', 10)
+  loop
+    v_count := v_count + 1;
+  end loop;
+
+  assert v_count = 0,
+    'ack(batch_id) should finish the whole batch, even if receive(..., 1) returned one row';
+end $$;
+
 -- Cleanup
 do $$
 begin
   perform pgque.unregister_consumer('test_recv', 'c1');
   perform pgque.drop_queue('test_recv');
-  raise notice 'PASS: receive + ack';
+  perform pgque.unregister_consumer('test_recv_partial', 'c1');
+  perform pgque.drop_queue('test_recv_partial');
+  raise notice 'PASS: receive + ack semantics';
 end $$;

--- a/tests/test_pgque_roles.sql
+++ b/tests/test_pgque_roles.sql
@@ -1,4 +1,4 @@
--- test_pgque_roles.sql -- Verify pgque roles exist
+-- test_pgque_roles.sql -- Verify pgque roles exist and modern API grants are present
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 
 do $$
@@ -9,6 +9,15 @@ begin
     'pgque_writer should exist';
   assert exists (select 1 from pg_roles where rolname = 'pgque_admin'),
     'pgque_admin should exist';
+
+  assert has_function_privilege('pgque_writer', 'pgque.send(text, jsonb)', 'EXECUTE'),
+    'pgque_writer should have execute on send(text, jsonb)';
+  assert has_function_privilege('pgque_writer', 'pgque.receive(text, text, integer)', 'EXECUTE'),
+    'pgque_writer should have execute on receive(text, text, integer)';
+  assert has_function_privilege('pgque_writer', 'pgque.ack(bigint)', 'EXECUTE'),
+    'pgque_writer should have execute on ack(bigint)';
+  assert has_function_privilege('pgque_writer', 'pgque.nack(bigint, pgque.message, interval, text)', 'EXECUTE'),
+    'pgque_writer should have execute on nack(bigint, pgque.message, interval, text)';
 
   raise notice 'PASS: pgque_roles';
 end $$;


### PR DESCRIPTION
## Summary

Salvage the still-useful parts of PR #43 onto current `main`:

- keep useful API semantics test updates
- keep role grant coverage for the modern API
- add an explicit README warning that no ticker means no delivery

This intentionally avoids redoing packaging/assembly changes that are already in `main`, and it does not revive the nack/retry integration case that is still not solid on current main.
