### PR TITLE
fix: schedule pgque.maint_retry_events() from pgque.start()

### DIFF
--- a/sql/pgque-additions/lifecycle.sql
+++ b/sql/pgque-additions/lifecycle.sql
@@ -5,6 +5,7 @@ create or replace function pgque.start()
 returns void as $$
 declare
     v_ticker_id bigint;
+    v_retry_id bigint;
     v_maint_id bigint;
     v_step2_id bigint;
     v_dbname text;
@@ -29,7 +30,18 @@ begin
         v_dbname
     ) into v_ticker_id;
 
-    -- Maintenance: every 30 seconds (rotation step1, retry, vacuum)
+    -- Retry events: every 30 seconds (move nack'd events from the retry
+    -- queue back into the main event stream for the next tick).
+    -- pgque.maint() / maint_operations() does NOT include retry handling,
+    -- so this has to be scheduled separately — matches pgqd cadence.
+    select cron.schedule_in_database(
+        'pgque_retry_events',
+        '30 seconds',
+        $sql$SET statement_timeout = '25s'; SELECT pgque.maint_retry_events()$sql$,
+        v_dbname
+    ) into v_retry_id;
+
+    -- Maintenance: every 30 seconds (rotation step 1 and vacuum).
     select cron.schedule_in_database(
         'pgque_maint',
         '30 seconds',
@@ -47,13 +59,13 @@ begin
         v_dbname
     ) into v_step2_id;
 
-    -- Store job IDs in config
+    -- Store job IDs in config (retry + rotate_step2 unscheduled by name)
     update pgque.config
     set ticker_job_id = v_ticker_id,
         maint_job_id = v_maint_id;
 
-    raise notice 'pgque started: ticker job=%, maint job=%, rotate_step2 job=%',
-        v_ticker_id, v_maint_id, v_step2_id;
+    raise notice 'pgque started: ticker=%, retry_events=%, maint=%, rotate_step2=%',
+        v_ticker_id, v_retry_id, v_maint_id, v_step2_id;
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
@@ -83,6 +95,14 @@ begin
         if v_maint_id is not null then
             perform cron.unschedule(v_maint_id);
         end if;
+
+        -- Unschedule retry_events by name (job ID not stored in config).
+        -- Ignore if job doesn't exist (first run or already removed).
+        begin
+            perform cron.unschedule('pgque_retry_events');
+        exception when others then
+            raise notice 'pgque.stop: retry_events job not found (OK on first install)';
+        end;
 
         -- Unschedule rotate_step2 by name (job ID not stored in config)
         -- Ignore if job doesn't exist (first run or already removed)

--- a/sql/pgque-additions/lifecycle.sql
+++ b/sql/pgque-additions/lifecycle.sql
@@ -37,7 +37,7 @@ begin
     select cron.schedule_in_database(
         'pgque_retry_events',
         '30 seconds',
-        $sql$SET statement_timeout = '25s'; SELECT pgque.maint_retry_events()$sql$,
+        $sql$set statement_timeout = '25s'; select pgque.maint_retry_events()$sql$,
         v_dbname
     ) into v_retry_id;
 

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -4028,7 +4028,7 @@ begin
     select cron.schedule_in_database(
         'pgque_retry_events',
         '30 seconds',
-        $sql$SET statement_timeout = '25s'; SELECT pgque.maint_retry_events()$sql$,
+        $sql$set statement_timeout = '25s'; select pgque.maint_retry_events()$sql$,
         v_dbname
     ) into v_retry_id;
 

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -3996,6 +3996,7 @@ create or replace function pgque.start()
 returns void as $$
 declare
     v_ticker_id bigint;
+    v_retry_id bigint;
     v_maint_id bigint;
     v_step2_id bigint;
     v_dbname text;
@@ -4020,7 +4021,18 @@ begin
         v_dbname
     ) into v_ticker_id;
 
