### PR TITLE
docs: sentence-level polish across README + docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - [Contributing](#contributing)
 - [License](#license)
 
-PgQue brings back [PgQ](https://github.com/pgq/pgq) — one of the longest-running Postgres queue architectures in production — in a form that fits modern Postgres.
+PgQue brings back [PgQ](https://github.com/pgq/pgq) — one of the longest-running Postgres queue architectures in production — in a form that runs on any Postgres platform, managed providers included.
 
 PgQ was designed at Skype to run messaging for hundreds of millions of users, and it ran on large self-managed Postgres deployments for over a decade. Standard PgQ depends on a C extension (`pgq`) and an external daemon (`pgqd`), neither of which run on most managed Postgres providers.
 
@@ -172,7 +172,7 @@ DDL-class operations (`create_queue`, `drop_queue`, `start`, `stop`, `maint`, `t
 
 ## Project status
 
-PgQue is **early-stage** as a product and API layer. PgQ itself is **rock solid** — battle-tested at Skype scale for over a decade. What's new here is the packaging, modernization, managed-Postgres compatibility, and the higher-level PgQue API around that core.
+PgQue is **early-stage** as a product and API layer. PgQ itself has run at Skype scale for over a decade. What's new here is the packaging, modernization, managed-Postgres compatibility, and the higher-level PgQue API around that core.
 
 The default install stays small in v0.1; additional APIs live under `sql/experimental/` until they are worth promoting. See [blueprints/PHASES.md](blueprints/PHASES.md).
 
@@ -213,7 +213,7 @@ Longer walkthrough in the [tutorial](docs/tutorial.md); patterns like fan-out, e
 
 ## Client libraries
 
-PgQue is SQL-first, so any Postgres driver works. On top of that, example client libraries exist for **Python**, **Go**, and **TypeScript** — unpublished, still evolving, meant to demonstrate integration patterns rather than promise stable SDKs yet. **Help improving them is very much appreciated.**
+PgQue is SQL-first, so any Postgres driver works. Example client libraries exist for **Python**, **Go**, and **TypeScript** — unpublished, still evolving, demonstrating integration patterns rather than stable SDKs. **Contributions welcome.**
 
 ### Python (`pgque-py`) — psycopg 3
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # PgQue docs
 
-Five short docs for users, plus one contributor primer.
+Short docs for users, plus a contributor primer.
 
 ## For users
 
@@ -13,7 +13,7 @@ Five short docs for users, plus one contributor primer.
 - **[Benchmarks](benchmarks.md)** — current throughput numbers and
   methodology.
 - **[PgQ concepts](pgq-concepts.md)** — glossary of the core vocabulary
-  (event, batch, tick, rotation, ticker contract). Useful alongside the
+  (event, batch, tick, rotation, ticker rule). Useful alongside the
   tutorial.
 
 ## For contributors

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,7 +1,7 @@
 # Benchmarks
 
 Preliminary results on a laptop (Apple Silicon, 10 cores, 24 GiB RAM,
-PostgreSQL 18.3, `synchronous_commit=off` per-session). Full methodology:
+PostgreSQL 18.3, `synchronous_commit=off`). Full methodology:
 [NikolayS/pgq#1](https://github.com/NikolayS/pgq/issues/1).
 
 | Scenario | Throughput | Per core |
@@ -14,7 +14,7 @@ PostgreSQL 18.3, `synchronous_commit=off` per-session). Full methodology:
 
 Key takeaways:
 
-- **Zero bloat under load** — a 30-minute sustained test showed zero
+- **Zero bloat under load** — a 30-minute sustained test: zero
   dead-tuple growth in event tables.
 - **Batching matters** — throughput jumps sharply when you stop doing one
   tiny transaction per event.
@@ -25,5 +25,4 @@ Key takeaways:
 > `synchronous_commit=off` can be set per session or per transaction for
 > queue-heavy workloads if that trade-off makes sense for your system.
 
-These numbers are from a single laptop and are preliminary; server-class
-results will be posted as they become available.
+These numbers are preliminary, from a single laptop. Server-class numbers to follow.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,10 +1,10 @@
 # Examples
 
-A few common PgQue patterns. For a guided first-run, see [the tutorial](tutorial.md). For every function signature, see [the reference](reference.md).
+Common PgQue patterns. For a guided first-run, see [the tutorial](tutorial.md). For every function signature, see [the reference](reference.md).
 
 ## Send with event type
 
-The event type is an arbitrary string tag — consumers can filter on it.
+The event type is a string tag consumers can filter on.
 
 ```sql
 select pgque.send('orders', 'order.created',
@@ -16,7 +16,7 @@ select pgque.send('orders', 'order.shipped',
 
 ## Batch send
 
-Both `jsonb[]` and `text[]` overloads ship — see [the reference](reference.md) for when to pick which.
+Both `jsonb[]` and `text[]` overloads exist — the [reference](reference.md) explains the trade-off.
 
 ```sql
 select pgque.send_batch('orders', 'order.created', array[
@@ -28,9 +28,9 @@ select pgque.send_batch('orders', 'order.created', array[
 
 ## Fan-out with multiple consumers
 
-Three subscribers on the same queue, each tracking its own cursor. Unlike `skip locked` queues, every consumer sees every event.
+Three subscribers on the same queue, each tracking its own cursor. Unlike SKIP LOCKED queues, every consumer sees every event.
 
-Subscribe **before** producing — a new consumer starts from the latest tick and will not see events that were sent before its `subscribe` call. Produce, tick, and then receive:
+Subscribe **before** producing — a new consumer starts from the latest tick and will not see events that were sent before its `subscribe` call.
 
 ```sql
 select pgque.subscribe('orders', 'audit_logger');
@@ -45,11 +45,11 @@ select * from pgque.receive('orders', 'audit_logger', 100);
 select * from pgque.receive('orders', 'notification_sender', 100);
 ```
 
-Each `receive` returns the same event to its own consumer — no duplication on the producer side, independent cursors on the consumer side.
+Each consumer sees the same event through its own cursor — no producer-side duplication, independent cursors on the consumer side.
 
 ## Exactly-once processing (transactional pattern)
 
-Wrap the receive, your writes, and the ack in one transaction. If it rolls back, everything rolls back together.
+Wrap the receive, your writes, and the ack in one transaction — either all commit or none do.
 
 ```sql
 begin;
@@ -64,7 +64,7 @@ begin;
 commit;
 ```
 
-Every row in `msgs` shares the same `batch_id`, so `select distinct batch_id from msgs limit 1` is safe. If you prefer extracting it directly, a PL/pgSQL block with `select batch_id into v_batch_id from msgs limit 1` reads the same.
+Every row in `msgs` shares the same `batch_id`, so `select distinct batch_id from msgs limit 1` is safe. A PL/pgSQL block with `select batch_id into v_batch_id from msgs limit 1` is equivalent.
 
 ## Recurring jobs with pg_cron
 
@@ -77,7 +77,7 @@ select cron.schedule('daily_report',
 
 ## Dead letter queue inspection
 
-`pgque.dlq_inspect()` lists entries for a queue; from there, replay a single row by its `dl_id` or purge anything older than a given interval.
+`pgque.dlq_inspect()` lists entries for a queue. Replay a single row by its `dl_id`, or purge rows older than a given interval.
 
 ```sql
 select dl_id, dl_reason, ev_type, ev_data
@@ -94,7 +94,7 @@ See [the tutorial](tutorial.md) for the full DLQ flow including retry budgets an
 
 ## Monitoring: queue + consumer health
 
-Two functions inherited from PgQ give a one-shot read of the system. Use `\x` in psql for the readable per-column layout.
+Two functions inherited from PgQ read out queue and consumer health. Use `\x` in psql for the per-column layout below.
 
 A healthy snapshot:
 
@@ -145,7 +145,7 @@ next_tick      | 1389
 pending_events | 847
 ```
 
-The ticker is still running (`ticker_lag` in `get_queue_info` stays low), but the worker stopped draining — `lag` and `last_seen` climbed to hours and `pending_events` filled up.
+The ticker is still running — `ticker_lag` stays low. But the worker stopped draining: `lag` and `last_seen` climbed to hours, and `pending_events` filled up.
 
 Red flags to alert on:
 

--- a/docs/pgq-concepts.md
+++ b/docs/pgq-concepts.md
@@ -39,7 +39,7 @@ commit
 
 `ev_id`, `ev_time`, `ev_txid` (`xid8`), `ev_retry`, `ev_type`, `ev_data`,
 `ev_extra1..4`. `ev_extra1` is table name by convention (triggers).
-Payload format is producer/consumer contract; PgQue does not interpret it.
+Payload format is a producer/consumer contract — PgQue does not interpret it.
 
 ## Health signals
 

--- a/docs/pgq-history.md
+++ b/docs/pgq-history.md
@@ -13,8 +13,7 @@
 PgQ (Skype, ISC) → Skytools 2/3 → `github.com/pgq/pgq` → **PgQue**
 (Apache-2.0, PG14+).
 
-Skype ran hundreds of queues on PgQ in production. PgQue inherits that
-engine; it does not reinvent it.
+Skype ran hundreds of queues on PgQ in production; PgQue inherits that engine rather than reinventing it.
 
 ## Attribution
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,15 +1,15 @@
 # Function reference
 
-This reference documents the complete function surface shipped by the v0.1 default install (`\i sql/pgque.sql`). Every entry lists the exact signature, return type, the role it is granted to, and the source file. A short code example appears where the call shape is not obvious from the signature alone.
+Every function shipped in the v0.1 default install (`\i sql/pgque.sql`). Each entry lists the signature, return type, the role it is granted to, and the source file. A short code example appears where the signature alone leaves the call ambiguous.
 
-If you are new to PgQue, start with [tutorial.md](tutorial.md) — it walks the end-to-end `send` / `receive` / `ack` loop. This document is the lookup table you reach for afterwards.
+If you are new to PgQue, start with [tutorial.md](tutorial.md) — it walks the end-to-end `send` / `receive` / `ack` loop. Use this as the lookup table.
 
-Each function is documented in the following form.
+Each entry takes this form:
 
 ```
 #### `pgque.<name>(arg text, …) → returntype`
 
-One-line description. Optional second line with a caveat worth knowing.
+One-line description. Optional second line with a caveat.
 Grant: `role_name` or `PUBLIC (default)`. Source: `sql/<path>`.
 ```
 
@@ -30,7 +30,7 @@ select pgque.send('orders', '{"order_id": 42}'::jsonb);
 
 #### `pgque.send(queue text, payload text) → bigint`
 
-Fast-path send: the payload bytes are stored verbatim with no JSON parse. Untyped string literals (`'…'`) resolve to this overload. Returns the event id.
+Fast-path send: stores the payload bytes verbatim, no JSON parse. Untyped string literals (`'…'`) resolve to this overload. Returns the event id.
 Grant: `pgque_writer`. Source: `sql/pgque-api/send.sql`.
 
 #### `pgque.send(queue text, type text, payload jsonb) → bigint`
@@ -82,7 +82,7 @@ Grant: `pgque_writer`. Source: `sql/pgque-api/receive.sql`.
 
 #### `pgque.nack(batch_id bigint, msg pgque.message, retry_after interval default '60 seconds', reason text default null) → integer`
 
-Negative-acknowledges one message. If `msg.retry_count` is below the queue's `max_retries`, re-queues after `retry_after`. Otherwise routes the event to `pgque.dead_letter` via `pgque.event_dead`. Returns `1`.
+Negative-acknowledges one message. If `msg.retry_count` is below the queue's `max_retries`, re-queues after `retry_after`; otherwise routes the event to `pgque.dead_letter` via `pgque.event_dead`. Returns `1`.
 Grant: `pgque_writer`. Source: `sql/pgque-api/receive.sql`.
 
 ```sql

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,12 +1,12 @@
 # PgQue tutorial
 
-This is a hands-on walkthrough. If you have psql access to a Postgres 14+ instance and ten minutes, you can follow every step end to end. You will type SQL, see what comes back, and build an intuition for how PgQue moves messages.
+A hands-on walkthrough. With psql access to a Postgres 14+ instance and ten minutes, you can follow every step end to end. You will type SQL, see what comes back, and build an intuition for how PgQue moves messages.
 
-By the end, you will have a working `orders` queue with a `processor` consumer, a retry flow, a dead letter queue, and a way to check that the whole thing is healthy.
+By the end, you will have a working `orders` queue with a `processor` consumer, a retry flow, a dead letter queue, and health checks.
 
-Prerequisites: Postgres 14 or newer, a database you are willing to install into, and `psql` (the tutorial uses `\i` and `\gset`, which are psql meta-commands). `pg_cron` is recommended for production but not required here — this tutorial drives the ticker manually so it works anywhere.
+Prerequisites: Postgres 14 or newer, a database to install into, and `psql` (the tutorial uses `\i` and `\gset`, which are psql meta-commands). `pg_cron` is recommended for production but not required here — this tutorial drives the ticker manually so it works anywhere.
 
-How to read this tutorial: each step shows the exact SQL and the expected output. The sample `msg_id` / `ev_id` numbers will not match what you see — every `pgque.force_tick` call skips the event sequence forward by about 1000, so the specific ids depend on when you call it. Treat those numbers as illustrative. When transaction boundaries matter (and they do — PgQue is snapshot-based), the text calls that out.
+Each step shows the exact SQL and the expected output. Your `msg_id` / `ev_id` / `pending_events` / `ev_new` numbers will differ from the examples — every `pgque.force_tick` call skips the event sequence forward by about 1000, so exact numeric output depends on when you call it. Treat those numbers as illustrative. When transaction boundaries matter (and they matter — PgQue is snapshot-based), the text calls that out.
 
 You can run every snippet in `psql` with `--no-psqlrc` and `PAGER=cat` if you want reproducible output. From the cloned repo, so `\i sql/pgque.sql` resolves:
 
@@ -59,7 +59,7 @@ select pgque.subscribe('orders', 'processor');
          1
 ```
 
-`create_queue` returns `1` when it actually created the queue (and `0` if it already existed — the call is idempotent). `subscribe` is the modern alias for `register_consumer`.
+`create_queue` returns `1` when it created the queue (and `0` if it already existed — the call is idempotent). `subscribe` is the modern alias for `register_consumer`.
 
 ## Step 3: Send an order
 
@@ -75,9 +75,9 @@ select pgque.send('orders', '{"order_id": 42, "total": 99.95}'::jsonb);
     1
 ```
 
-The returned number is the event id (`ev_id`). It is unique within the queue and monotonically increasing within a rotation window.
+That is the event id (`ev_id`) — unique within the queue, monotonically increasing within a rotation window.
 
-A brief callout on overloads: `pgque.send` also accepts a raw `text` payload — useful for protobuf, msgpack, or XML that you encode yourself. Untyped string literals like `'{"x":1}'` without the `::jsonb` cast resolve to the `text` overload. This tutorial stays on `jsonb` for clarity; see the [reference](reference.md) for the full overload rules and the NUL-byte caveat for binary payloads.
+`pgque.send` also accepts a raw `text` payload — useful for protobuf, msgpack, or XML that you encode yourself. Untyped string literals like `'{"x":1}'` without the `::jsonb` cast resolve to the `text` overload. This tutorial stays on `jsonb` for clarity; see the [reference](reference.md) for the full overload rules and the NUL-byte caveat for binary payloads.
 
 ## Step 4: Try to receive — and get nothing
 
@@ -93,9 +93,9 @@ select * from pgque.receive('orders', 'processor', 100);
 (0 rows)
 ```
 
-Zero rows. This surprises every first-time user, so it is worth being explicit about why.
+Zero rows. This surprises every first-time user. Here is why.
 
-PgQue is **tick-based**, not row-claiming. Producers append events to the queue, but consumers do not see individual rows — they see **batches**. A batch is the set of events between two ticks. Until a tick happens, there is no batch boundary, so `pgque.receive` has nothing to return.
+PgQue is **tick-based**, not row-claiming. Producers append events to the queue, but consumers do not see rows directly — they see **batches**. A batch is the set of events between two ticks. Until a tick happens, there is no batch boundary, so `pgque.receive` has nothing to return.
 
 In normal operation, a scheduler (`pg_cron` or an external loop) calls `pgque.ticker()` every second and ticks happen continuously. In this tutorial you have not started a scheduler, so no tick has run yet.
 
@@ -103,7 +103,7 @@ See the [concepts glossary](pgq-concepts.md) for the full definitions of event, 
 
 ## Step 5: Force a tick, then receive
 
-For demos and tests, PgQue provides `pgque.force_tick` to bump the event-count threshold for one queue. It does **not** create the tick by itself — you still have to call `pgque.ticker()` afterwards to actually produce the tick:
+For demos and tests, PgQue provides `pgque.force_tick` to bypass the tick thresholds for one queue. It does **not** create the tick by itself — you still have to call `pgque.ticker()` afterwards to produce the tick:
 
 ```sql
 select pgque.force_tick('orders');
@@ -135,7 +135,7 @@ select * from pgque.receive('orders', 'processor', 100);
 (1 row)
 ```
 
-The event is back. Note `retry_count` is null — this is the first delivery attempt. The `batch_id` is the important value for the next step.
+The event is back. `retry_count` is null because this is the first delivery attempt. The `batch_id` is the important value for the next step.
 
 In production, `pg_cron` (or a small worker loop) calls `pgque.ticker()` every second. `force_tick` exists for the situation here: advancing the queue without waiting on the ticker's lag threshold.
 
@@ -190,7 +190,7 @@ Every row `pgque.receive` returns is a `pgque.message` composite: `msg_id` (PgQ'
 
 ## Step 7: Send, nack, retry
 
-Real consumers sometimes fail. `nack` handles that: the message is scheduled for redelivery after a delay you choose. Before demoing it, lower the retry ceiling so you can drive a message to the DLQ in step 8:
+Consumers sometimes fail. `nack` handles that: the message is scheduled for redelivery after a delay you choose. Before demoing it, lower the retry ceiling so you can drive a message to the DLQ in step 8:
 
 ```sql
 select pgque.set_queue_config('orders', 'max_retries', '2');
@@ -229,7 +229,7 @@ begin
 end $$;
 ```
 
-The event is now in PgQ's retry queue. Moving it back into the main event stream is a separate maintenance step — `pgque.maint_retry_events()` does exactly that, and then the next tick makes it visible again:
+The event is now in PgQ's retry queue. Moving it back into the main event stream is a separate maintenance step: `pgque.maint_retry_events()`. After that, the next tick makes it visible again:
 
 ```sql
 select pgque.maint_retry_events();
@@ -247,13 +247,13 @@ In production, `pgque.start()` schedules `maint_retry_events` on its own cadence
 (1 row)
 ```
 
-Same `msg_id = 2`, new `batch_id = 3`, and `retry_count = 1`. That is the redelivery.
+Same `msg_id = 2`, new `batch_id = 3`, `retry_count = 1` — that's the redelivery.
 
 ## Step 8: Drive the message to the dead letter queue
 
 Keep nacking. You set `max_retries = 2` in step 7, and the message was just redelivered with `retry_count = 1`. On the next `nack` it becomes `retry_count = 2`; one more `nack` after that, and `nack` sees `retry_count >= max_retries` and routes the message to `pgque.dead_letter` instead of the retry queue.
 
-That is two more nack cycles. Run the following block twice — the `nack` `do` block followed by `maint_retry_events` + tick:
+Two more nack cycles. Run the following block twice — the `nack` `do` block followed by `maint_retry_events` + tick:
 
 ```sql
 do $$
@@ -270,7 +270,7 @@ select pgque.force_tick('orders');
 select pgque.ticker();
 ```
 
-The second iteration sees `retry_count = 2` and routes to the DLQ instead of to the retry queue. After it runs, no events come back out of `receive` — the event has moved to `pgque.dead_letter`.
+The second iteration sees `retry_count = 2` and routes to the DLQ instead of the retry queue. After it runs, `receive` returns nothing — the event has moved to `pgque.dead_letter`.
 
 Inspect the DLQ:
 
@@ -286,7 +286,7 @@ from pgque.dlq_inspect('orders');
 (1 row)
 ```
 
-Two useful moves from here. After you have fixed the upstream bug, put the event back on the queue:
+From here, two moves. After you have fixed the upstream bug, put the event back on the queue:
 
 ```sql
 select pgque.dlq_replay(1);
@@ -302,7 +302,7 @@ select pgque.dlq_purge('orders', '0 seconds'::interval);
 
 ## Step 9: Look at queue and consumer health
 
-Three functions give you a quick read on the system.
+Three functions read out queue and consumer health.
 
 ```sql
 select queue_name, ticker_lag, ev_per_sec, ev_new, last_tick_id
@@ -358,11 +358,11 @@ With `pg_cron` available in the same database as PgQue:
 select pgque.start();
 ```
 
-That one call schedules three cron jobs: `pgque_ticker` every second, `pgque_maint` every thirty seconds (rotation step 1 and vacuum), and `pgque_rotate_step2` every ten seconds (rotation step 2). Check them with `select * from pgque.status();` or `select * from cron.job;`.
+That one call schedules four cron jobs: `pgque_ticker` every second, `pgque_retry_events` every thirty seconds (moves `nack`'d events back into the main stream), `pgque_maint` every thirty seconds (rotation step 1 and vacuum), and `pgque_rotate_step2` every ten seconds (rotation step 2). Check them with `select * from pgque.status();` or `select * from cron.job;`.
 
 **pg_cron in a different database.** `pg_cron` runs jobs in one designated database (`cron.database_name`, typically `postgres`). If your PgQue schema lives in a different database, use the [cross-database pattern](https://github.com/citusdata/pg_cron#creating-a-cron-job-in-a-different-database) to call `pgque.ticker()` and `pgque.maint()` across databases. *Todo: a future release will detect this and emit the correct `cron.schedule_in_database` calls from `pgque.start()` automatically.*
 
-**pg_cron log hygiene.** `pg_cron` logs every job execution to `cron.job_run_details`. At the two-second ticker cadence, that table grows by roughly 2,000 rows per hour from PgQue alone, with no built-in purge.
+**pg_cron log hygiene.** `pg_cron` logs every job execution to `cron.job_run_details`. At the one-second ticker cadence, that table grows by roughly 3,600 rows per hour from PgQue alone, with no built-in purge.
 
 Recommended: disable successful-run logging globally.
 
@@ -391,4 +391,4 @@ Without `pg_cron` at all, call `pgque.ticker()` and `pgque.maint()` from your ap
 - [reference](reference.md) — every function with signatures, return types, and role grants.
 - [examples](examples.md) — patterns: fan-out, exactly-once consumption, batch loading, recurring jobs.
 - [concepts](pgq-concepts.md) — glossary of batch, tick, rotation, and the consumer loop.
-- [history](pgq-history.md) — how this engine came from PgQ and why it is worth trusting.
+- [history](pgq-history.md) — how this engine came from PgQ.


### PR DESCRIPTION
## Summary

Follow-up from the DevRel round 3 review. Sentence-level polish across every user-facing doc. No structural or content-shape changes — just tightening prose. Applies ~30 line-level nits that were deferred from the main docs PR (#59).

## Highlights

- **README framing correction.** "In a form that fits modern Postgres" misread as "Postgres can run PgQue" — but Postgres can run old PgQ too; the real contrast is platform availability (managed providers block C extensions). Now reads "in a form that runs on any Postgres platform, managed providers included."
- **Tutorial Production cadence corrected.** Said "three cron jobs" — reality since PR #63 merged is four (`pgque_retry_events` joined the set). Also updated pg_cron log-hygiene volume from 2,000 rows/hour (2-second cadence) to 3,600 rows/hour (1-second cadence, since PR #64).
- **Examples Monitoring section** aligned with tutorial Step 9 noun phrasing; em-dash-then-comma-then-and wall sentence broken up.
- **Tutorial voice clean-up**: "Real consumers" → "Consumers", "actually produce" → "produce", "That is two more nack cycles" → "Two more nack cycles" (avoids the duplicate "That is" opener that landed two sentences apart).
- **Reference intro** tightened: "This reference documents the complete function surface shipped by" → "Every function shipped in"; form template loses the "worth knowing" pad.
- **Benchmarks methodology**: "per-session" parenthetical dropped (disclosed one sentence later); "are ... are" echo fixed; "will be posted as they become available" → "Server-class numbers to follow."

Every change is line-level and boring by design. Commit message has the full per-file breakdown.

## Test plan

- [x] No SQL touched; CI should be a no-op.
- [x] Every internal cross-reference verified still resolves.
- [x] No new link added without a target that exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)