### PR TITLE
fix: grant execute on pgque.receive/ack/nack to pgque_writer

### DIFF
--- a/sql/pgque-api/receive.sql
+++ b/sql/pgque-api/receive.sql
@@ -99,3 +99,14 @@ begin
     return 1;
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- ---------------------------------------------------------------------------
+-- Grants
+-- ---------------------------------------------------------------------------
+-- Colocated here (not in pgque-additions/roles.sql) because roles.sql is
+-- assembled before pgque-api/, so these functions do not yet exist when
+-- roles.sql runs. Same convention as sql/pgque-api/send.sql.
+
+grant execute on function pgque.receive(text, text, int)                      to pgque_writer;
+grant execute on function pgque.ack(bigint)                                   to pgque_writer;
+grant execute on function pgque.nack(bigint, pgque.message, interval, text)   to pgque_writer;

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -4225,6 +4225,12 @@ grant execute on function pgque.finish_batch(bigint) to pgque_writer;
 grant execute on function pgque.event_retry(bigint, bigint, timestamptz) to pgque_writer;
 grant execute on function pgque.event_retry(bigint, bigint, integer) to pgque_writer;
 
+-- Note: grants for the modern API wrappers (send*, subscribe, unsubscribe,
+-- receive, ack, nack) live colocated with their definitions in
+-- sql/pgque-api/*.sql. transform.sh appends pgque-additions/ before
+-- pgque-api/, so API-layer grants cannot reference their functions from
+-- this file.
+
 -- ---------------------------------------------------------------------------
 -- Admin: full access to everything in the pgque schema
 -- ---------------------------------------------------------------------------
@@ -4383,6 +4389,17 @@ begin
     return 1;
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- ---------------------------------------------------------------------------
+-- Grants
+-- ---------------------------------------------------------------------------
+-- Colocated here (not in pgque-additions/roles.sql) because roles.sql is
+-- assembled before pgque-api/, so these functions do not yet exist when
+-- roles.sql runs. Same convention as sql/pgque-api/send.sql.
+
+grant execute on function pgque.receive(text, text, int)                      to pgque_writer;
+grant execute on function pgque.ack(bigint)                                   to pgque_writer;
+grant execute on function pgque.nack(bigint, pgque.message, interval, text)   to pgque_writer;
 
 -- pgque-api/send.sql
 -- pgque-api/send.sql -- Modern send/subscribe API layer

--- a/tests/test_pgque_roles.sql
+++ b/tests/test_pgque_roles.sql
@@ -32,7 +32,8 @@ begin
   assert has_function_privilege('pgque_writer', 'pgque.unsubscribe(text, text)', 'EXECUTE'),
     'pgque_writer should have execute on unsubscribe(text, text)';
 
-  -- receive/ack/nack (grants still inherited via PUBLIC; tracked separately)
+  -- receive/ack/nack — explicit grants colocated with the function
+  -- definitions in sql/pgque-api/receive.sql (same convention as send.sql).
   assert has_function_privilege('pgque_writer', 'pgque.receive(text, text, integer)', 'EXECUTE'),
     'pgque_writer should have execute on receive(text, text, integer)';
   assert has_function_privilege('pgque_writer', 'pgque.ack(bigint)', 'EXECUTE'),


### PR DESCRIPTION
## Problem

`README.md` §"Roles and grants" claims that `pgque_writer` has execute privileges on `receive`, `ack`, and `nack`. `tests/test_pgque_roles.sql` also asserts it. But the grants were never explicit — those functions rely on PostgreSQL's default `PUBLIC execute`.

The role test passes today only because `pgque_writer` inherits `PUBLIC` privileges, not because of an explicit grant. Found during the v0.1 docs audit as a secondary issue behind the `nack()` / DLQ bug.

## Fix

Add three `grant execute` statements at the bottom of `sql/pgque-api/receive.sql`, matching the convention already used by `sql/pgque-api/send.sql` (grants colocated with function definitions, since the `pgque-api/` section is assembled after `roles.sql`):

\`\`\`sql
grant execute on function pgque.receive(text, text, int)                      to pgque_writer;
grant execute on function pgque.ack(bigint)                                   to pgque_writer;
grant execute on function pgque.nack(bigint, pgque.message, interval, text)   to pgque_writer;
\`\`\`

Also update the stale comment in \`tests/test_pgque_roles.sql\` — it previously said the grants were "inherited via PUBLIC; tracked separately", which is no longer true.

## Scope

- Does not revoke \`PUBLIC\` execute (consistent with the rest of the codebase — no function in \`pgque-additions/\` or \`pgque-api/\` revokes from PUBLIC explicitly).
- Does not change the role test's assertions; they already cover the intended surface.

## Test plan

- [x] \`build/transform.sh\` rebuilds \`sql/pgque.sql\` cleanly
- [x] Explicit grants appear at the bottom of \`sql/pgque.sql\`
- [ ] \`tests/test_pgque_roles.sql\` passes on PG 14–18 via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)