### PR TITLE
feat(clients): add TypeScript example client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,60 @@ jobs:
         if: always()
         run: docker rm -f pgque-test
 
+  client-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Start PostgreSQL 17
+        run: |
+          docker run -d --name pgque-client-test \
+            -e POSTGRES_PASSWORD=pgque_test \
+            -e POSTGRES_DB=pgque_test \
+            -p 5432:5432 \
+            postgres:17
+
+          for i in $(seq 1 30); do
+            docker exec pgque-client-test pg_isready -U postgres && break
+            sleep 1
+          done || { echo "PG not ready after 30 seconds"; exit 1; }
+
+      - name: Build pgque
+        run: bash build/transform.sh
+
+      - name: Install pgque
+        run: |
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
+            -v ON_ERROR_STOP=1 -f sql/pgque.sql
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
+            -v ON_ERROR_STOP=1 -c "select pgque.create_queue('smoke_py'); select pgque.create_queue('smoke_go'); select pgque.create_queue('smoke_ts');"
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
+            -v ON_ERROR_STOP=1 -c "select pgque.force_tick('smoke_py'); select pgque.force_tick('smoke_go'); select pgque.force_tick('smoke_ts'); select pgque.ticker();"
+
+      - name: Python smoke
+        run: |
+          python3 -m pip install -U pip
+          python3 -m pip install -e clients/python[dev]
+          pytest -q clients/python/tests/test_smoke.py
+
+      - name: Go smoke
+        run: |
+          cd clients/go
+          go test -run TestSmoke ./...
+
+      - name: TypeScript smoke
+        run: |
+          cd clients/typescript
+          npm install
+          npm run check
+          npx tsx src/smoke.ts
+
+      - name: Cleanup client smoke DB
+        if: always()
+        run: docker rm -f pgque-client-test
+
   verify:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -302,6 +302,12 @@ select cron.schedule('daily_report',
 
 ## Client libraries
 
+PgQue currently includes example client libraries for **Go**, **Python**, and **TypeScript**.
+
+These are **examples for now** — **unpublished**, still evolving, and meant to demonstrate integration patterns rather than promise stable SDKs yet.
+
+**Help improving them is very much appreciated.**
+
 PgQue is SQL-first, so any PostgreSQL driver works. On top of that, dedicated client libraries already exist or are being built around the API.
 
 ### Python (`pgque-py`)
@@ -335,6 +341,23 @@ consumer.Handle("order.created", func(ctx context.Context, msg pgque.Message) er
     return processOrder(msg)
 })
 consumer.Start(ctx)