-    -- Maintenance: every 30 seconds (rotation step1, retry, vacuum)
+    -- Retry events: every 30 seconds (move nack'd events from the retry
+    -- queue back into the main event stream for the next tick).
+    -- pgque.maint() / maint_operations() does NOT include retry handling,
+    -- so this has to be scheduled separately — matches pgqd cadence.
+    select cron.schedule_in_database(
+        'pgque_retry_events',
+        '30 seconds',
+        $sql$SET statement_timeout = '25s'; SELECT pgque.maint_retry_events()$sql$,
+        v_dbname
+    ) into v_retry_id;
+
+    -- Maintenance: every 30 seconds (rotation step 1 and vacuum).
     select cron.schedule_in_database(
         'pgque_maint',
         '30 seconds',
@@ -4038,13 +4050,13 @@ begin
         v_dbname
     ) into v_step2_id;
 
-    -- Store job IDs in config
+    -- Store job IDs in config (retry + rotate_step2 unscheduled by name)
     update pgque.config
     set ticker_job_id = v_ticker_id,
         maint_job_id = v_maint_id;
 
-    raise notice 'pgque started: ticker job=%, maint job=%, rotate_step2 job=%',
-        v_ticker_id, v_maint_id, v_step2_id;
+    raise notice 'pgque started: ticker=%, retry_events=%, maint=%, rotate_step2=%',
+        v_ticker_id, v_retry_id, v_maint_id, v_step2_id;
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
@@ -4074,6 +4086,14 @@ begin
         if v_maint_id is not null then
             perform cron.unschedule(v_maint_id);
         end if;
+
+        -- Unschedule retry_events by name (job ID not stored in config).
+        -- Ignore if job doesn't exist (first run or already removed).
+        begin
+            perform cron.unschedule('pgque_retry_events');
+        exception when others then
+            raise notice 'pgque.stop: retry_events job not found (OK on first install)';
+        end;
 
         -- Unschedule rotate_step2 by name (job ID not stored in config)
         -- Ignore if job doesn't exist (first run or already removed)

--- a/tests/test_pgcron_lifecycle.sql
+++ b/tests/test_pgcron_lifecycle.sql
@@ -42,7 +42,7 @@ do $$
 declare
   v_job_count int;
 begin
-  if not exists (select 1 from pg_extension where extname = 'pg_cron') then
+  if not exists (select from pg_extension where extname = 'pg_cron') then
     raise notice 'SKIP: pg_cron not installed';
     return;
   end if;

--- a/tests/test_pgcron_lifecycle.sql
+++ b/tests/test_pgcron_lifecycle.sql
@@ -4,11 +4,12 @@
 -- These tests exercise the pg_cron lifecycle integration.
 -- Tests auto-skip when pg_cron is not available.
 
--- Test 1: start() sets job IDs in config
+-- Test 1: start() sets job IDs in config and schedules all four jobs
 do $$
 declare
   v_ticker_id bigint;
   v_maint_id bigint;
+  v_job_count int;
 begin
   if not exists (select 1 from pg_extension where extname = 'pg_cron') then
     raise notice 'SKIP: pg_cron not installed';
@@ -23,10 +24,39 @@ begin
   assert v_ticker_id is not null, 'ticker_job_id should be set after start()';
   assert v_maint_id is not null, 'maint_job_id should be set after start()';
 
+  -- All four named jobs should exist in cron.job after start().
+  select count(*) into v_job_count
+  from cron.job
+  where jobname in ('pgque_ticker', 'pgque_retry_events', 'pgque_maint', 'pgque_rotate_step2');
+  assert v_job_count = 4,
+    'expected 4 pgque_* jobs in cron.job, found ' || v_job_count;
+
   -- Clean up
   perform pgque.stop();
 
