### PR TITLE
fix: revoke execute on pgque.uninstall() from PUBLIC

### DIFF
--- a/sql/pgque-additions/roles.sql
+++ b/sql/pgque-additions/roles.sql
@@ -77,5 +77,8 @@ grant all on all tables in schema pgque to pgque_admin;
 grant all on all sequences in schema pgque to pgque_admin;
 grant execute on all functions in schema pgque to pgque_admin;
 
--- uninstall() drops the entire schema — only superuser / schema owner should run it
+-- uninstall() drops the entire schema — only superuser / schema owner should run it.
+-- SECURITY DEFINER functions default to PUBLIC execute; revoke both PUBLIC and
+-- pgque_admin so the function really is superuser-only.
+revoke execute on function pgque.uninstall() from public;
 revoke execute on function pgque.uninstall() from pgque_admin;

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -4239,7 +4239,10 @@ grant all on all tables in schema pgque to pgque_admin;
 grant all on all sequences in schema pgque to pgque_admin;
 grant execute on all functions in schema pgque to pgque_admin;
 
--- uninstall() drops the entire schema — only superuser / schema owner should run it
+-- uninstall() drops the entire schema — only superuser / schema owner should run it.
+-- SECURITY DEFINER functions default to PUBLIC execute; revoke both PUBLIC and
+-- pgque_admin so the function really is superuser-only.
+revoke execute on function pgque.uninstall() from public;
 revoke execute on function pgque.uninstall() from pgque_admin;
 
 -- pgque-additions/dlq.sql

--- a/tests/test_pgque_roles.sql
+++ b/tests/test_pgque_roles.sql
@@ -41,5 +41,15 @@ begin
   assert has_function_privilege('pgque_writer', 'pgque.nack(bigint, pgque.message, interval, text)', 'EXECUTE'),
     'pgque_writer should have execute on nack(bigint, pgque.message, interval, text)';
 
+  -- uninstall() must be superuser-only: execute is revoked from both
+  -- pgque_admin and PUBLIC. Any non-superuser role (including pgque_admin,
+  -- pgque_writer, pgque_reader) should NOT be able to execute it.
+  assert not has_function_privilege('pgque_admin',  'pgque.uninstall()', 'EXECUTE'),
+    'pgque_admin should NOT have execute on uninstall() (revoked in roles.sql)';
+  assert not has_function_privilege('pgque_writer', 'pgque.uninstall()', 'EXECUTE'),
+    'pgque_writer should NOT have execute on uninstall() (inherits PUBLIC revoke)';
+  assert not has_function_privilege('pgque_reader', 'pgque.uninstall()', 'EXECUTE'),
+    'pgque_reader should NOT have execute on uninstall() (inherits PUBLIC revoke)';
+
   raise notice 'PASS: pgque_roles';
 end $$;


### PR DESCRIPTION
## Problem

`pgque.uninstall()` is a `SECURITY DEFINER` function that calls `drop schema pgque cascade`. PostgreSQL's default for `SECURITY DEFINER` functions grants `EXECUTE` to `PUBLIC`. The install script explicitly revoked the function from `pgque_admin` — but **not** from `PUBLIC`. Result: any role that can connect to the database could call `pgque.uninstall()` and drop the pgque schema.

The README (§"Roles and grants") and `docs/reference.md` both claimed `uninstall()` was "superuser only". The claim was wrong.

Found during the functional review of PR #59 (docs restructure). The reviewer verified the bypass by connecting as a plain non-admin role and successfully calling `pgque.uninstall()`.

## Fix

Add `revoke execute on function pgque.uninstall() from public;` in `sql/pgque-additions/roles.sql`, alongside the existing `pgque_admin` revoke. Rebuild `sql/pgque.sql` via `build/transform.sh`.

Extend `tests/test_pgque_roles.sql` to assert that none of `pgque_admin`, `pgque_writer`, or `pgque_reader` can execute `pgque.uninstall()` — catches any future regression that re-exposes the function.

## Downstream effect on #59

PR #59's docs already flagged this accurately ("explicitly revoked from `pgque_admin`, but PUBLIC execute is NOT revoked by default — run `revoke execute … from public` to tighten"). Once this PR merges and PR #59 rebases, the PUBLIC revoke becomes automatic and the docs claim becomes true without user action. No wording change required on #59.

## Test plan

- [x] `build/transform.sh` rebuilds `sql/pgque.sql` cleanly
- [x] The two revoke lines land in `sql/pgque.sql` after the `pgque_admin` admin-grants block
- [x] `tests/test_pgque_roles.sql` adds three `assert not has_function_privilege(...)` checks
- [ ] CI on PG 14–18 confirms the assertions hold across versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)