### PR TITLE
feat: add text overloads for pgque.send() and pgque.send_batch()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg_version: ['14', '15', '16', '17', '18']
+        pg_version: ['18', '17', '16', '15', '14']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg_version: ['14', '15', '16', '17']
+        pg_version: ['14', '15', '16', '17', '18']
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -353,9 +353,9 @@ select pgque.ack(batch_id);
 
 | Function | Returns | Description |
 |---|---|---|
-| `pgque.send(queue, payload)` | `bigint` | Send with default type; `payload` may be `jsonb` (validated, canonicalized) or `text` (fast path, opaque bytes) |
-| `pgque.send(queue, type, payload)` | `bigint` | Send with explicit event type; `jsonb` and `text` overloads |
-| `pgque.send_batch(queue, type, payloads[])` | `bigint[]` | Batch send in a single transaction; `jsonb[]` and `text[]` overloads |
+| `pgque.send(queue, payload)` | `bigint` | Send with default type. Untyped literals resolve to the `text` overload (fast path, bytes verbatim); use `::jsonb` cast to opt into validation + canonicalization |
+| `pgque.send(queue, type, payload)` | `bigint` | Send with explicit event type. Same `text` / `jsonb` overload rules as above |
+| `pgque.send_batch(queue, type, payloads[])` | `bigint[]` | Batch send in a single transaction. `text[]` by default, `jsonb[]` opt-in via cast |
 | `pgque.send_at(queue, type, payload, deliver_at)` | `bigint` | Delayed/scheduled delivery |
 
 ### Consuming

--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ sustained load this causes documented, reproducible production failures:
   autovacuum starvation documented at Heroku
 - Oban Pro shipped table partitioning specifically to mitigate bloat
 - PGMQ ships aggressive autovacuum settings in some deployment setups
-  image
 
 PgQue's TRUNCATE rotation creates zero dead tuples in event tables by
 construction. No tuning required, immune to xmin horizon pinning. This
@@ -195,6 +194,40 @@ To uninstall:
 \i sql/pgque_uninstall.sql
 ```
 
+## Roles and grants
+
+The install creates three roles with explicit grants for the operational
+API. Application users do not need superuser; grant them whichever role
+matches their access pattern.
+
+| Role | Purpose | Granted access |
+|---|---|---|
+| `pgque_reader` | Dashboards, metrics, debugging | `get_queue_info`, `get_consumer_info`, `get_batch_info`, `version`, plus `select` on all tables |
+| `pgque_writer` | Producers and consumers (most apps) | inherits `pgque_reader` + the modern API (`send`, `send_batch`, `subscribe`, `unsubscribe`, `receive`, `ack`, `nack`) and the underlying PgQ primitives (`insert_event`, `next_batch`, `get_batch_events`, `finish_batch`, `event_retry`, `register_consumer`, `unregister_consumer`) |
+| `pgque_admin`  | Operators, migrations | inherits `pgque_writer` + full schema/table/sequence access. Excludes `uninstall()` (superuser-only on purpose: it drops the schema). |
+
+Typical app setup:
+
+```sql
+-- once, as superuser or schema owner
+\i sql/pgque.sql
+select pgque.start();           -- optional: pg_cron ticker + maint
+
+-- for the application connection
+create user app_orders with password '...';
+grant pgque_writer to app_orders;
+
+-- for a read-only metrics user
+create user metrics with password '...';
+grant pgque_reader to metrics;
+```
+
+DDL-class operations (`create_queue`, `drop_queue`, `start`, `stop`,
+`maint`, `ticker`, `force_tick`) are not granted to `pgque_writer` and
+should be performed by an admin / migration role. They run on PUBLIC
+default for now; revoking from PUBLIC and granting only to
+`pgque_admin` is on the roadmap.
+
 ## Project status
 
 PgQue is **early-stage** as a product and API layer.
@@ -219,10 +252,11 @@ select pgque.force_tick('orders');
 select pgque.ticker();
 
 -- transaction 4: receive and process messages
+-- (capture batch_id from any returned row -- it's the same for the whole batch)
 select * from pgque.receive('orders', 'processor', 100);
 
 -- transaction 5: acknowledge the batch
-select pgque.ack(1);
+select pgque.ack(:batch_id);  -- substitute the batch_id you saw above
 ```
 
 Important: send/tick/receive should be separate transactions. That's not a PgQue quirk so much as PgQ's snapshot-based design doing exactly what it is supposed to do.
@@ -353,26 +387,38 @@ select pgque.ack(batch_id);
 
 | Function | Returns | Description |
 |---|---|---|
-| `pgque.send(queue, payload)` | `bigint` | Send with default type. Untyped literals resolve to the `text` overload (fast path, bytes verbatim); use `::jsonb` cast to opt into validation + canonicalization |
+| `pgque.send(queue, payload)` | `bigint` | Send with default type. Untyped literals resolve to the `text` overload (fast path, bytes verbatim — text only, no NUL bytes); use `::jsonb` cast to opt into validation + canonicalization. See [SPECx.md §4.1](blueprints/SPECx.md) for the NUL-byte caveat and binary-payload encoding guidance |
 | `pgque.send(queue, type, payload)` | `bigint` | Send with explicit event type. Same `text` / `jsonb` overload rules as above |
 | `pgque.send_batch(queue, type, payloads[])` | `bigint[]` | Batch send in a single transaction. `text[]` by default, `jsonb[]` opt-in via cast |
-| `pgque.send_at(queue, type, payload, deliver_at)` | `bigint` | Delayed/scheduled delivery |
+| `pgque.send_at(queue, type, payload, deliver_at)` | `bigint` | Delayed/scheduled delivery (experimental) |
 
 ### Consuming
 
 | Function | Returns | Description |
 |---|---|---|
 | `pgque.receive(queue, consumer, max_return)` | `setof pgque.message` | Receive up to N messages from the next batch |
-| `pgque.ack(batch_id)` | `integer` | Finish batch and advance consumer position |
-| `pgque.subscribe(queue, consumer)` | `integer` | Register a consumer |
+| `pgque.ack(batch_id)` | `integer` | Finish batch and advance consumer position (modern alias for `finish_batch`) |
+| `pgque.nack(batch_id, msg, retry_after, reason)` | `integer` | Retry the message after `retry_after` (default 60s), or move to dead letter once the queue's `max_retries` is reached |
+| `pgque.subscribe(queue, consumer)` | `integer` | Register a consumer (modern alias for `register_consumer`) |
 | `pgque.unsubscribe(queue, consumer)` | `integer` | Unregister a consumer |
 
 ### Queue management
 
 | Function | Returns | Description |
 |---|---|---|
-| `pgque.create_queue(queue)` | `integer` | Create a new queue |
-| `pgque.drop_queue(queue)` | `integer` | Drop a queue |
+| `pgque.create_queue(queue)` | `integer` | Create a new queue (admin / migration role) |
+| `pgque.drop_queue(queue)` | `integer` | Drop a queue (admin / migration role) |
+
+### Observability
+
+Granted to `pgque_reader`, so dashboards and metrics services don't need write access.
+
+| Function | Returns | Description |
+|---|---|---|
+| `pgque.get_queue_info()` / `pgque.get_queue_info(queue)` | `setof record` | Per-queue stats: tick count, last tick time, event count, table sizes |
+| `pgque.get_consumer_info()` / `(queue)` / `(queue, consumer)` | `setof record` | Per-consumer lag, last seen tick, pending batches |
+| `pgque.get_batch_info(batch_id)` | `record` | Inspect a specific batch (consumer, queue, range) |
+| `pgque.version()` | `text` | Installed PgQue version |
 
 ### Lifecycle
 