-  raise notice 'PASS: start() sets job IDs (ticker=%, maint=%)', v_ticker_id, v_maint_id;
+  raise notice 'PASS: start() schedules four jobs (ticker, retry_events, maint, rotate_step2)';
+end $$;
+
+-- Test 1b: stop() unschedules every pgque_* job (ticker, retry_events, maint, rotate_step2)
+do $$
+declare
+  v_job_count int;
+begin
+  if not exists (select 1 from pg_extension where extname = 'pg_cron') then
+    raise notice 'SKIP: pg_cron not installed';
+    return;
+  end if;
+
+  perform pgque.start();
+  perform pgque.stop();
+
+  select count(*) into v_job_count
+  from cron.job
+  where jobname in ('pgque_ticker', 'pgque_retry_events', 'pgque_maint', 'pgque_rotate_step2');
+  assert v_job_count = 0,
+    'expected 0 pgque_* jobs in cron.job after stop(), found ' || v_job_count;
+
+  raise notice 'PASS: stop() unschedules all four pgque_* jobs';
 end $$;
 
 -- Test 2: start() is idempotent


### PR DESCRIPTION
## Problem

\`pgque.start()\` schedules three cron jobs: \`pgque_ticker\`, \`pgque_maint\`, \`pgque_rotate_step2\`. But \`pgque.maint()\` delegates to \`maint_operations()\`, and \`maint_operations()\` does **not** include \`pgque.maint_retry_events\`. So events a consumer nacks get inserted into \`pgque.retry_queue\` and then sit there until someone manually calls \`pgque.maint_retry_events()\` — they are never moved back into the main event stream for redelivery.

On any default-install deployment using \`nack()\` (the documented retry path), **retries are silently broken**. The DLQ routing still works because \`nack()\` calls \`event_dead\` directly inside its body; but anything that does not exceed \`max_retries\` is stranded.

Kukushkin's 2026 "Rediscovering PgQ" deck shows the pgqd schedule cleanly: ticker 1s, retries 30s, maintenance 120s. We mirror the first two today but fused retries into the wrong function.

Found during the docs restructure (PR #59) — the tutorial had to call \`maint_retry_events()\` explicitly to show a retry loop. That was the smoking gun.

## Fix

Add a fourth cron job in \`pgque.start()\`:

| Job | Cadence | Function |
|---|---|---|
| \`pgque_ticker\` | 2 s | \`pgque.ticker()\` |
| \`pgque_retry_events\` | **30 s (new)** | \`pgque.maint_retry_events()\` |
| \`pgque_maint\` | 30 s | \`pgque.maint()\` (rotation step 1 + vacuum) |
| \`pgque_rotate_step2\` | 10 s | \`pgque.maint_rotate_tables_step2()\` |

Cadence matches pgqd for retries (30 s). We keep \`pgque_maint\` at 30 s for now; whether to drop it to 60 or 120 s (pgqd default) is a separate design question, out of scope for this PR.

### Changes

- \`sql/pgque-additions/lifecycle.sql\`:
  - \`pgque.start()\` schedules \`pgque_retry_events\` alongside the other three jobs. Job id is not stored in \`pgque.config\`; unscheduled by name in \`pgque.stop()\` like \`pgque_rotate_step2\`.
  - \`pgque.stop()\` unschedules \`pgque_retry_events\` before \`pgque_rotate_step2\`.
  - Start notice lists all four jobs.
- \`tests/test_pgcron_lifecycle.sql\`:
  - Test 1 now asserts all four \`pgque_*\` jobs exist in \`cron.job\` after \`start()\`.
  - New Test 1b asserts all four are gone after \`stop()\`.
- \`sql/pgque.sql\` rebuilt via \`build/transform.sh\`.

## Test plan

- [x] \`build/transform.sh\` rebuilds cleanly.
- [x] Four \`pgque_*\` cron jobs after \`start()\`; zero after \`stop()\` (assertions added).
- [ ] CI on PG 14–18 confirms.
- [ ] Manual verification: \`nack\` event with \`0 seconds\` retry delay, let \`pgque_retry_events\` fire, confirm event reappears on the next tick.

## Docs impact

PR #59 (docs restructure) documents \`pgque_maint\` as "(rotation step 1 and vacuum)" — accurate against both the pre- and post-fix surface. Once this merges and #59 rebases, the tutorial's Production cadence subsection will get a one-line update to mention the fourth job. No wording change to this PR's description needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)