### PR TITLE
fix: tick every 1 second to match pgqd cadence

### DIFF
--- a/sql/pgque-additions/lifecycle.sql
+++ b/sql/pgque-additions/lifecycle.sql
@@ -21,11 +21,12 @@ begin
 
     v_dbname := current_database();
 
-    -- Ticker: every 2 seconds (pg_cron >= 1.5 for sub-minute scheduling)
+    -- Ticker: every 1 second (matches pgqd cadence; requires pg_cron >= 1.5
+    -- for sub-minute scheduling)
     select cron.schedule_in_database(
         'pgque_ticker',
-        '2 seconds',
-        $sql$SET statement_timeout = '1500ms'; SELECT pgque.ticker()$sql$,
+        '1 second',
+        $sql$SET statement_timeout = '950ms'; SELECT pgque.ticker()$sql$,
         v_dbname
     ) into v_ticker_id;
 

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -4012,11 +4012,12 @@ begin
 
     v_dbname := current_database();
 
-    -- Ticker: every 2 seconds (pg_cron >= 1.5 for sub-minute scheduling)
+    -- Ticker: every 1 second (matches pgqd cadence; requires pg_cron >= 1.5
+    -- for sub-minute scheduling)
     select cron.schedule_in_database(
         'pgque_ticker',
-        '2 seconds',
-        $sql$SET statement_timeout = '1500ms'; SELECT pgque.ticker()$sql$,
+        '1 second',
+        $sql$SET statement_timeout = '950ms'; SELECT pgque.ticker()$sql$,
         v_dbname
     ) into v_ticker_id;
 


### PR DESCRIPTION
## Problem

\`pgque.start()\` schedules \`pgque_ticker\` at **2-second** intervals. Picked as a conservative default when pg_cron first added sub-minute scheduling in 1.5. Result: end-to-end delivery latency is up to 2 s for the next tick — worse than pgqd's original 1 s cadence and worse than anyone who remembers PgQ expects (Kukushkin's 2026 "Rediscovering PgQ" deck shows 1 s as the canonical interval).

pg_cron 1.5+ handles 1-second scheduling fine.

## Fix

\`sql/pgque-additions/lifecycle.sql\`: change \`pgque_ticker\` cadence from \`'2 seconds'\` to \`'1 second'\`. Tighten the per-invocation \`statement_timeout\` from 1500 ms to 950 ms so a single tick never overruns the interval.

This is the ticker cadence only:
- \`pgque_ticker\`: 1 s (this PR)
- \`pgque_retry_events\`: 30 s (unchanged; added by #63)
- \`pgque_maint\`: 30 s (unchanged)
- \`pgque_rotate_step2\`: 10 s (unchanged)

Rebuilt \`sql/pgque.sql\` via \`build/transform.sh\`.

## Docs impact

README / tutorial / reference still say "every 2 seconds" / "one to two seconds" / "every 1–2 seconds" in several places. Those updates land on PR #59 once this merges and that branch rebases — tracked there, not here.

## Test plan

- [x] \`build/transform.sh\` rebuilds cleanly.
- [x] \`pgque.start()\` in the rebuilt \`pgque.sql\` schedules \`pgque_ticker\` at \`'1 second'\`.
- [ ] CI across PG 14–18. No test changes needed — existing tests don't depend on cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)