@@ -380,10 +426,11 @@ select pgque.ack(batch_id);
 |---|---|---|
 | `pgque.start()` | `void` | Create pg_cron ticker + maintenance jobs when pg_cron is available |
 | `pgque.stop()` | `void` | Remove pg_cron jobs |
-| `pgque.status()` | `table` | Diagnostic dashboard |
-| `pgque.ticker()` | `bigint` | Manual ticker for all queues |
-| `pgque.maint()` | `integer` | Manual maintenance runner |
-| `pgque.uninstall()` | `void` | Stop jobs and drop schema |
+| `pgque.status()` | `setof record` | Diagnostic dashboard (cron jobs, ticker health, queue lag) |
+| `pgque.ticker()` | `bigint` | Manual ticker for all queues — call from your scheduler if you do not use pg_cron |
+| `pgque.force_tick(queue)` | `bigint` | Bypass tick thresholds for one queue and create a tick now. Useful in demos and tests; not for production hot paths |
+| `pgque.maint()` | `integer` | Manual maintenance runner — table rotation, retry processing, cleanup |
+| `pgque.uninstall()` | `void` | Stop jobs and drop schema (superuser only) |
 
 ### PgQ-native API
 

--- a/README.md
+++ b/README.md
@@ -353,9 +353,9 @@ select pgque.ack(batch_id);
 
 | Function | Returns | Description |
 |---|---|---|
-| `pgque.send(queue, payload)` | `bigint` | Send a message with default type |
-| `pgque.send(queue, type, payload)` | `bigint` | Send with explicit event type |
-| `pgque.send_batch(queue, type, payloads[])` | `bigint[]` | Batch send in a single transaction |
+| `pgque.send(queue, payload)` | `bigint` | Send with default type; `payload` may be `jsonb` (validated, canonicalized) or `text` (fast path, opaque bytes) |
+| `pgque.send(queue, type, payload)` | `bigint` | Send with explicit event type; `jsonb` and `text` overloads |
+| `pgque.send_batch(queue, type, payloads[])` | `bigint[]` | Batch send in a single transaction; `jsonb[]` and `text[]` overloads |
 | `pgque.send_at(queue, type, payload, deliver_at)` | `bigint` | Delayed/scheduled delivery |
 
 ### Consuming

--- a/blueprints/SPECx.md
+++ b/blueprints/SPECx.md
@@ -623,7 +623,7 @@ send a JSON message, receive it, ack or nack it.
 ### 4.1 Publishing: `pgque.send()`
 
 ```sql
--- Simple send
+-- Simple send (jsonb: ergonomic default; PG validates JSON at parse time)
 SELECT pgque.send('orders', '{"order_id": 42, "total": 99.95}'::jsonb);
 
 -- Send with explicit type
@@ -636,6 +636,17 @@ SELECT pgque.send_batch('orders', 'order.created', ARRAY[
     '{"order_id": 44}'::jsonb
 ]);
 
+-- Fast path: text overload. Skips the jsonb parse + canonical
+-- reserialization round-trip and stores the payload byte-for-byte.
+-- Use this for large payloads, non-JSON encodings (protobuf, msgpack,
+-- Avro, XML), or when the caller has already validated the input.
+SELECT pgque.send('orders', '{"order_id": 42}'::text);
+SELECT pgque.send('orders', 'order.proto', E'\\x08\\x2a\\x10\\x63'::text);
+SELECT pgque.send_batch('orders', 'order.created', ARRAY[
+    '{"order_id": 42}',
+    '{"order_id": 43}'
+]::text[]);
+
 -- Delayed send (deliver after timestamp)
 SELECT pgque.send_at('orders', 'reminder.send',
     '{"user_id": 7}'::jsonb,
@@ -645,9 +656,26 @@ SELECT pgque.send_at('orders', 'reminder.send',
 -- client-side sorting within a batch (see section 7.6)
 ```
 
+**Payload type choice.** Storage is always `ev_data TEXT`; the two overloads
+differ only in the client-side validation/reserialization contract:
+
+- `jsonb` overload: ergonomic default. PG rejects malformed JSON at parse
+  time and the payload is stored in canonical form (keys sorted, whitespace
+  normalized).
+- `text` overload: fast path. Bytes flow straight through to `insert_event`.
+  No validation, no reserialization, key order preserved. Required for
+  non-JSON payloads.
+
+Both overloads return `bigint` (event ID). `receive()` returns payload as
+`text`, so the `text`-both-sides path is symmetric (no implicit canonicalization
+anywhere). The `jsonb`-in / `text`-out path leaves client-side JSON parsing
+to the consumer, which is where it has to live anyway (a PG composite type
+cannot polymorphically carry both `text` and `jsonb`).
+
 **Internal mapping:**
 
 ```sql
+-- jsonb overloads (ergonomic default, validation + canonicalization)
 CREATE FUNCTION pgque.send(i_queue text, i_payload jsonb)
 RETURNS bigint AS $$
 BEGIN
@@ -659,6 +687,21 @@ CREATE FUNCTION pgque.send(i_queue text, i_type text, i_payload jsonb)
 RETURNS bigint AS $$
 BEGIN
     RETURN pgque.insert_event(i_queue, i_type, i_payload::text);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pgque, pg_catalog;
+
+-- text overloads (fast path, opaque payload)
+CREATE FUNCTION pgque.send(i_queue text, i_payload text)
+RETURNS bigint AS $$
+BEGIN
+    RETURN pgque.insert_event(i_queue, 'default', i_payload);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pgque, pg_catalog;
+
+CREATE FUNCTION pgque.send(i_queue text, i_type text, i_payload text)
+RETURNS bigint AS $$
+BEGIN
+    RETURN pgque.insert_event(i_queue, i_type, i_payload);
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pgque, pg_catalog;
 
@@ -675,6 +718,21 @@ begin
     foreach p in array i_payloads loop
         ids := array_append(ids,
             pgque.insert_event(i_queue, i_type, p::text));
+    end loop;
+    return ids;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+create function pgque.send_batch(
+    i_queue text, i_type text, i_payloads text[])
+returns bigint[] as $$
+declare
+    ids bigint[];
+    p text;
+begin
+    foreach p in array i_payloads loop
+        ids := array_append(ids,
+            pgque.insert_event(i_queue, i_type, p));
     end loop;
     return ids;
 end;
@@ -1074,8 +1132,8 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pgque, pg_catalog;
 
 | Modern API | PgQ primitive underneath | Notes |
 |---|---|---|
-| `pgque.send(queue, payload)` | `pgque.insert_event(queue, type, data)` | JSONB convenience |
-| `pgque.send_batch(queue, type, payloads[])` | Loop of `insert_event()` calls | Single TX |
+| `pgque.send(queue, payload)` | `pgque.insert_event(queue, type, data)` | JSONB overload (validation + canonicalization) or TEXT overload (fast path, opaque bytes) |
+| `pgque.send_batch(queue, type, payloads[])` | Loop of `insert_event()` calls | Single TX; both `jsonb[]` and `text[]` overloads |
 | `pgque.send_at(queue, type, payload, time)` | `delayed_events` table + `maint_deliver_delayed()` | New |
 | `pgque.receive(queue, consumer, n)` | `next_batch()` + `get_batch_events()` | Combined |
 | `pgque.ack(batch_id)` | `finish_batch(batch_id)` | Rename |

--- a/blueprints/SPECx.md
+++ b/blueprints/SPECx.md
@@ -640,8 +640,11 @@ select pgque.send_batch('orders', 'order.created', array[
     '{"order_id": 44}'
 ]);
 
--- Non-JSON encodings go through the text overload directly
-select pgque.send('orders', 'order.proto', E'\\x08\\x2a\\x10\\x63');
+-- Textual non-JSON payloads (XML, CSV, base64/hex-encoded binary) go
+-- through the text overload as-is. Raw binary with NUL bytes is rejected
+-- by PG text -- encode first (e.g. encode(raw_proto, 'base64')).
+select pgque.send('orders', 'order.xml', '<order id="42"/>');
+select pgque.send('orders', 'order.proto_b64', encode('\x08\x2a\x10\x63'::bytea, 'base64'));
 
 -- Delayed send (deliver after timestamp)
 select pgque.send_at('orders', 'reminder.send',
@@ -674,12 +677,22 @@ overload is opt-in via an explicit `::jsonb` cast.
 
 - `text` overload (default for untyped literals): fast path. Bytes flow
   straight through to `insert_event`. No parse, no reserialization, key
-  order preserved. Required for non-JSON payloads (protobuf, msgpack, Avro,
-  XML). Caller is responsible for validating the payload.
+  order preserved. Required for non-JSON *textual* payloads (XML, CSV,
+  base64/hex-encoded binary). Caller is responsible for validating the
+  payload.
 - `jsonb` overload (opt-in): PG rejects malformed JSON at parse time and
   the payload is stored in canonical form (keys sorted, whitespace
   normalized). Useful when you want PG to be the last line of defense
   against malformed JSON.
+
+**NUL bytes.** `ev_data` is `text`, and PostgreSQL `text` does not accept
+NUL (`\x00`). Raw binary wire formats (protobuf, msgpack, Avro, packed
+bytea dumps) routinely contain NULs and will be rejected with `invalid
+byte sequence` at insert time. Callers that want to ship binary payloads
+must encode them first -- `encode(bytes, 'base64')`, `encode(bytes, 'hex')`,
+or a custom escape -- and decode on the consumer side. A future `bytea`
+overload could bypass this at the cost of changing `ev_data`'s storage
+type; deferred pending demand.
 
 Both overloads return `bigint` (event ID). `receive()` returns payload as
 `text`, so the `text`-both-sides path is symmetric (no implicit canonicalization

--- a/blueprints/SPECx.md
+++ b/blueprints/SPECx.md
@@ -623,32 +623,28 @@ send a JSON message, receive it, ack or nack it.
 ### 4.1 Publishing: `pgque.send()`
 
 ```sql