+```
+
+### TypeScript (`pgque-ts`)
+
+Built on node-postgres (`pg`). Typical usage:
+
+```ts
+const client = new PgqueClient('postgresql://localhost/mydb');
+await client.connect();
+
+await client.send('orders', { order_id: 42 }, 'order.created');
+await client.subscribe('orders', 'processor');
+
+const messages = await client.receive('orders', 'processor', 100);
+if (messages.length > 0) {
+  await client.ack(messages[0].batch_id);
+}
 ```
 
 ### Any language

--- a/clients/go/smoke_test.go
+++ b/clients/go/smoke_test.go
@@ -1,0 +1,33 @@
+package pgque
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSmoke(t *testing.T) {
+	ctx := context.Background()
+	client, err := Connect(ctx, "postgresql://postgres:pgque_test@localhost:5432/pgque_test")
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer client.Close(ctx)
+
+	if err := client.Send(ctx, "smoke_go", "smoke.test", map[string]any{"hello": "world"}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if err := client.Subscribe(ctx, "smoke_go", "go-smoke"); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	msgs, err := client.Receive(ctx, "smoke_go", "go-smoke", 10)
+	if err != nil {
+		t.Fatalf("receive: %v", err)
+	}
+	if len(msgs) == 0 {
+		t.Fatal("expected at least one message")
+	}
+	if err := client.Ack(ctx, msgs[0].BatchID); err != nil {
+		t.Fatalf("ack: %v", err)
+	}
+}

--- a/clients/python/tests/test_smoke.py
+++ b/clients/python/tests/test_smoke.py
@@ -1,0 +1,13 @@
+from pgque import PgqueClient, Consumer
+
+
+def test_python_client_smoke(conn):
+    client = PgqueClient(conn)
+    client.send("smoke_py", {"hello": "world"}, "smoke.test")
+    client.subscribe("smoke_py", "py-smoke")
+
+    consumer = Consumer(conn, queue="smoke_py", name="py-smoke")
+    messages = consumer.receive(limit=10)
+
+    assert len(messages) >= 1
+    consumer.ack(messages[0].batch_id)

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -1,0 +1,32 @@
+# pgque-ts-example
+
+Example TypeScript client for PgQue.
+
+This is an unpublished example library for now. It is meant to demonstrate
+integration patterns, not to promise a stable SDK yet.
+
+## Usage
+
+```ts
+import { PgqueClient } from './src/index.js';
+
+const client = new PgqueClient('postgresql://localhost/mydb');
+await client.connect();
+
+await client.send('orders', { order_id: 42 }, 'order.created');
+await client.subscribe('orders', 'processor');
+
+const messages = await client.receive('orders', 'processor', 100);
+for (const msg of messages) {
+  console.log(msg.type, msg.payload);
+}
+
+if (messages.length > 0) {
+  await client.ack(messages[0].batch_id);
+}
+
+await client.close();
+```
+
+Important: `ack(batch_id)` acknowledges the whole batch, not just one returned
+row.

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "pgque-ts-example",
+  "private": true,
+  "version": "0.0.1",
+  "description": "Example TypeScript client for PgQue",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "check": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "pg": "^8.16.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3",
+    "@types/node": "^22.15.3",
+    "@types/pg": "^8.15.2"
+  }
+}

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "typescript": "^5.8.3",
+    "tsx": "^4.19.3",
     "@types/node": "^22.15.3",
     "@types/pg": "^8.15.2"
   }

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -1,0 +1,55 @@
+import { Client, type ClientConfig } from 'pg';
+
+export interface PgqueMessage {
+  msg_id: number;
+  batch_id: number;
+  type: string;
+  payload: unknown;
+  retry_count: number | null;
+  created_at: string;
+  extra1: string | null;
+  extra2: string | null;
+  extra3: string | null;
+  extra4: string | null;
+}
+
+export class PgqueClient {
+  private readonly client: Client;
+
+  constructor(config: string | ClientConfig) {
+    this.client = typeof config === 'string'
+      ? new Client({ connectionString: config })
+      : new Client(config);
+  }
+
+  async connect(): Promise<void> {
+    await this.client.connect();
+  }
+
+  async close(): Promise<void> {
+    await this.client.end();
+  }
+
+  async send(queue: string, payload: unknown, type = 'message'): Promise<void> {
+    await this.client.query(
+      'select pgque.send($1, $2, $3::jsonb)',
+      [queue, type, JSON.stringify(payload)]
+    );
+  }
+
+  async subscribe(queue: string, consumer: string): Promise<void> {
+    await this.client.query('select pgque.subscribe($1, $2)', [queue, consumer]);
+  }
+
+  async receive(queue: string, consumer: string, limit = 100): Promise<PgqueMessage[]> {
+    const result = await this.client.query<PgqueMessage>(
+      'select * from pgque.receive($1, $2, $3)',
+      [queue, consumer, limit]
+    );
+    return result.rows;
+  }
+
+  async ack(batchId: number): Promise<void> {
+    await this.client.query('select pgque.ack($1)', [batchId]);
+  }
+}

--- a/clients/typescript/src/smoke.ts
+++ b/clients/typescript/src/smoke.ts
@@ -1,0 +1,22 @@
+import { PgqueClient } from './index.js';
+
+async function main(): Promise<void> {
+  const client = new PgqueClient('postgresql://postgres:pgque_test@localhost:5432/pgque_test');
+  await client.connect();
+
+  await client.send('smoke_ts', { hello: 'world' }, 'smoke.test');
+  await client.subscribe('smoke_ts', 'ts-smoke');
+
+  const messages = await client.receive('smoke_ts', 'ts-smoke', 10);
+  if (messages.length === 0) {
+    throw new Error('expected at least one message in TypeScript smoke test');
+  }
+
+  await client.ack(messages[0].batch_id);
+  await client.close();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/clients/typescript/tsconfig.json
+++ b/clients/typescript/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add a minimal TypeScript example client under `clients/typescript`
- update README client libraries section to include Go, Python, and TypeScript
- clarify that client libraries are unpublished examples for now and contributions are welcome

## Notes
- this is an example client, not a published SDK
- built on node-postgres (`pg`)
- keeps the batch semantics explicit: `ack(batch_id)` acknowledges the whole batch