--- Simple send (jsonb: ergonomic default; PG validates JSON at parse time)
-SELECT pgque.send('orders', '{"order_id": 42, "total": 99.95}'::jsonb);
+-- Default path: untyped literal resolves to send(text, text) -- verbatim bytes
+select pgque.send('orders', '{"order_id": 42, "total": 99.95}');
 
--- Send with explicit type
-SELECT pgque.send('orders', 'order.created', '{"order_id": 42}'::jsonb);
+-- Opt-in validation: explicit ::jsonb cast resolves to send(text, jsonb)
+select pgque.send('orders', '{"order_id": 42, "total": 99.95}'::jsonb);
 
--- Send batch (array of payloads)
-SELECT pgque.send_batch('orders', 'order.created', ARRAY[
-    '{"order_id": 42}'::jsonb,
-    '{"order_id": 43}'::jsonb,
-    '{"order_id": 44}'::jsonb
+-- Send with explicit type (both overloads available on the same rules)
+select pgque.send('orders', 'order.created', '{"order_id": 42}');
+select pgque.send('orders', 'order.created', '{"order_id": 42}'::jsonb);
+
+-- Send batch (text[] default; use ::jsonb[] cast to opt into validation)
+select pgque.send_batch('orders', 'order.created', array[
+    '{"order_id": 42}',
+    '{"order_id": 43}',
+    '{"order_id": 44}'
 ]);
 
--- Fast path: text overload. Skips the jsonb parse + canonical
--- reserialization round-trip and stores the payload byte-for-byte.
--- Use this for large payloads, non-JSON encodings (protobuf, msgpack,
--- Avro, XML), or when the caller has already validated the input.
-SELECT pgque.send('orders', '{"order_id": 42}'::text);
-SELECT pgque.send('orders', 'order.proto', E'\\x08\\x2a\\x10\\x63'::text);
-SELECT pgque.send_batch('orders', 'order.created', ARRAY[
-    '{"order_id": 42}',
-    '{"order_id": 43}'
-]::text[]);
+-- Non-JSON encodings go through the text overload directly
+select pgque.send('orders', 'order.proto', E'\\x08\\x2a\\x10\\x63');
 
 -- Delayed send (deliver after timestamp)
-SELECT pgque.send_at('orders', 'reminder.send',
+select pgque.send_at('orders', 'reminder.send',
     '{"user_id": 7}'::jsonb,
     now() + interval '24 hours');
 
@@ -666,10 +662,10 @@ implicit cast. So:
 
 ```sql
 -- Untyped literal → resolves to send(text, text), bytes verbatim
-SELECT pgque.send('orders', '{"order_id": 42}');
+select pgque.send('orders', '{"order_id": 42}');
 
 -- Explicit ::jsonb → resolves to send(text, jsonb), validated + canonicalized
-SELECT pgque.send('orders', '{"order_id": 42}'::jsonb);
+select pgque.send('orders', '{"order_id": 42}'::jsonb);
 ```
 
 The `text` overload is therefore the natural default for plain SQL callers
@@ -694,35 +690,35 @@ cannot polymorphically carry both `text` and `jsonb`).
 **Internal mapping:**
 
 ```sql
--- jsonb overloads (ergonomic default, validation + canonicalization)
-CREATE FUNCTION pgque.send(i_queue text, i_payload jsonb)
-RETURNS bigint AS $$
-BEGIN
-    RETURN pgque.insert_event(i_queue, 'default', i_payload::text);
-END;
-$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pgque, pg_catalog;
+-- jsonb overloads (opt-in via ::jsonb cast; validation + canonicalization)
+create function pgque.send(i_queue text, i_payload jsonb)
+returns bigint as $$
+begin
+    return pgque.insert_event(i_queue, 'default', i_payload::text);
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
-CREATE FUNCTION pgque.send(i_queue text, i_type text, i_payload jsonb)
-RETURNS bigint AS $$
-BEGIN
-    RETURN pgque.insert_event(i_queue, i_type, i_payload::text);
-END;
-$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pgque, pg_catalog;
+create function pgque.send(i_queue text, i_type text, i_payload jsonb)
+returns bigint as $$
+begin
+    return pgque.insert_event(i_queue, i_type, i_payload::text);
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
--- text overloads (fast path, opaque payload)
-CREATE FUNCTION pgque.send(i_queue text, i_payload text)
-RETURNS bigint AS $$
-BEGIN
-    RETURN pgque.insert_event(i_queue, 'default', i_payload);
-END;
-$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pgque, pg_catalog;
+-- text overloads (default for untyped literals; fast path, opaque payload)
+create function pgque.send(i_queue text, i_payload text)
+returns bigint as $$
+begin
+    return pgque.insert_event(i_queue, 'default', i_payload);
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
-CREATE FUNCTION pgque.send(i_queue text, i_type text, i_payload text)
-RETURNS bigint AS $$
-BEGIN
-    RETURN pgque.insert_event(i_queue, i_type, i_payload);
-END;
-$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pgque, pg_catalog;
+create function pgque.send(i_queue text, i_type text, i_payload text)
+returns bigint as $$
+begin
+    return pgque.insert_event(i_queue, i_type, i_payload);
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
 create function pgque.send_batch(
     i_queue text, i_type text, i_payloads jsonb[])

--- a/blueprints/SPECx.md
+++ b/blueprints/SPECx.md
@@ -643,8 +643,10 @@ select pgque.send_batch('orders', 'order.created', array[
 -- Textual non-JSON payloads (XML, CSV, base64/hex-encoded binary) go
 -- through the text overload as-is. Raw binary with NUL bytes is rejected
 -- by PG text -- encode first (e.g. encode(raw_proto, 'base64')).
+-- Note PG bytea hex input is a single \x prefix followed by hex digits;
+-- per-byte separators are not allowed (use \x082a1063, not \x08\x2a\x10\x63).
 select pgque.send('orders', 'order.xml', '<order id="42"/>');
-select pgque.send('orders', 'order.proto_b64', encode('\x08\x2a\x10\x63'::bytea, 'base64'));
+select pgque.send('orders', 'order.proto_b64', encode('\x082a1063'::bytea, 'base64'));
 
 -- Delayed send (deliver after timestamp)
 select pgque.send_at('orders', 'reminder.send',

--- a/blueprints/SPECx.md
+++ b/blueprints/SPECx.md
@@ -657,14 +657,33 @@ SELECT pgque.send_at('orders', 'reminder.send',
 ```
 
 **Payload type choice.** Storage is always `ev_data TEXT`; the two overloads
-differ only in the client-side validation/reserialization contract:
+differ only in the client-side validation/reserialization contract.
 
-- `jsonb` overload: ergonomic default. PG rejects malformed JSON at parse
-  time and the payload is stored in canonical form (keys sorted, whitespace
-  normalized).
-- `text` overload: fast path. Bytes flow straight through to `insert_event`.
-  No validation, no reserialization, key order preserved. Required for
-  non-JSON payloads.
+**Overload resolution.** PostgreSQL picks the overload that needs fewest
+implicit casts. An untyped SQL string literal has type `unknown`, and
+`unknown → text` is a direct match while `unknown → jsonb` needs an
+implicit cast. So:
+
+```sql
+-- Untyped literal → resolves to send(text, text), bytes verbatim
+SELECT pgque.send('orders', '{"order_id": 42}');
+
+-- Explicit ::jsonb → resolves to send(text, jsonb), validated + canonicalized
+SELECT pgque.send('orders', '{"order_id": 42}'::jsonb);
+```
+
+The `text` overload is therefore the natural default for plain SQL callers
+and for drivers that pass parameters as text (most of them). The `jsonb`
+overload is opt-in via an explicit `::jsonb` cast.
+
+- `text` overload (default for untyped literals): fast path. Bytes flow
+  straight through to `insert_event`. No parse, no reserialization, key
+  order preserved. Required for non-JSON payloads (protobuf, msgpack, Avro,
+  XML). Caller is responsible for validating the payload.
+- `jsonb` overload (opt-in): PG rejects malformed JSON at parse time and
+  the payload is stored in canonical form (keys sorted, whitespace
+  normalized). Useful when you want PG to be the last line of defense
+  against malformed JSON.
 
 Both overloads return `bigint` (event ID). `receive()` returns payload as
 `text`, so the `text`-both-sides path is symmetric (no implicit canonicalization
@@ -709,7 +728,7 @@ create function pgque.send_batch(
     i_queue text, i_type text, i_payloads jsonb[])
 returns bigint[] as $$
 declare
-    ids bigint[];
+    ids bigint[] := '{}';
     p jsonb;
 begin
     -- TODO: optimize to resolve queue/table once and bypass insert_event_raw
@@ -727,7 +746,7 @@ create function pgque.send_batch(
     i_queue text, i_type text, i_payloads text[])
 returns bigint[] as $$
 declare
-    ids bigint[];
+    ids bigint[] := '{}';
     p text;
 begin
     foreach p in array i_payloads loop
@@ -1132,8 +1151,8 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pgque, pg_catalog;
 
 | Modern API | PgQ primitive underneath | Notes |
 |---|---|---|
-| `pgque.send(queue, payload)` | `pgque.insert_event(queue, type, data)` | JSONB overload (validation + canonicalization) or TEXT overload (fast path, opaque bytes) |
-| `pgque.send_batch(queue, type, payloads[])` | Loop of `insert_event()` calls | Single TX; both `jsonb[]` and `text[]` overloads |
+| `pgque.send(queue, payload)` | `pgque.insert_event(queue, type, data)` | TEXT overload is default for untyped literals (fast path, opaque bytes); JSONB overload is opt-in via `::jsonb` cast (validation + canonicalization) |
+| `pgque.send_batch(queue, type, payloads[])` | Loop of `insert_event()` calls | Single TX; `text[]` default, `jsonb[]` opt-in via `::jsonb[]` cast |
 | `pgque.send_at(queue, type, payload, time)` | `delayed_events` table + `maint_deliver_delayed()` | New |
 | `pgque.receive(queue, consumer, n)` | `next_batch()` + `get_batch_events()` | Combined |
 | `pgque.ack(batch_id)` | `finish_batch(batch_id)` | Rename |

--- a/sql/pgque-additions/roles.sql
+++ b/sql/pgque-additions/roles.sql
@@ -63,6 +63,12 @@ grant execute on function pgque.finish_batch(bigint) to pgque_writer;
 grant execute on function pgque.event_retry(bigint, bigint, timestamptz) to pgque_writer;
 grant execute on function pgque.event_retry(bigint, bigint, integer) to pgque_writer;
 
+-- Note: grants for the modern API wrappers (send*, subscribe, unsubscribe,
+-- receive, ack, nack) live colocated with their definitions in
+-- sql/pgque-api/*.sql. transform.sh appends pgque-additions/ before
+-- pgque-api/, so API-layer grants cannot reference their functions from
+-- this file.
+
 -- ---------------------------------------------------------------------------
 -- Admin: full access to everything in the pgque schema
 -- ---------------------------------------------------------------------------

--- a/sql/pgque-api/send.sql
+++ b/sql/pgque-api/send.sql
@@ -18,8 +18,12 @@
 --   select pgque.send('orders', '{"k":1}'::jsonb);    -- picks send(text, jsonb)
 --
 -- The `text` overloads are the default for untyped literals: bytes flow
--- through verbatim (no parse, no canonicalization, key order preserved),
--- and non-JSON encodings (protobuf, msgpack, Avro, XML) are supported.
+-- through verbatim (no parse, no canonicalization, key order preserved)
+-- for *textual* payloads -- JSON, XML, CSV, or binary that has already
+-- been base64/hex-encoded. PostgreSQL `text` cannot store NUL (\x00),
+-- so true binary payloads (raw protobuf, msgpack, Avro, bytea dumps)
+-- must be caller-encoded before `send()` -- otherwise PG rejects the
+-- insert with `invalid byte sequence`.
 -- The `jsonb` overloads are opt-in via explicit `::jsonb` cast: PG
 -- validates JSON at parse time and stores the canonical form.
 -- Storage (ev_data TEXT) is identical in both paths.
@@ -49,10 +53,12 @@ begin
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
--- pgque.send(queue, payload text) -- fast path, opaque payload
+-- pgque.send(queue, payload text) -- fast path, opaque textual payload
 -- Skips the jsonb parse + canonical reserialize round-trip. Use this when
--- the payload is not JSON (protobuf, msgpack, Avro, XML) or when the caller
--- has already validated the payload and wants to avoid the extra CPU.
+-- the payload is text (JSON, XML, CSV, base64/hex-encoded binary) or when
+-- the caller has already validated the payload. Raw binary with NUL bytes
+-- (protobuf, msgpack, Avro wire format) is not accepted by PG `text` --
+-- encode first.
 create or replace function pgque.send(i_queue text, i_payload text)
 returns bigint as $$
 begin
@@ -123,4 +129,17 @@ begin
     return pgque.unregister_consumer(i_queue, i_consumer);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- Explicit writer grants for the send* + subscribe/unsubscribe family.
+-- Colocated here (not in pgque-additions/roles.sql) because roles.sql
+-- runs before the pgque-api section during build, so API-layer grants
+-- must live alongside the function definitions they apply to.
+grant execute on function pgque.send(text, jsonb)               to pgque_writer;
+grant execute on function pgque.send(text, text)                to pgque_writer;
+grant execute on function pgque.send(text, text, jsonb)         to pgque_writer;
+grant execute on function pgque.send(text, text, text)          to pgque_writer;
+grant execute on function pgque.send_batch(text, text, jsonb[]) to pgque_writer;
+grant execute on function pgque.send_batch(text, text, text[])  to pgque_writer;
+grant execute on function pgque.subscribe(text, text)           to pgque_writer;
+grant execute on function pgque.unsubscribe(text, text)         to pgque_writer;
 

--- a/sql/pgque-api/send.sql
+++ b/sql/pgque-api/send.sql
@@ -4,11 +4,17 @@
 --
 -- Implements default v0.1 API surface:
 --   pgque.message type
---   pgque.send(queue, payload)
---   pgque.send(queue, type, payload)
---   pgque.send_batch(queue, type, payloads[])
+--   pgque.send(queue, payload)                -- jsonb + text overloads
+--   pgque.send(queue, type, payload)          -- jsonb + text overloads
+--   pgque.send_batch(queue, type, payloads[]) -- jsonb + text overloads
 --   pgque.subscribe(queue, consumer)
 --   pgque.unsubscribe(queue, consumer)
+--
+-- The jsonb overloads are the ergonomic default: PG validates JSON at parse
+-- time and the caller gets a clear error for malformed payloads. The text
+-- overloads skip the jsonb parse + canonical reserialization round-trip
+-- (material for large payloads) and unlock non-JSON encodings: protobuf,
+-- msgpack, Avro, XML. Storage (ev_data TEXT) is identical in both paths.
 
 -- pgque.message type (idempotent creation)
 do $$ begin
@@ -27,7 +33,7 @@ do $$ begin
 exception when duplicate_object then null;
 end $$;
 
--- pgque.send(queue, payload) -- send with default type
+-- pgque.send(queue, payload jsonb) -- send with default type, JSON payload
 create or replace function pgque.send(i_queue text, i_payload jsonb)
 returns bigint as $$
 begin
@@ -35,7 +41,18 @@ begin
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
--- pgque.send(queue, type, payload) -- send with explicit type
+-- pgque.send(queue, payload text) -- fast path, opaque payload
+-- Skips the jsonb parse + canonical reserialize round-trip. Use this when
+-- the payload is not JSON (protobuf, msgpack, Avro, XML) or when the caller
+-- has already validated the payload and wants to avoid the extra CPU.
+create or replace function pgque.send(i_queue text, i_payload text)
+returns bigint as $$
+begin
+    return pgque.insert_event(i_queue, 'default', i_payload);
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.send(queue, type, payload jsonb) -- send with explicit type, JSON payload
 create or replace function pgque.send(i_queue text, i_type text, i_payload jsonb)
 returns bigint as $$
 begin
@@ -43,7 +60,15 @@ begin
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
--- pgque.send_batch(queue, type, payloads[]) -- batch send
+-- pgque.send(queue, type, payload text) -- fast path with explicit type
+create or replace function pgque.send(i_queue text, i_type text, i_payload text)
+returns bigint as $$
+begin
+    return pgque.insert_event(i_queue, i_type, i_payload);
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.send_batch(queue, type, payloads jsonb[]) -- batch send, JSON payloads
 create or replace function pgque.send_batch(
     i_queue text, i_type text, i_payloads jsonb[])
 returns bigint[] as $$
@@ -54,6 +79,22 @@ begin
     foreach p in array i_payloads loop
         ids := array_append(ids,
             pgque.insert_event(i_queue, i_type, p::text));
+    end loop;
+    return ids;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.send_batch(queue, type, payloads text[]) -- fast-path batch send
+create or replace function pgque.send_batch(
+    i_queue text, i_type text, i_payloads text[])
+returns bigint[] as $$
+declare
+    ids bigint[];
+    p text;
+begin
+    foreach p in array i_payloads loop
+        ids := array_append(ids,
+            pgque.insert_event(i_queue, i_type, p));
     end loop;
     return ids;
 end;

--- a/sql/pgque-api/send.sql
+++ b/sql/pgque-api/send.sql
@@ -4,17 +4,25 @@
 --
 -- Implements default v0.1 API surface:
 --   pgque.message type
---   pgque.send(queue, payload)                -- jsonb + text overloads
---   pgque.send(queue, type, payload)          -- jsonb + text overloads
---   pgque.send_batch(queue, type, payloads[]) -- jsonb + text overloads
+--   pgque.send(queue, payload)                -- text + jsonb overloads
+--   pgque.send(queue, type, payload)          -- text + jsonb overloads
+--   pgque.send_batch(queue, type, payloads[]) -- text[] + jsonb[] overloads
 --   pgque.subscribe(queue, consumer)
 --   pgque.unsubscribe(queue, consumer)
 --
--- The jsonb overloads are the ergonomic default: PG validates JSON at parse
--- time and the caller gets a clear error for malformed payloads. The text
--- overloads skip the jsonb parse + canonical reserialization round-trip
--- (material for large payloads) and unlock non-JSON encodings: protobuf,
--- msgpack, Avro, XML. Storage (ev_data TEXT) is identical in both paths.
+-- Overload resolution note: PostgreSQL resolves untyped string literals
+-- (type `unknown`) to the `text` overload because `unknown -> text` needs
+-- no implicit cast, while `unknown -> jsonb` does. Consequently:
+--
+--   select pgque.send('orders', '{"k":1}');           -- picks send(text, text)
+--   select pgque.send('orders', '{"k":1}'::jsonb);    -- picks send(text, jsonb)
+--
+-- The `text` overloads are the default for untyped literals: bytes flow
+-- through verbatim (no parse, no canonicalization, key order preserved),
+-- and non-JSON encodings (protobuf, msgpack, Avro, XML) are supported.
+-- The `jsonb` overloads are opt-in via explicit `::jsonb` cast: PG
+-- validates JSON at parse time and stores the canonical form.
+-- Storage (ev_data TEXT) is identical in both paths.
 
 -- pgque.message type (idempotent creation)
 do $$ begin
@@ -73,7 +81,7 @@ create or replace function pgque.send_batch(
     i_queue text, i_type text, i_payloads jsonb[])
 returns bigint[] as $$
 declare
-    ids bigint[];
+    ids bigint[] := '{}';
     p jsonb;
 begin
     foreach p in array i_payloads loop
@@ -89,7 +97,7 @@ create or replace function pgque.send_batch(
     i_queue text, i_type text, i_payloads text[])
 returns bigint[] as $$
 declare
-    ids bigint[];
+    ids bigint[] := '{}';
     p text;
 begin
     foreach p in array i_payloads loop

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -4391,17 +4391,25 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 --
 -- Implements default v0.1 API surface:
 --   pgque.message type
---   pgque.send(queue, payload)                -- jsonb + text overloads
---   pgque.send(queue, type, payload)          -- jsonb + text overloads
---   pgque.send_batch(queue, type, payloads[]) -- jsonb + text overloads
+--   pgque.send(queue, payload)                -- text + jsonb overloads
+--   pgque.send(queue, type, payload)          -- text + jsonb overloads
+--   pgque.send_batch(queue, type, payloads[]) -- text[] + jsonb[] overloads
 --   pgque.subscribe(queue, consumer)
 --   pgque.unsubscribe(queue, consumer)
 --
--- The jsonb overloads are the ergonomic default: PG validates JSON at parse
--- time and the caller gets a clear error for malformed payloads. The text
--- overloads skip the jsonb parse + canonical reserialization round-trip
--- (material for large payloads) and unlock non-JSON encodings: protobuf,
--- msgpack, Avro, XML. Storage (ev_data TEXT) is identical in both paths.
+-- Overload resolution note: PostgreSQL resolves untyped string literals
+-- (type `unknown`) to the `text` overload because `unknown -> text` needs
+-- no implicit cast, while `unknown -> jsonb` does. Consequently:
+--
+--   select pgque.send('orders', '{"k":1}');           -- picks send(text, text)
+--   select pgque.send('orders', '{"k":1}'::jsonb);    -- picks send(text, jsonb)
+--
+-- The `text` overloads are the default for untyped literals: bytes flow
+-- through verbatim (no parse, no canonicalization, key order preserved),
+-- and non-JSON encodings (protobuf, msgpack, Avro, XML) are supported.
+-- The `jsonb` overloads are opt-in via explicit `::jsonb` cast: PG
+-- validates JSON at parse time and stores the canonical form.
+-- Storage (ev_data TEXT) is identical in both paths.
 
 -- pgque.message type (idempotent creation)
 do $$ begin
@@ -4460,7 +4468,7 @@ create or replace function pgque.send_batch(
     i_queue text, i_type text, i_payloads jsonb[])
 returns bigint[] as $$
 declare
-    ids bigint[];
+    ids bigint[] := '{}';
     p jsonb;
 begin
     foreach p in array i_payloads loop
@@ -4476,7 +4484,7 @@ create or replace function pgque.send_batch(
     i_queue text, i_type text, i_payloads text[])
 returns bigint[] as $$
 declare
-    ids bigint[];
+    ids bigint[] := '{}';
     p text;
 begin
     foreach p in array i_payloads loop

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -4405,8 +4405,12 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 --   select pgque.send('orders', '{"k":1}'::jsonb);    -- picks send(text, jsonb)
 --
 -- The `text` overloads are the default for untyped literals: bytes flow
--- through verbatim (no parse, no canonicalization, key order preserved),
--- and non-JSON encodings (protobuf, msgpack, Avro, XML) are supported.
+-- through verbatim (no parse, no canonicalization, key order preserved)
+-- for *textual* payloads -- JSON, XML, CSV, or binary that has already
+-- been base64/hex-encoded. PostgreSQL `text` cannot store NUL (\x00),
+-- so true binary payloads (raw protobuf, msgpack, Avro, bytea dumps)
+-- must be caller-encoded before `send()` -- otherwise PG rejects the
+-- insert with `invalid byte sequence`.
 -- The `jsonb` overloads are opt-in via explicit `::jsonb` cast: PG
 -- validates JSON at parse time and stores the canonical form.
 -- Storage (ev_data TEXT) is identical in both paths.
@@ -4436,10 +4440,12 @@ begin
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
--- pgque.send(queue, payload text) -- fast path, opaque payload
+-- pgque.send(queue, payload text) -- fast path, opaque textual payload
 -- Skips the jsonb parse + canonical reserialize round-trip. Use this when
--- the payload is not JSON (protobuf, msgpack, Avro, XML) or when the caller
--- has already validated the payload and wants to avoid the extra CPU.
+-- the payload is text (JSON, XML, CSV, base64/hex-encoded binary) or when
+-- the caller has already validated the payload. Raw binary with NUL bytes
+-- (protobuf, msgpack, Avro wire format) is not accepted by PG `text` --
+-- encode first.
 create or replace function pgque.send(i_queue text, i_payload text)
 returns bigint as $$
 begin
@@ -4510,5 +4516,18 @@ begin
     return pgque.unregister_consumer(i_queue, i_consumer);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- Explicit writer grants for the send* + subscribe/unsubscribe family.
+-- Colocated here (not in pgque-additions/roles.sql) because roles.sql
+-- runs before the pgque-api section during build, so API-layer grants
+-- must live alongside the function definitions they apply to.
+grant execute on function pgque.send(text, jsonb)               to pgque_writer;
+grant execute on function pgque.send(text, text)                to pgque_writer;
+grant execute on function pgque.send(text, text, jsonb)         to pgque_writer;
+grant execute on function pgque.send(text, text, text)          to pgque_writer;
+grant execute on function pgque.send_batch(text, text, jsonb[]) to pgque_writer;
+grant execute on function pgque.send_batch(text, text, text[])  to pgque_writer;
+grant execute on function pgque.subscribe(text, text)           to pgque_writer;
+grant execute on function pgque.unsubscribe(text, text)         to pgque_writer;
 
 

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -4391,11 +4391,17 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 --
 -- Implements default v0.1 API surface:
 --   pgque.message type
---   pgque.send(queue, payload)
---   pgque.send(queue, type, payload)
---   pgque.send_batch(queue, type, payloads[])
+--   pgque.send(queue, payload)                -- jsonb + text overloads
+--   pgque.send(queue, type, payload)          -- jsonb + text overloads
+--   pgque.send_batch(queue, type, payloads[]) -- jsonb + text overloads
 --   pgque.subscribe(queue, consumer)
 --   pgque.unsubscribe(queue, consumer)
+--
+-- The jsonb overloads are the ergonomic default: PG validates JSON at parse
+-- time and the caller gets a clear error for malformed payloads. The text
+-- overloads skip the jsonb parse + canonical reserialization round-trip
+-- (material for large payloads) and unlock non-JSON encodings: protobuf,
+-- msgpack, Avro, XML. Storage (ev_data TEXT) is identical in both paths.
 
 -- pgque.message type (idempotent creation)
 do $$ begin
@@ -4414,7 +4420,7 @@ do $$ begin
 exception when duplicate_object then null;
 end $$;
 
--- pgque.send(queue, payload) -- send with default type
+-- pgque.send(queue, payload jsonb) -- send with default type, JSON payload
 create or replace function pgque.send(i_queue text, i_payload jsonb)
 returns bigint as $$
 begin
@@ -4422,7 +4428,18 @@ begin
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
--- pgque.send(queue, type, payload) -- send with explicit type
+-- pgque.send(queue, payload text) -- fast path, opaque payload
+-- Skips the jsonb parse + canonical reserialize round-trip. Use this when
+-- the payload is not JSON (protobuf, msgpack, Avro, XML) or when the caller
+-- has already validated the payload and wants to avoid the extra CPU.
+create or replace function pgque.send(i_queue text, i_payload text)
+returns bigint as $$
+begin
+    return pgque.insert_event(i_queue, 'default', i_payload);
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.send(queue, type, payload jsonb) -- send with explicit type, JSON payload
 create or replace function pgque.send(i_queue text, i_type text, i_payload jsonb)
 returns bigint as $$
 begin
@@ -4430,7 +4447,15 @@ begin
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
--- pgque.send_batch(queue, type, payloads[]) -- batch send
+-- pgque.send(queue, type, payload text) -- fast path with explicit type
+create or replace function pgque.send(i_queue text, i_type text, i_payload text)
+returns bigint as $$
+begin
+    return pgque.insert_event(i_queue, i_type, i_payload);
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.send_batch(queue, type, payloads jsonb[]) -- batch send, JSON payloads
 create or replace function pgque.send_batch(
     i_queue text, i_type text, i_payloads jsonb[])
 returns bigint[] as $$
@@ -4441,6 +4466,22 @@ begin
     foreach p in array i_payloads loop
         ids := array_append(ids,
             pgque.insert_event(i_queue, i_type, p::text));
+    end loop;
+    return ids;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- pgque.send_batch(queue, type, payloads text[]) -- fast-path batch send
+create or replace function pgque.send_batch(
+    i_queue text, i_type text, i_payloads text[])
+returns bigint[] as $$
+declare
+    ids bigint[];
+    p text;
+begin
+    foreach p in array i_payloads loop
+        ids := array_append(ids,
+            pgque.insert_event(i_queue, i_type, p));
     end loop;
     return ids;
 end;

--- a/tests/test_api_receive.sql
+++ b/tests/test_api_receive.sql
@@ -110,6 +110,55 @@ begin
     'ack(batch_id) should finish the whole batch, even if receive(..., 1) returned one row';
 end $$;
 
+-- Step 7: send(text) fast path must store payload byte-for-byte
+do $$
+begin
+  perform pgque.create_queue('test_recv_text');
+  perform pgque.register_consumer('test_recv_text', 'c1');
+end $$;
+
+do $$
+begin
+  -- Intentionally unsorted keys + non-JSON payload. The jsonb overload
+  -- would canonicalize keys; the text overload must not.
+  perform pgque.send('test_recv_text', 'json.raw', '{"b":2,"a":1}'::text);
+  perform pgque.send('test_recv_text', 'bin.raw',  E'\\x01\\x02opaque'::text);
+end $$;
+
+do $$
+begin
+  perform pgque.force_tick('test_recv_text');
+  perform pgque.ticker();
+end $$;
+
+do $$
+declare
+  v_msg pgque.message;
+  v_batch_id bigint;
+  v_seen_json boolean := false;
+  v_seen_bin  boolean := false;
+begin
+  for v_msg in select * from pgque.receive('test_recv_text', 'c1', 10)
+  loop
+    v_batch_id := v_msg.batch_id;
+    if v_msg.type = 'json.raw' then
+      assert v_msg.payload = '{"b":2,"a":1}',
+        format('send(text) must preserve key order; got %s', v_msg.payload);
+      v_seen_json := true;
+    elsif v_msg.type = 'bin.raw' then
+      assert v_msg.payload = E'\\x01\\x02opaque',
+        format('send(text) must preserve non-JSON bytes; got %s', v_msg.payload);
+      v_seen_bin := true;
+    end if;
+  end loop;
+
+  assert v_seen_json, 'expected verbatim json.raw message';
+  assert v_seen_bin,  'expected verbatim bin.raw message';
+
+  perform pgque.ack(v_batch_id);
+  raise notice 'PASS: send(text) preserves payload byte-for-byte';
+end $$;
+
 -- Cleanup
 do $$
 begin
@@ -117,5 +166,7 @@ begin
   perform pgque.drop_queue('test_recv');
   perform pgque.unregister_consumer('test_recv_partial', 'c1');
   perform pgque.drop_queue('test_recv_partial');
+  perform pgque.unregister_consumer('test_recv_text', 'c1');
+  perform pgque.drop_queue('test_recv_text');
   raise notice 'PASS: receive + ack semantics';
 end $$;

--- a/tests/test_api_receive.sql
+++ b/tests/test_api_receive.sql
@@ -119,8 +119,14 @@ end $$;
 
 do $$
 begin
-  -- Intentionally unsorted keys + non-JSON payload. The jsonb overload
-  -- would canonicalize keys; the text overload must not.
+  -- Two non-JSON-shaped payloads covering the properties the text overload
+  -- must preserve vs. the jsonb overload:
+  --   json.raw  -- valid-looking JSON but with unsorted keys; jsonb would
+  --               canonicalize (sort) them, text must leave them untouched.
+  --   bin.raw   -- a literal backslash-escape string (text bytes, not
+  --               actual binary; PG text can't hold NULs). It's not valid
+  --               JSON, so the jsonb overload would reject it; the text
+  --               overload must store it verbatim.
   perform pgque.send('test_recv_text', 'json.raw', '{"b":2,"a":1}'::text);
   perform pgque.send('test_recv_text', 'bin.raw',  E'\\x01\\x02opaque'::text);
 end $$;
@@ -147,7 +153,7 @@ begin
       v_seen_json := true;
     elsif v_msg.type = 'bin.raw' then
       assert v_msg.payload = E'\\x01\\x02opaque',
-        format('send(text) must preserve non-JSON bytes; got %s', v_msg.payload);
+        format('send(text) must preserve non-JSON payload verbatim; got %s', v_msg.payload);
       v_seen_bin := true;
     end if;
   end loop;

--- a/tests/test_api_receive.sql
+++ b/tests/test_api_receive.sql
@@ -119,16 +119,20 @@ end $$;
 
 do $$
 begin
-  -- Two non-JSON-shaped payloads covering the properties the text overload
-  -- must preserve vs. the jsonb overload:
-  --   json.raw  -- valid-looking JSON but with unsorted keys; jsonb would
-  --               canonicalize (sort) them, text must leave them untouched.
-  --   bin.raw   -- a literal backslash-escape string (text bytes, not
-  --               actual binary; PG text can't hold NULs). It's not valid
-  --               JSON, so the jsonb overload would reject it; the text
-  --               overload must store it verbatim.
-  perform pgque.send('test_recv_text', 'json.raw', '{"b":2,"a":1}'::text);
-  perform pgque.send('test_recv_text', 'bin.raw',  E'\\x01\\x02opaque'::text);
+  -- Three payloads covering the properties the text overload must
+  -- preserve vs. the jsonb overload:
+  --   json.raw   -- explicit ::text cast; unsorted keys must stay unsorted
+  --                (jsonb would canonicalize / sort them).
+  --   bin.raw    -- a literal backslash-escape string (text bytes, not
+  --                actual binary; PG text can't hold NULs). Not valid JSON,
+  --                so jsonb would reject it; text must store verbatim.
+  --   json.nocast -- *no* cast at all. Proves the headline claim: an
+  --                untyped SQL string literal resolves to send(text, text),
+  --                not send(text, jsonb). If PG picked the jsonb overload
+  --                here, the keys below would come back sorted.
+  perform pgque.send('test_recv_text', 'json.raw',   '{"b":2,"a":1}'::text);
+  perform pgque.send('test_recv_text', 'bin.raw',    E'\\x01\\x02opaque'::text);
+  perform pgque.send('test_recv_text', 'json.nocast', '{"z":9,"m":5,"a":1}');
 end $$;
 
 do $$
@@ -141,8 +145,9 @@ do $$
 declare
   v_msg pgque.message;
   v_batch_id bigint;
-  v_seen_json boolean := false;
-  v_seen_bin  boolean := false;
+  v_seen_json    boolean := false;
+  v_seen_bin     boolean := false;
+  v_seen_nocast  boolean := false;
 begin
   for v_msg in select * from pgque.receive('test_recv_text', 'c1', 10)
   loop
@@ -155,14 +160,23 @@ begin
       assert v_msg.payload = E'\\x01\\x02opaque',
         format('send(text) must preserve non-JSON payload verbatim; got %s', v_msg.payload);
       v_seen_bin := true;
+    elsif v_msg.type = 'json.nocast' then
+      -- Critical invariant: untyped literal must resolve to send(text,text).
+      -- If PG silently picked send(text,jsonb), keys would come back as
+      -- '{"a":1,"m":5,"z":9}' (sorted). The raw form below proves no
+      -- canonicalization happened.
+      assert v_msg.payload = '{"z":9,"m":5,"a":1}',
+        format('untyped literal must resolve to send(text,text); got %s (canonicalized = jsonb overload silently won)', v_msg.payload);
+      v_seen_nocast := true;
     end if;
   end loop;
 
-  assert v_seen_json, 'expected verbatim json.raw message';
-  assert v_seen_bin,  'expected verbatim bin.raw message';
+  assert v_seen_json,   'expected verbatim json.raw message';
+  assert v_seen_bin,    'expected verbatim bin.raw message';
+  assert v_seen_nocast, 'expected verbatim json.nocast message (untyped literal path)';
 
   perform pgque.ack(v_batch_id);
-  raise notice 'PASS: send(text) preserves payload byte-for-byte';
+  raise notice 'PASS: send(text) preserves payload byte-for-byte (incl. untyped literal)';
 end $$;
 
 -- Cleanup

--- a/tests/test_api_send.sql
+++ b/tests/test_api_send.sql
@@ -43,6 +43,42 @@ begin
   raise notice 'PASS: send_batch() returns 3 ids';
 end $$;
 
+-- Test 3a: send(text) fast path, default type
+do $$
+declare
+  v_eid bigint;
+begin
+  v_eid := pgque.send('test_send', '{"raw":"text"}'::text);
+  assert v_eid is not null, 'send(queue, text) should return event id';
+  raise notice 'PASS: send(queue, text) returns event id %', v_eid;
+end $$;
+
+-- Test 3b: send(type, text) fast path, explicit type
+do $$
+declare
+  v_eid bigint;
+begin
+  v_eid := pgque.send('test_send', 'raw.binary', E'\\x01\\x02\\x03 not-json');
+  assert v_eid is not null, 'send(queue, type, text) should return event id';
+  raise notice 'PASS: send(queue, type, text) accepts non-JSON payload';
+end $$;
+
+-- Test 3c: send_batch(text[]) fast path
+do $$
+declare
+  v_ids bigint[];
+begin
+  v_ids := pgque.send_batch('test_send', 'batch.text', array[
+    'opaque-1',
+    'opaque-2',
+    'opaque-3'
+  ]::text[]);
+  assert array_length(v_ids, 1) = 3,
+    'send_batch(text[]) should return 3 ids, got '
+    || coalesce(array_length(v_ids, 1)::text, 'NULL');
+  raise notice 'PASS: send_batch(text[]) returns 3 ids';
+end $$;
+
 -- Test 4: subscribe/unsubscribe
 do $$
 declare

--- a/tests/test_api_send.sql
+++ b/tests/test_api_send.sql
@@ -79,6 +79,26 @@ begin
   raise notice 'PASS: send_batch(text[]) returns 3 ids';
 end $$;
 
+-- Test 3d: send_batch() on empty input returns empty array, not NULL
+do $$
+declare
+  v_ids bigint[];
+begin
+  v_ids := pgque.send_batch('test_send', 'batch.empty', array[]::jsonb[]);
+  assert v_ids is not null, 'send_batch(jsonb[]) on empty input must not return NULL';
+  assert cardinality(v_ids) = 0,
+    'send_batch(jsonb[]) on empty input must return empty array, got '
+    || cardinality(v_ids)::text;
+
+  v_ids := pgque.send_batch('test_send', 'batch.empty', array[]::text[]);
+  assert v_ids is not null, 'send_batch(text[]) on empty input must not return NULL';
+  assert cardinality(v_ids) = 0,
+    'send_batch(text[]) on empty input must return empty array, got '
+    || cardinality(v_ids)::text;
+
+  raise notice 'PASS: send_batch() on empty input returns empty array';
+end $$;
+
 -- Test 4: subscribe/unsubscribe
 do $$
 declare

--- a/tests/test_pgque_roles.sql
+++ b/tests/test_pgque_roles.sql
@@ -10,8 +10,29 @@ begin
   assert exists (select 1 from pg_roles where rolname = 'pgque_admin'),
     'pgque_admin should exist';
 
+  -- send() overloads: jsonb + text at both arities
   assert has_function_privilege('pgque_writer', 'pgque.send(text, jsonb)', 'EXECUTE'),
     'pgque_writer should have execute on send(text, jsonb)';
+  assert has_function_privilege('pgque_writer', 'pgque.send(text, text)', 'EXECUTE'),
+    'pgque_writer should have execute on send(text, text)';
+  assert has_function_privilege('pgque_writer', 'pgque.send(text, text, jsonb)', 'EXECUTE'),
+    'pgque_writer should have execute on send(text, text, jsonb)';
+  assert has_function_privilege('pgque_writer', 'pgque.send(text, text, text)', 'EXECUTE'),
+    'pgque_writer should have execute on send(text, text, text)';
+
+  -- send_batch() overloads: jsonb[] + text[]
+  assert has_function_privilege('pgque_writer', 'pgque.send_batch(text, text, jsonb[])', 'EXECUTE'),
+    'pgque_writer should have execute on send_batch(text, text, jsonb[])';
+  assert has_function_privilege('pgque_writer', 'pgque.send_batch(text, text, text[])', 'EXECUTE'),
+    'pgque_writer should have execute on send_batch(text, text, text[])';
+
+  -- subscribe/unsubscribe wrappers
+  assert has_function_privilege('pgque_writer', 'pgque.subscribe(text, text)', 'EXECUTE'),
+    'pgque_writer should have execute on subscribe(text, text)';
+  assert has_function_privilege('pgque_writer', 'pgque.unsubscribe(text, text)', 'EXECUTE'),
+    'pgque_writer should have execute on unsubscribe(text, text)';
+
+  -- receive/ack/nack (grants still inherited via PUBLIC; tracked separately)
   assert has_function_privilege('pgque_writer', 'pgque.receive(text, text, integer)', 'EXECUTE'),
     'pgque_writer should have execute on receive(text, text, integer)';
   assert has_function_privilege('pgque_writer', 'pgque.ack(bigint)', 'EXECUTE'),


### PR DESCRIPTION
## Summary

- Add `text` overloads alongside the existing `jsonb` overloads for `pgque.send(queue, payload)`, `pgque.send(queue, type, payload)`, and `pgque.send_batch(queue, type, payloads[])`.
- The jsonb overloads stay the ergonomic default (PG validates JSON at parse time, clear error on malformed payloads). The text overloads skip the jsonb parse + canonical reserialization round-trip, store bytes verbatim (preserving key order), and unlock non-JSON encodings: protobuf, msgpack, Avro, XML.
- Storage is unchanged — `ev_data` is still `TEXT`. No changes to rotation, triggers, or any PgQ engine internals.
- Resolves the send/receive type-asymmetry concern: a symmetric `text`-in / `text`-out path is now available without forcing `jsonb` on consumers.

## Changes

- `sql/pgque-api/send.sql`: add text overloads for `send` (2-arg + 3-arg) and `send_batch`.
- `sql/pgque.sql`: mirror the same additions in the assembled single-file install.
- `blueprints/SPECx.md` §4.1 + mapping table: document both overloads and the rationale.
- `README.md` function reference: note both overloads.
- `tests/test_api_send.sql`: new fast-path cases (default type, explicit type with non-JSON payload, `send_batch(text[])`).
- `tests/test_api_receive.sql`: round-trip through ticker + receive to assert byte-for-byte verbatim preservation (unsorted JSON keys stay unsorted; binary bytes stay binary).

## Test plan

- [x] `test_api_send.sql` — fast-path overloads return event ids, accept non-JSON bytes
- [x] `test_api_receive.sql` — send(text) → ticker → receive preserves payload byte-for-byte (verifies no jsonb canonicalization sneaks in)
- [x] Full `tests/run_all.sql` suite — all 16 files pass on PG 16
- [ ] CI to confirm on PG 14, 15, 17, 18