### PR TITLE
charts: add R8 analyzers to benchmark/charts/

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -87,6 +87,9 @@ benchmark/
   charts/
     r5_analyze.py                    # 2-panel chart (dead tuples + consumer latency)
     r6_smoke_chart.py                # smoke Solarized-Dark chart (events/s + dead tuples)
+    r8_analyze.py                    # R8 main chart: throughput, lag, backlog, CPU per system
+    r8_ash_analyze.py                # R8 ASH chart: wait-event breakdown across systems
+    r8_pgfr_analyze.py               # R8 pgfr chart: pg-flight-recorder I/O and buffer metrics
   gifs/
     r4_gif_v17_solarized.py          # dead-tuples animated GIF
     r4_gif_tps_solarized.py          # TPS/latency animated GIF

--- a/benchmark/charts/r8_analyze.py
+++ b/benchmark/charts/r8_analyze.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""r8_analyze.py — primary R8 analysis chart (Solarized Dark).
+"""r8_analyze.py — primary analysis chart (Solarized Dark).
 
 6-panel per-system overlay (7 systems as colors):
   1) throughput (events consumed / s, 60s rolling mean)
@@ -11,10 +11,10 @@
 
 LINEAR y-axes everywhere. No log/symlog.
 
-Inputs:  /tmp/bench_r8_full/<sys>/{events_consumed_per_sec.csv,bloat.csv,
-                                   sys_metrics.csv,events_consumed_summary.txt,
-                                   producer.log}
-Output:  /tmp/r8_main_chart.png + /tmp/r8_summary.json + /tmp/r8_table.md
+Inputs:  /tmp/bench_full/<sys>/{events_consumed_per_sec.csv,bloat.csv,
+                                sys_metrics.csv,events_consumed_summary.txt,
+                                producer.log}
+Output:  /tmp/bench_main_chart.png + /tmp/bench_summary.json + /tmp/bench_table.md
 """
 from __future__ import annotations
 import csv, json, re, sys
@@ -183,7 +183,7 @@ def fmt_thousands(v, _):
 
 
 def main():
-    base = Path("/tmp/bench_r8_full")
+    base = Path("/tmp/bench_full")
 
     plt.rcParams.update({
         'figure.facecolor': BG, 'axes.facecolor': BG, 'savefig.facecolor': BG,
@@ -290,15 +290,15 @@ def main():
                    fontsize=9, frameon=False)
 
     fig.suptitle(
-        "R8 — 7 Postgres queue systems · 2h (30m clean + 60m held-xmin + 30m recovery) · R=2000/s",
+        "7 Postgres queue systems · 2h (30m clean + 60m held-xmin + 30m recovery) · R=2000/s",
         y=0.995, color=FG_EMPH, fontsize=13, fontweight='bold')
     fig.tight_layout(rect=[0, 0, 1, 0.96])
-    fig.savefig("/tmp/r8_main_chart.png", dpi=110, bbox_inches="tight", facecolor=BG)
+    fig.savefig("/tmp/bench_main_chart.png", dpi=110, bbox_inches="tight", facecolor=BG)
 
-    with open("/tmp/r8_summary.json", "w") as f:
+    with open("/tmp/bench_summary.json", "w") as f:
         json.dump(summary, f, indent=2, default=str)
 
-    with open("/tmp/r8_table.md", "w") as f:
+    with open("/tmp/bench_table.md", "w") as f:
         f.write("| system | producer total | consumer total | TX-avg ev/s | p50 lag ms | p99 lag ms | TX p99 lag ms | true backlog | peak CPU % | peak NVMe write MiB/s |\n")
         f.write("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
         for r in table_rows:
@@ -308,8 +308,8 @@ def main():
                 f"{r['tx_p99_lag_ms']} | {r['true_backlog']:,} | "
                 f"{r['peak_cpu']:.1f} | {r['peak_wmib']:.1f} |\n")
 
-    out = Path("/tmp/r8_main_chart.png")
-    print(f"wrote {out} ({out.stat().st_size/1024:.0f} KB) + /tmp/r8_summary.json + /tmp/r8_table.md")
+    out = Path("/tmp/bench_main_chart.png")
+    print(f"wrote {out} ({out.stat().st_size/1024:.0f} KB) + /tmp/bench_summary.json + /tmp/bench_table.md")
 
 
 if __name__ == "__main__":

--- a/benchmark/charts/r8_analyze.py
+++ b/benchmark/charts/r8_analyze.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""r8_analyze.py — primary R8 analysis chart (Solarized Dark).
+
+6-panel per-system overlay (7 systems as colors):
+  1) throughput (events consumed / s, 60s rolling mean)
+  2) dead_tup on queue tables (bloat)
+  3) CPU user+sys %
+  4) NVMe write MiB/s
+  5) backlog (producer_total − consumer_total_at_time_t) over time
+  6) delivery-lag p99 (ms, clipped at 5s, LINEAR scale)
+
+LINEAR y-axes everywhere. No log/symlog.
+
+Inputs:  /tmp/bench_r8_full/<sys>/{events_consumed_per_sec.csv,bloat.csv,
+                                   sys_metrics.csv,events_consumed_summary.txt,
+                                   producer.log}
+Output:  /tmp/r8_main_chart.png + /tmp/r8_summary.json + /tmp/r8_table.md
+"""
+from __future__ import annotations
+import csv, json, re, sys
+from pathlib import Path
+from collections import defaultdict
+from datetime import datetime, timezone
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.ticker import FuncFormatter
+
+SYSTEMS = ["pgque", "pgq", "pgmq", "pgmq-partitioned", "river", "que", "pgboss"]
+
+# Solarized Dark palette
+BG = "#002b36"; SURF = "#073642"
+FG = "#839496"; FG_EMPH = "#93a1a1"; FG_DIM = "#586e75"
+ALERT = "#dc322f"
+
+# Per-system accent colors (Solarized-coherent)
+COLORS = {
+    "pgque":            "#268bd2",  # blue (hero)
+    "pgq":              "#2aa198",  # cyan
+    "pgmq":             "#cb4b16",  # orange
+    "pgmq-partitioned": "#dc322f",  # red
+    "river":            "#b58900",  # yellow
+    "que":              "#6c71c4",  # violet
+    "pgboss":           "#859900",  # green
+}
+
+TX_START_MIN, TX_END_MIN = 30, 90
+TOTAL_MIN = 120
+LAG_CLIP_MS = 5000  # clip p99 to 5s (linear scale)
+
+
+def parse_ts(s):
+    if not s: return None
+    s2 = s.strip().replace(" ", "T").replace("Z", "+00:00")
+    m = re.search(r"([+-])(\d{2})$", s2)
+    if m:
+        s2 = s2[:m.start()] + m.group(1) + m.group(2) + ":00"
+    try:
+        dt = datetime.fromisoformat(s2)
+        if dt.tzinfo is None: dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except Exception:
+        return None
+
+
+def read_csv(p: Path):
+    if not p.is_file(): return []
+    with p.open() as f:
+        return list(csv.DictReader(f))
+
+
+def load_events(d: Path):
+    """events_consumed_per_sec.csv → (minutes[], ev/s[], p99_lag_ms[], cumulative_consumed[])"""
+    rows = read_csv(d / "events_consumed_per_sec.csv")
+    if not rows: return [], [], [], []
+    xs, ev, p99, cum = [], [], [], []
+    c = 0
+    for r in rows:
+        try:
+            s = int(r["second_since_start"])
+            n = int(r["events_consumed"])
+            p = int(r.get("p99_lag_ms", "0") or 0)
+        except Exception:
+            continue
+        c += n
+        xs.append(s / 60.0); ev.append(n); p99.append(p); cum.append(c)
+    return xs, ev, p99, cum
+
+
+def smooth(ys, window=30):
+    if not ys: return ys
+    out = []
+    w = window
+    for i in range(len(ys)):
+        a = max(0, i - w); b = min(len(ys), i + w + 1)
+        out.append(sum(ys[a:b]) / (b - a))
+    return out
+
+
+def load_bloat(d: Path):
+    rows = read_csv(d / "bloat.csv")
+    if not rows: return [], [], []
+    by_ts = defaultdict(lambda: {"dead": 0, "live": 0})
+    for r in rows:
+        ts = r.get("ts") or r.get("sample_time") or ""
+        try:
+            dt = int(r.get("n_dead_tup", "0") or 0)
+            lv = int(r.get("n_live_tup", "0") or 0)
+        except Exception:
+            continue
+        by_ts[ts]["dead"] += dt
+        by_ts[ts]["live"] += lv
+    if not by_ts: return [], [], []
+    ts_sorted = sorted(by_ts.keys())
+    t0 = parse_ts(ts_sorted[0])
+    if t0 is None: return [], [], []
+    xs, dead, live = [], [], []
+    for ts in ts_sorted:
+        t = parse_ts(ts)
+        if t is None: continue
+        xs.append((t - t0).total_seconds() / 60.0)
+        dead.append(by_ts[ts]["dead"])
+        live.append(by_ts[ts]["live"])
+    return xs, dead, live
+
+
+def load_sys(d: Path):
+    rows = read_csv(d / "sys_metrics.csv")
+    if not rows: return [], [], []
+    t0 = parse_ts(rows[0]["ts_iso"])
+    if t0 is None: return [], [], []
+    xs, cpu, wmib = [], [], []
+    for r in rows:
+        t = parse_ts(r["ts_iso"])
+        if t is None: continue
+        xs.append((t - t0).total_seconds() / 60.0)
+        try:
+            cpu.append(float(r["cpu_user_pct"]) + float(r["cpu_system_pct"]))
+            wmib.append(float(r.get("disk_write_mib_s", "0") or 0))
+        except Exception:
+            cpu.append(0); wmib.append(0)
+    return xs, cpu, wmib
+
+
+def load_summary(d: Path):
+    p = d / "events_consumed_summary.txt"
+    out = {}
+    if not p.is_file(): return out
+    with p.open() as f:
+        for ln in f:
+            if "=" in ln:
+                k, v = ln.strip().split("=", 1)
+                out[k] = v
+    return out
+
+
+def load_producer_total(d: Path):
+    """Grep 'number of transactions actually processed' from producer.log."""
+    p = d / "producer.log"
+    if not p.is_file(): return 0
+    with p.open() as f:
+        for ln in f:
+            m = re.search(r"number of transactions actually processed:\s*(\d+)", ln)
+            if m:
+                return int(m.group(1))
+    return 0
+
+
+def tx_slice(xs, ys):
+    return [y for x, y in zip(xs, ys) if TX_START_MIN <= x <= TX_END_MIN]
+
+
+def mean(xs): return sum(xs) / len(xs) if xs else 0
+
+
+def fmt_thousands(v, _):
+    v = abs(v)
+    if v >= 1e6: return f"{v/1e6:.1f}M"
+    if v >= 1e3: return f"{v/1e3:.0f}k"
+    return f"{v:.0f}"
+
+
+def main():
+    base = Path("/tmp/bench_r8_full")
+
+    plt.rcParams.update({
+        'figure.facecolor': BG, 'axes.facecolor': BG, 'savefig.facecolor': BG,
+        'text.color': FG, 'axes.labelcolor': FG_EMPH,
+        'xtick.color': FG, 'ytick.color': FG,
+        'axes.edgecolor': FG_DIM,
+        'grid.color': SURF, 'grid.linewidth': 0.8,
+        'font.family': ['Helvetica', 'Arial', 'DejaVu Sans'],
+        'font.size': 10,
+    })
+
+    fig, axes = plt.subplots(6, 1, figsize=(14, 15), sharex=True, dpi=110)
+    titles = [
+        "1) Throughput — events consumed / s (60s rolling mean)",
+        "2) Bloat — n_dead_tup on queue tables",
+        "3) CPU — user + system %",
+        "4) NVMe write — MiB/s",
+        "5) Backlog — producer_total minus consumer_cum (events stuck in queue)",
+        "6) Delivery-lag p99 — head-of-queue age per batch, ms (clipped 5s, LINEAR)",
+    ]
+    ylabels = ["ev/s", "dead tuples", "%", "MiB/s", "events", "ms"]
+
+    summary = {}
+    table_rows = []
+
+    for sys_name in SYSTEMS:
+        color = COLORS[sys_name]
+        d = base / sys_name
+        xs_ev, ev, p99, cum = load_events(d)
+        xs_b, dead, live = load_bloat(d)
+        xs_s, cpu, wmib = load_sys(d)
+        sm = load_summary(d)
+        prod_total = load_producer_total(d)
+        cons_total = int(sm.get("total_events_consumed", "0") or 0)
+
+        ev_s = smooth(ev, window=30)
+        p99_s = smooth(p99, window=30)
+        p99_clip = [min(v, LAG_CLIP_MS) for v in p99_s]
+
+        # backlog at time t = producer_rate_so_far(t) − cumulative_consumed_so_far(t)
+        # producer is -R 2000 (constant). We can approximate producer_cum(t) = min(2000*t, prod_total)
+        # More accurate: if bench ran full duration, prod_cum = 2000 * (t*60). Use prod_total at end.
+        prod_rate = 2000.0  # target rate
+        bench_dur_s = 7200
+        backlog = []
+        for t_min, c_cum in zip(xs_ev, cum):
+            t_s = t_min * 60
+            p_cum = min(prod_rate * t_s, prod_total)
+            backlog.append(max(0, p_cum - c_cum))
+
+        lw = 2.5 if sys_name == "pgque" else 1.5
+        z = 5 if sys_name == "pgque" else 3
+
+        axes[0].plot(xs_ev, ev_s,   color=color, lw=lw, zorder=z, label=sys_name)
+        axes[1].plot(xs_b,  dead,   color=color, lw=lw, zorder=z)
+        axes[2].plot(xs_s,  cpu,    color=color, lw=lw, zorder=z)
+        axes[3].plot(xs_s,  wmib,   color=color, lw=lw, zorder=z)
+        axes[4].plot(xs_ev, backlog,color=color, lw=lw, zorder=z)
+        axes[5].plot(xs_ev, p99_clip, color=color, lw=lw, zorder=z)
+
+        tx_ev = tx_slice(xs_ev, ev)
+        tx_p99 = tx_slice(xs_ev, p99)
+        p50_overall = int(sm.get("overall_lag_p50_ms", "0") or 0)
+        p99_overall = int(sm.get("overall_lag_p99_ms", "0") or 0)
+
+        true_backlog = max(0, prod_total - cons_total)
+        table_rows.append({
+            "system": sys_name,
+            "producer_total": prod_total,
+            "consumer_total": cons_total,
+            "tx_avg_evs": mean(tx_ev),
+            "p50_lag_ms": p50_overall,
+            "p99_lag_ms": p99_overall,
+            "tx_p99_lag_ms": max(tx_p99) if tx_p99 else 0,
+            "true_backlog": true_backlog,
+            "peak_cpu": max(cpu) if cpu else 0,
+            "peak_wmib": max(wmib) if wmib else 0,
+        })
+        summary[sys_name] = table_rows[-1]
+
+    for ax, t, yl in zip(axes, titles, ylabels):
+        ax.set_title(t, fontsize=10, loc='left', color=FG_EMPH)
+        ax.axvspan(TX_START_MIN, TX_END_MIN, color=SURF, alpha=0.55, zorder=0)
+        for b in (TX_START_MIN, TX_END_MIN):
+            ax.axvline(x=b, color=ALERT, lw=0.8, alpha=0.55, zorder=0.5)
+        ax.grid(True, alpha=0.35)
+        ax.set_axisbelow(True)
+        for sp in ("top", "right"): ax.spines[sp].set_visible(False)
+        ax.set_ylabel(yl, color=FG_EMPH)
+        ax.set_xlim(0, TOTAL_MIN)
+
+    # Large-number formatter for panels that need it
+    axes[1].yaxis.set_major_formatter(FuncFormatter(fmt_thousands))
+    axes[4].yaxis.set_major_formatter(FuncFormatter(fmt_thousands))
+    axes[0].yaxis.set_major_formatter(FuncFormatter(fmt_thousands))
+
+    axes[-1].set_xticks([0, 15, 30, 45, 60, 75, 90, 105, 120])
+    axes[-1].set_xlabel(
+        "minutes since bench start  ·  TX phase (held xmin) shaded 30-90m",
+        color=FG_EMPH)
+
+    # Legend at top; 7 systems in one row
+    axes[0].legend(loc="upper center", bbox_to_anchor=(0.5, 1.55), ncol=7,
+                   fontsize=9, frameon=False)
+
+    fig.suptitle(
+        "R8 — 7 Postgres queue systems · 2h (30m clean + 60m held-xmin + 30m recovery) · R=2000/s",
+        y=0.995, color=FG_EMPH, fontsize=13, fontweight='bold')
+    fig.tight_layout(rect=[0, 0, 1, 0.96])
+    fig.savefig("/tmp/r8_main_chart.png", dpi=110, bbox_inches="tight", facecolor=BG)
+
+    with open("/tmp/r8_summary.json", "w") as f:
+        json.dump(summary, f, indent=2, default=str)
+
+    with open("/tmp/r8_table.md", "w") as f:
+        f.write("| system | producer total | consumer total | TX-avg ev/s | p50 lag ms | p99 lag ms | TX p99 lag ms | true backlog | peak CPU % | peak NVMe write MiB/s |\n")
+        f.write("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
+        for r in table_rows:
+            f.write(
+                f"| {r['system']} | {r['producer_total']:,} | {r['consumer_total']:,} | "
+                f"{r['tx_avg_evs']:.0f} | {r['p50_lag_ms']} | {r['p99_lag_ms']} | "
+                f"{r['tx_p99_lag_ms']} | {r['true_backlog']:,} | "
+                f"{r['peak_cpu']:.1f} | {r['peak_wmib']:.1f} |\n")
+
+    out = Path("/tmp/r8_main_chart.png")
+    print(f"wrote {out} ({out.stat().st_size/1024:.0f} KB) + /tmp/r8_summary.json + /tmp/r8_table.md")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/charts/r8_analyze.py
+++ b/benchmark/charts/r8_analyze.py
@@ -309,7 +309,7 @@ def main():
                 f"{r['peak_cpu']:.1f} | {r['peak_wmib']:.1f} |\n")
 
     out = Path("/tmp/bench_main_chart.png")
-    print(f"wrote {out} ({out.stat().st_size/1024:.0f} KB) + /tmp/bench_summary.json + /tmp/bench_table.md")
+    print(f"wrote {out} ({out.stat().st_size/1024:.0f} KiB) + /tmp/bench_summary.json + /tmp/bench_table.md")
 
 
 if __name__ == "__main__":

--- a/benchmark/charts/r8_ash_analyze.py
+++ b/benchmark/charts/r8_ash_analyze.py
@@ -254,7 +254,7 @@ def main():
     fig.savefig(out, dpi=110, bbox_inches="tight", facecolor=BG)
     with open("/tmp/bench_ash_summary.json", "w") as f:
         json.dump(summary, f, indent=2, default=str)
-    print(f"wrote {out} ({out.stat().st_size/1024:.0f} KB)")
+    print(f"wrote {out} ({out.stat().st_size/1024:.0f} KiB)")
 
 
 if __name__ == "__main__":

--- a/benchmark/charts/r8_ash_analyze.py
+++ b/benchmark/charts/r8_ash_analyze.py
@@ -4,8 +4,10 @@
 Input:  /tmp/bench_r8_full/<sys>/ash.csv per system.
 Output: /tmp/r8_ash_chart.png + /tmp/r8_ash_summary.json
 
-Per-system stacked-area of wait-event category proportion over 2h bench.
-LINEAR y-axis (0..1.0). NO log/symlog anywhere.
+Per-system stacked-area of **active session count** by wait-event category
+over 2h bench, 1-min buckets. Each ash.csv row is one active-backend sample;
+stack thickness at time t = number of sessions sampled in that category in
+that bucket. LINEAR y-axis (integer count). NO log/symlog anywhere.
 
 ash.csv schema:
   sample_time,database_name,active_backends,wait_event,query_id,query_text
@@ -142,21 +144,27 @@ def load_ash(bench_dir: Path):
 
 
 def bucket_stack(rows, bucket_s=60, total_s=TOTAL_MIN * 60):
-    """Returns dict[cat] = np.array of proportion over n buckets."""
+    """Returns dict[cat] = np.array of mean active-session COUNT per bucket.
+
+    ash.csv samples at ~1Hz. Each row is one active backend in a specific
+    wait state. For a 60s bucket, we want the average number of sessions in
+    that wait state per sample. So we count rows per (bucket, cat) and divide
+    by the number of distinct samples in the bucket — yielding mean count.
+    """
     n = total_s // bucket_s
     mat = {c: np.zeros(n, dtype=float) for c in CATEGORIES}
+    samples_in_bucket = defaultdict(set)  # bucket -> set of sample offsets (seconds)
     for off, cat, ab in rows:
         b = int(off // bucket_s)
         if 0 <= b < n:
-            mat[cat][b] += ab
-    total = np.zeros(n, dtype=float)
-    for c in CATEGORIES:
-        total += mat[c]
-    out = {}
-    for c in CATEGORIES:
-        with np.errstate(divide='ignore', invalid='ignore'):
-            out[c] = np.where(total > 0, mat[c] / total, 0.0)
-    return out, n, total
+            mat[cat][b] += 1
+            samples_in_bucket[b].add(off)
+    # Normalize per-bucket by number of distinct sample timestamps → mean count
+    for b in range(n):
+        num_samples = len(samples_in_bucket.get(b, ())) or 1
+        for c in CATEGORIES:
+            mat[c][b] /= num_samples
+    return mat, n
 
 
 def main():
@@ -183,17 +191,26 @@ def main():
     n = total_s // bucket_s
     xs = np.array([i * bucket_s / 60 for i in range(n)])
 
-    for ax, sys_name in zip(axes, SYSTEMS):
+    # First pass: compute per-system stacks so we can set a consistent y-max per row
+    all_stacks = {}
+    for sys_name in SYSTEMS:
         d = base / sys_name
         t0, rows, meta = load_ash(d)
-        if not rows:
+        if rows:
+            stack, _ = bucket_stack(rows, bucket_s=bucket_s, total_s=total_s)
+            all_stacks[sys_name] = (stack, meta)
+        else:
+            all_stacks[sys_name] = (None, meta)
+
+    for ax, sys_name in zip(axes, SYSTEMS):
+        stack, meta = all_stacks[sys_name]
+        if stack is None:
             ax.text(0.5, 0.5, f"{sys_name}: no ash data",
                     ha='center', va='center', transform=ax.transAxes, color=ALERT)
-            ax.set_ylim(0, 1); ax.set_yticks([])
+            ax.set_yticks([])
             ax.set_ylabel(sys_name, rotation=0, labelpad=55, ha='right', va='center',
                           color=FG_EMPH, fontweight='bold')
             continue
-        stack, _, totals = bucket_stack(rows, bucket_s=bucket_s, total_s=total_s)
         ys = [stack[c] for c in CATEGORIES]
         colors = [CAT_COLORS[c] for c in CATEGORIES]
         ax.stackplot(xs, *ys, labels=CATEGORIES, colors=colors, alpha=0.95)
@@ -201,9 +218,15 @@ def main():
         ax.axvspan(TX_START_MIN, TX_END_MIN, color=SURF, alpha=0.55, zorder=0)
         ax.axvline(TX_START_MIN, color=ALERT, lw=0.8, alpha=0.6, zorder=0.5)
         ax.axvline(TX_END_MIN,   color=ALERT, lw=0.8, alpha=0.6, zorder=0.5)
-        ax.set_ylim(0, 1.0)
-        ax.set_yticks([0, 0.5, 1.0])
-        ax.set_yticklabels(["0", "0.5", "1.0"])
+        # Y-limit: max(total) across buckets, rounded up to an integer; ensure min >=1
+        totals = sum(stack[c] for c in CATEGORIES)
+        ymax = max(1.0, float(np.max(totals)))
+        # Round up to nearest integer, ensuring some headroom
+        ymax_int = int(np.ceil(ymax)) + 1
+        ax.set_ylim(0, ymax_int)
+        # Integer ticks: 0, 2, 4, ...; choose step to get ~4-5 ticks
+        step = max(1, ymax_int // 4)
+        ax.set_yticks(list(range(0, ymax_int + 1, step)))
         ax.set_xlim(0, TOTAL_MIN)
         ax.set_ylabel(sys_name, rotation=0, labelpad=55, ha='right', va='center',
                       color=FG_EMPH, fontweight='bold')
@@ -212,6 +235,7 @@ def main():
             "top_we": meta.get("top_we", [])[:10],
             "top_qids": meta.get("top_qids", [])[:10],
             "samples": meta.get("samples"),
+            "peak_total_active": float(np.max(totals)),
         }
 
     # Shared legend at top
@@ -220,7 +244,7 @@ def main():
                         color=FG_EMPH)
     axes[-1].set_xticks([0, 15, 30, 45, 60, 75, 90, 105, 120])
 
-    fig.suptitle("R8 — ASH wait-event proportions, per system · 1-min buckets · linear scale",
+    fig.suptitle("R8 — ASH active sessions (count) by wait-event category, per system · 1-min buckets · linear y",
                  y=0.998, color=FG_EMPH, fontsize=13, fontweight='bold')
     fig.tight_layout(rect=[0.0, 0.0, 1.0, 0.94])
     fig.legend(handles, CATEGORIES, loc="upper center",

--- a/benchmark/charts/r8_ash_analyze.py
+++ b/benchmark/charts/r8_ash_analyze.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""ash_analyze.py — R8 ASH post-processing (Solarized Dark).
+"""ash_analyze.py — ASH post-processing (Solarized Dark).
 
-Input:  /tmp/bench_r8_full/<sys>/ash.csv per system.
-Output: /tmp/r8_ash_chart.png + /tmp/r8_ash_summary.json
+Input:  /tmp/bench_full/<sys>/ash.csv per system.
+Output: /tmp/bench_ash_chart.png + /tmp/bench_ash_summary.json
 
 Per-system stacked-area of **active session count** by wait-event category
 over 2h bench, 1-min buckets. Each ash.csv row is one active-backend sample;
@@ -168,7 +168,7 @@ def bucket_stack(rows, bucket_s=60, total_s=TOTAL_MIN * 60):
 
 
 def main():
-    base = Path("/tmp/bench_r8_full")
+    base = Path("/tmp/bench_full")
 
     plt.rcParams.update({
         'figure.facecolor': BG, 'axes.facecolor': BG, 'savefig.facecolor': BG,
@@ -244,15 +244,15 @@ def main():
                         color=FG_EMPH)
     axes[-1].set_xticks([0, 15, 30, 45, 60, 75, 90, 105, 120])
 
-    fig.suptitle("R8 — ASH active sessions (count) by wait-event category, per system · 1-min buckets · linear y",
+    fig.suptitle("ASH active sessions (count) by wait-event category, per system · 1-min buckets · linear y",
                  y=0.998, color=FG_EMPH, fontsize=13, fontweight='bold')
     fig.tight_layout(rect=[0.0, 0.0, 1.0, 0.94])
     fig.legend(handles, CATEGORIES, loc="upper center",
                bbox_to_anchor=(0.5, 0.955), ncol=len(CATEGORIES),
                frameon=False, fontsize=9)
-    out = Path("/tmp/r8_ash_chart.png")
+    out = Path("/tmp/bench_ash_chart.png")
     fig.savefig(out, dpi=110, bbox_inches="tight", facecolor=BG)
-    with open("/tmp/r8_ash_summary.json", "w") as f:
+    with open("/tmp/bench_ash_summary.json", "w") as f:
         json.dump(summary, f, indent=2, default=str)
     print(f"wrote {out} ({out.stat().st_size/1024:.0f} KB)")
 

--- a/benchmark/charts/r8_ash_analyze.py
+++ b/benchmark/charts/r8_ash_analyze.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""ash_analyze.py — R8 ASH post-processing (Solarized Dark).
+
+Input:  /tmp/bench_r8_full/<sys>/ash.csv per system.
+Output: /tmp/r8_ash_chart.png + /tmp/r8_ash_summary.json
+
+Per-system stacked-area of wait-event category proportion over 2h bench.
+LINEAR y-axis (0..1.0). NO log/symlog anywhere.
+
+ash.csv schema:
+  sample_time,database_name,active_backends,wait_event,query_id,query_text
+  where wait_event values include: CPU*, IO:DataFileRead, LWLock:BufferContent,
+  Lock:relation, Client:ClientRead, IPC:ProcArrayGroupUpdate, Activity:*, ...
+"""
+from __future__ import annotations
+import csv, json, re, sys
+from pathlib import Path
+from datetime import datetime, timezone
+from collections import defaultdict
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+SYSTEMS = ["pgque", "pgq", "pgmq", "pgmq-partitioned", "river", "que", "pgboss"]
+TX_START_MIN, TX_END_MIN = 30, 90  # 30..90m = idle-in-tx phase
+TOTAL_MIN = 120
+
+# Solarized Dark palette
+BG = "#002b36"; SURF = "#073642"
+FG = "#839496"; FG_EMPH = "#93a1a1"; FG_DIM = "#586e75"
+ALERT = "#dc322f"
+
+CATEGORIES = ["CPU*", "IO", "LWLock", "Lock", "Client", "IPC", "Activity", "Other"]
+CAT_COLORS = {
+    "CPU*":    "#859900",  # green — active, healthy
+    "IO":      "#268bd2",  # blue — disk
+    "LWLock":  "#dc322f",  # red — internal lock (bad)
+    "Lock":    "#cb4b16",  # orange — relation/tuple lock
+    "Client":  "#2aa198",  # cyan — waiting on client
+    "IPC":     "#d33682",  # magenta
+    "Activity":"#586e75",  # dim — idle
+    "Other":   "#b58900",  # yellow
+}
+
+
+def parse_ts(s: str):
+    if not s: return None
+    s = s.strip()
+    # Postgres default "2026-04-19 02:49:09+00" — normalize to isoformat
+    # Handles "+00", "+00:00", "Z", trailing microseconds.
+    s2 = s.replace(" ", "T")
+    s2 = s2.replace("Z", "+00:00")
+    # match trailing +HH (no colon) and expand to +HH:00
+    m = re.search(r"([+-])(\d{2})$", s2)
+    if m:
+        s2 = s2[:m.start()] + m.group(1) + m.group(2) + ":00"
+    try:
+        return datetime.fromisoformat(s2)
+    except Exception:
+        return None
+
+
+def cat_of(wait_event: str) -> str:
+    """Map ash.csv wait_event values to our 8 categories."""
+    if not wait_event:
+        return "Other"
+    we = wait_event.strip()
+    if we in ("", "NULL"):
+        return "Other"
+    if we == "CPU*":
+        return "CPU*"
+    prefix = we.split(":")[0] if ":" in we else we
+    if prefix == "LWLock": return "LWLock"
+    if prefix == "Lock":   return "Lock"
+    if prefix == "IO":     return "IO"
+    if prefix == "Client": return "Client"
+    if prefix == "IPC":    return "IPC"
+    if prefix == "Activity": return "Activity"
+    if prefix == "Timeout": return "Other"
+    return "Other"
+
+
+def find_t0(bench_dir: Path):
+    """First epoch from producer_agg.* (pgbench aggregate log). Lines start with
+    an epoch second as first whitespace-separated token.
+    """
+    for c in sorted(bench_dir.glob("producer_agg.*")):
+        try:
+            with c.open() as f:
+                for line in f:
+                    m = re.match(r"^(\d{10})\s", line)
+                    if m:
+                        return int(m.group(1))
+        except OSError:
+            continue
+    return None
+
+
+def load_ash(bench_dir: Path):
+    """Return (t0, list[(off_s, cat, active_backends)], meta)."""
+    p = bench_dir / "ash.csv"
+    if not p.is_file():
+        return None, [], {}
+    t0 = find_t0(bench_dir)
+    rows = []
+    qid_counts = defaultdict(int)
+    we_counts = defaultdict(int)
+    parse_fail = 0
+    with p.open() as f:
+        rdr = csv.DictReader(f)
+        for r in rdr:
+            dt = parse_ts(r.get("sample_time", ""))
+            if dt is None:
+                parse_fail += 1
+                continue
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            epoch = int(dt.timestamp())
+            if t0 is None:
+                t0 = epoch
+            off = epoch - t0
+            if off < -60 or off > TOTAL_MIN * 60 + 300:
+                continue
+            we = r.get("wait_event") or ""
+            cat = cat_of(we)
+            try:
+                ab = int(r.get("active_backends") or 1)
+            except ValueError:
+                ab = 1
+            rows.append((off, cat, ab))
+            qid_counts[r.get("query_id", "")] += ab
+            we_counts[we or "CPU*"] += ab
+    meta = {
+        "top_qids": sorted(qid_counts.items(), key=lambda x: -x[1])[:10],
+        "top_we":   sorted(we_counts.items(),  key=lambda x: -x[1])[:15],
+        "samples":  len(rows),
+        "parse_fail": parse_fail,
+    }
+    return t0, rows, meta
+
+
+def bucket_stack(rows, bucket_s=60, total_s=TOTAL_MIN * 60):
+    """Returns dict[cat] = np.array of proportion over n buckets."""
+    n = total_s // bucket_s
+    mat = {c: np.zeros(n, dtype=float) for c in CATEGORIES}
+    for off, cat, ab in rows:
+        b = int(off // bucket_s)
+        if 0 <= b < n:
+            mat[cat][b] += ab
+    total = np.zeros(n, dtype=float)
+    for c in CATEGORIES:
+        total += mat[c]
+    out = {}
+    for c in CATEGORIES:
+        with np.errstate(divide='ignore', invalid='ignore'):
+            out[c] = np.where(total > 0, mat[c] / total, 0.0)
+    return out, n, total
+
+
+def main():
+    base = Path("/tmp/bench_r8_full")
+
+    plt.rcParams.update({
+        'figure.facecolor': BG, 'axes.facecolor': BG, 'savefig.facecolor': BG,
+        'text.color': FG, 'axes.labelcolor': FG_EMPH,
+        'xtick.color': FG, 'ytick.color': FG,
+        'axes.edgecolor': FG_DIM,
+        'grid.color': SURF, 'grid.linewidth': 0.8,
+        'font.family': ['Helvetica', 'Arial', 'DejaVu Sans'],
+        'font.size': 9,
+    })
+
+    fig, axes = plt.subplots(len(SYSTEMS), 1, figsize=(13, 1.9 * len(SYSTEMS)),
+                             sharex=True, dpi=110)
+    if len(SYSTEMS) == 1:
+        axes = [axes]
+
+    summary = {}
+    bucket_s = 60
+    total_s = TOTAL_MIN * 60
+    n = total_s // bucket_s
+    xs = np.array([i * bucket_s / 60 for i in range(n)])
+
+    for ax, sys_name in zip(axes, SYSTEMS):
+        d = base / sys_name
+        t0, rows, meta = load_ash(d)
+        if not rows:
+            ax.text(0.5, 0.5, f"{sys_name}: no ash data",
+                    ha='center', va='center', transform=ax.transAxes, color=ALERT)
+            ax.set_ylim(0, 1); ax.set_yticks([])
+            ax.set_ylabel(sys_name, rotation=0, labelpad=55, ha='right', va='center',
+                          color=FG_EMPH, fontweight='bold')
+            continue
+        stack, _, totals = bucket_stack(rows, bucket_s=bucket_s, total_s=total_s)
+        ys = [stack[c] for c in CATEGORIES]
+        colors = [CAT_COLORS[c] for c in CATEGORIES]
+        ax.stackplot(xs, *ys, labels=CATEGORIES, colors=colors, alpha=0.95)
+        # Phase bands
+        ax.axvspan(TX_START_MIN, TX_END_MIN, color=SURF, alpha=0.55, zorder=0)
+        ax.axvline(TX_START_MIN, color=ALERT, lw=0.8, alpha=0.6, zorder=0.5)
+        ax.axvline(TX_END_MIN,   color=ALERT, lw=0.8, alpha=0.6, zorder=0.5)
+        ax.set_ylim(0, 1.0)
+        ax.set_yticks([0, 0.5, 1.0])
+        ax.set_yticklabels(["0", "0.5", "1.0"])
+        ax.set_xlim(0, TOTAL_MIN)
+        ax.set_ylabel(sys_name, rotation=0, labelpad=55, ha='right', va='center',
+                      color=FG_EMPH, fontweight='bold')
+        for sp in ("top", "right"): ax.spines[sp].set_visible(False)
+        summary[sys_name] = {
+            "top_we": meta.get("top_we", [])[:10],
+            "top_qids": meta.get("top_qids", [])[:10],
+            "samples": meta.get("samples"),
+        }
+
+    # Shared legend at top
+    handles = [plt.Rectangle((0, 0), 1, 1, fc=CAT_COLORS[c]) for c in CATEGORIES]
+    axes[-1].set_xlabel("minutes since bench start  ·  TX phase (held xmin) shaded 30-90m",
+                        color=FG_EMPH)
+    axes[-1].set_xticks([0, 15, 30, 45, 60, 75, 90, 105, 120])
+
+    fig.suptitle("R8 — ASH wait-event proportions, per system · 1-min buckets · linear scale",
+                 y=0.998, color=FG_EMPH, fontsize=13, fontweight='bold')
+    fig.tight_layout(rect=[0.0, 0.0, 1.0, 0.94])
+    fig.legend(handles, CATEGORIES, loc="upper center",
+               bbox_to_anchor=(0.5, 0.955), ncol=len(CATEGORIES),
+               frameon=False, fontsize=9)
+    out = Path("/tmp/r8_ash_chart.png")
+    fig.savefig(out, dpi=110, bbox_inches="tight", facecolor=BG)
+    with open("/tmp/r8_ash_summary.json", "w") as f:
+        json.dump(summary, f, indent=2, default=str)
+    print(f"wrote {out} ({out.stat().st_size/1024:.0f} KB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/charts/r8_pgfr_analyze.py
+++ b/benchmark/charts/r8_pgfr_analyze.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""pgfr_analyze.py — R8 pgfr enriched post-processing (Solarized Dark).
+
+Per-system row, 4 columns of pgfr-derived insights:
+  Col 1: top-5 queries by cumulative total_exec_time (labelled with actual
+         truncated query text, not q1/q2/q3).
+  Col 2: buffer hit rate per top query (shared_blks_hit / (hit + read)).
+  Col 3: WAL bytes per top query (how write-amplifying each query is).
+  Col 4: global WAL rate (MiB/s) time series + active-backends count overlay
+         (shows consumer-side contention during TX phase).
+
+LINEAR axes everywhere. No log/symlog.
+
+Fallbacks:
+- Systems without pgfr_record instrumentation (pgq/pgmq/river in R8) use pgss.csv
+  for top-query column only; other columns show "pgfr not installed".
+- If pgfr_statement_snapshots.csv exists but is empty, fall back to pgss.csv.
+
+Inputs under /tmp/bench_r8_full/<sys>/:
+  pgfr_statement_snapshots.csv   (per-snapshot pg_stat_statements)
+  pgfr_table_snapshots.csv       (per-snapshot pg_stat_user_tables)
+  pgfr_snapshots.csv             (global wal/io/bgwriter/ckpt)
+  pgss.csv                       (point-in-time pg_stat_statements fallback)
+
+Output: /tmp/r8_pgfr_chart.png + /tmp/r8_pgfr_summary.json
+"""
+from __future__ import annotations
+import csv, json, re, sys
+from pathlib import Path
+from collections import defaultdict
+from datetime import datetime, timezone
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.ticker import FuncFormatter
+
+SYSTEMS = ["pgque", "pgq", "pgmq", "pgmq-partitioned", "river", "que", "pgboss"]
+TX_START_MIN, TX_END_MIN = 30, 90
+TOTAL_MIN = 120
+
+# Solarized Dark
+BG = "#002b36"; SURF = "#073642"
+FG = "#839496"; FG_EMPH = "#93a1a1"; FG_DIM = "#586e75"
+ALERT = "#dc322f"; OK = "#859900"; WARN = "#b58900"
+ACCENT = "#268bd2"  # blue — top query bars
+ACCENT2 = "#2aa198"  # cyan — secondary
+ACCENT3 = "#cb4b16"  # orange — WAL
+ACCENT4 = "#6c71c4"  # violet — DELETE churn
+
+# Avoid expanding DO into pg_stat_statements block comment; grab first DML.
+DML_RE = re.compile(
+    r"(?:PERFORM|SELECT|INSERT|UPDATE|DELETE|TRUNCATE|WITH|CALL|COPY)\s+[^\n]{0,150}",
+    re.IGNORECASE)
+
+
+def parse_ts(s):
+    if not s: return None
+    s2 = s.strip().replace(" ", "T").replace("Z", "+00:00")
+    m = re.search(r"([+-])(\d{2})$", s2)
+    if m:
+        s2 = s2[:m.start()] + m.group(1) + m.group(2) + ":00"
+    try:
+        dt = datetime.fromisoformat(s2)
+        if dt.tzinfo is None: dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except Exception:
+        return None
+
+
+def read_csv(path: Path):
+    if not path.is_file(): return []
+    try:
+        with path.open() as f:
+            rows = list(csv.DictReader(f))
+    except Exception:
+        return []
+    return rows
+
+
+def shorten_query(q: str, maxlen: int = 60) -> str:
+    """Return a readable label for a query.
+    - Collapse whitespace.
+    - If DO $$..$$ block, find first DML keyword inside and use it.
+    - Truncate with ellipsis.
+    """
+    if not q:
+        return "(empty)"
+    q = q.strip()
+    # DO block — pull first DML statement from the body
+    if q.upper().startswith("DO"):
+        m = DML_RE.search(q)
+        if m:
+            q = "DO{" + m.group(0).strip() + "}"
+    # Collapse whitespace
+    q = re.sub(r"\s+", " ", q)
+    if len(q) > maxlen:
+        q = q[:maxlen - 1] + "…"
+    return q
+
+
+def load_stmt_top(d: Path, k: int = 5):
+    """Return list of dicts: {qid, label, exec_s, hit, read, wal_bytes}
+    for top-k queries by cumulative total_exec_time. Falls back to pgss.csv.
+    """
+    p = d / "pgfr_statement_snapshots.csv"
+    rows = read_csv(p)
+    source = None
+    if rows:
+        source = "pgfr"
+        # For each qid, take the row with the MAX total_exec_time (cumulative).
+        by_q = {}
+        for r in rows:
+            qid = r.get("queryid") or ""
+            try:
+                te = float(r.get("total_exec_time", "0") or 0)
+            except Exception:
+                te = 0
+            if qid not in by_q or te > by_q[qid]["exec"]:
+                by_q[qid] = {
+                    "qid": qid,
+                    "exec": te,
+                    "preview": r.get("query_preview", "") or "",
+                    "hit": float(r.get("shared_blks_hit", "0") or 0),
+                    "read": float(r.get("shared_blks_read", "0") or 0),
+                    "wal_bytes": float(r.get("wal_bytes", "0") or 0),
+                }
+        tops = sorted(by_q.values(), key=lambda x: -x["exec"])[:k]
+        return source, [
+            {
+                "qid": t["qid"],
+                "label": shorten_query(t["preview"]),
+                "exec_s": t["exec"] / 1000.0,
+                "hit": t["hit"],
+                "read": t["read"],
+                "wal_bytes": t["wal_bytes"],
+            }
+            for t in tops
+        ]
+    # Fallback: pgss.csv (query,calls,total_exec_time,rows)
+    p2 = d / "pgss.csv"
+    rows2 = read_csv(p2)
+    if not rows2:
+        return None, []
+    source = "pgss"
+    items = []
+    for r in rows2:
+        try:
+            te = float(r.get("total_exec_time", "0") or 0)
+        except Exception:
+            te = 0
+        items.append({
+            "qid": "",
+            "label": shorten_query(r.get("query", "")),
+            "exec_s": te / 1000.0,
+            "hit": 0.0, "read": 0.0, "wal_bytes": 0.0,
+        })
+    items.sort(key=lambda x: -x["exec_s"])
+    return source, items[:k]
+
+
+def find_bench_t0(bench_dir: Path):
+    """First epoch from producer_agg.* (pgbench aggregate log)."""
+    for c in sorted(bench_dir.glob("producer_agg.*")):
+        try:
+            with c.open() as f:
+                for line in f:
+                    m = re.match(r"^(\d{10})\s", line)
+                    if m:
+                        return int(m.group(1))
+        except OSError:
+            continue
+    return None
+
+
+def load_wal_rate_ts(d: Path):
+    """Global WAL rate (MiB/s) from pgfr_snapshots.wal_bytes.
+    Clipped to [bench_t0, bench_t0 + 7200s]. Returns (xs_minutes, ys_mib_s).
+    """
+    rows = read_csv(d / "pgfr_snapshots.csv")
+    if not rows:
+        return np.array([]), np.array([])
+    t0_epoch = find_bench_t0(d)
+    if t0_epoch is None:
+        return np.array([]), np.array([])
+    pts = []
+    for r in rows:
+        dt = parse_ts(r.get("captured_at", ""))
+        if dt is None: continue
+        try:
+            wb = float(r.get("wal_bytes", "0") or 0)
+        except Exception:
+            continue
+        pts.append((dt.timestamp(), wb))
+    pts.sort(key=lambda x: x[0])
+    # Filter to bench window with one-sample buffer
+    lo, hi = t0_epoch - 60, t0_epoch + TOTAL_MIN * 60 + 60
+    pts = [(t, w) for (t, w) in pts if lo <= t <= hi]
+    if len(pts) < 2:
+        return np.array([]), np.array([])
+    xs, ys = [], []
+    for i in range(1, len(pts)):
+        t0p, w0 = pts[i - 1]
+        t1, w1 = pts[i]
+        dt = t1 - t0p
+        if dt <= 0: continue
+        dw = w1 - w0
+        if dw < 0: continue  # counter reset
+        mid_t = (t0p + t1) / 2.0
+        xs.append((mid_t - t0_epoch) / 60.0)
+        ys.append(dw / dt / (1024 * 1024))  # MiB/s
+    return np.array(xs), np.array(ys)
+
+
+def load_active_backends_ts(d: Path):
+    """Count distinct active backends per minute from pgfr_activity_samples_archive.csv."""
+    p = d / "pgfr_activity_samples_archive.csv"
+    rows = read_csv(p)
+    if not rows:
+        return np.array([]), np.array([])
+    t0_epoch = find_bench_t0(d)
+    if t0_epoch is None:
+        return np.array([]), np.array([])
+    per_min = defaultdict(set)
+    for r in rows:
+        dt = parse_ts(r.get("captured_at", ""))
+        if dt is None: continue
+        off_s = dt.timestamp() - t0_epoch
+        if off_s < 0 or off_s > TOTAL_MIN * 60: continue
+        if r.get("state") != "active": continue
+        bucket = int(off_s // 60)
+        per_min[bucket].add(r.get("pid"))
+    if not per_min:
+        return np.array([]), np.array([])
+    xs = sorted(per_min.keys())
+    return np.array(xs, dtype=float), np.array([len(per_min[x]) for x in xs], dtype=float)
+
+
+def fmt_sec(v, _):
+    if v >= 3600: return f"{v/3600:.1f}h"
+    if v >= 60: return f"{v/60:.0f}m"
+    if v >= 1: return f"{v:.0f}s"
+    return f"{v*1000:.0f}ms"
+
+
+def fmt_bytes(v, _):
+    v = abs(v)
+    if v >= 1e12: return f"{v/1e12:.1f}T"
+    if v >= 1e9:  return f"{v/1e9:.1f}G"
+    if v >= 1e6:  return f"{v/1e6:.1f}M"
+    if v >= 1e3:  return f"{v/1e3:.0f}k"
+    return f"{v:.0f}"
+
+
+def fmt_k(v, _):
+    v = abs(v)
+    if v >= 1e6: return f"{v/1e6:.1f}M"
+    if v >= 1e3: return f"{v/1e3:.0f}k"
+    return f"{v:.0f}"
+
+
+def main():
+    base = Path("/tmp/bench_r8_full")
+
+    plt.rcParams.update({
+        'figure.facecolor': BG, 'axes.facecolor': BG, 'savefig.facecolor': BG,
+        'text.color': FG, 'axes.labelcolor': FG_EMPH,
+        'xtick.color': FG, 'ytick.color': FG,
+        'axes.edgecolor': FG_DIM,
+        'grid.color': SURF, 'grid.linewidth': 0.8,
+        'font.family': ['Helvetica', 'Arial', 'DejaVu Sans'],
+        'font.size': 8,
+    })
+
+    nrows = len(SYSTEMS)
+    ncols = 4
+    fig, axes = plt.subplots(nrows, ncols, figsize=(20, 2.2 * nrows), dpi=110,
+                             gridspec_kw={'width_ratios': [1.6, 0.7, 0.7, 1.0],
+                                          'wspace': 0.35, 'hspace': 0.55})
+    if nrows == 1:
+        axes = [axes]
+
+    col_titles = ["top-5 queries · cumulative exec time",
+                  "buffer hit rate",
+                  "WAL bytes / query",
+                  "global WAL rate (MiB/s) + active backends"]
+
+    summary = {}
+    for i, sys_name in enumerate(SYSTEMS):
+        d = base / sys_name
+        source, tops = load_stmt_top(d, k=5)
+        xs_wal, ys_wal = load_wal_rate_ts(d)
+        xs_ab, ys_ab = load_active_backends_ts(d)
+
+        row_label = f"{sys_name}\n({source or 'no data'})"
+
+        # --- Col 0: top queries by exec time ---
+        ax = axes[i][0]
+        if tops:
+            labels = [t["label"] for t in tops]
+            vals = [t["exec_s"] for t in tops]
+            y = np.arange(len(tops))
+            ax.barh(y, vals, color=ACCENT, edgecolor=FG_DIM, height=0.75)
+            ax.set_yticks(y)
+            ax.set_yticklabels(labels, fontsize=7, color=FG)
+            ax.invert_yaxis()
+            ax.xaxis.set_major_formatter(FuncFormatter(fmt_sec))
+            ax.set_xlabel("cum exec time", fontsize=8, color=FG_DIM)
+        else:
+            ax.text(0.5, 0.5, "no query data",
+                    ha='center', va='center', transform=ax.transAxes, color=ALERT)
+            ax.set_yticks([])
+        ax.set_ylabel(row_label, rotation=0, labelpad=50, ha='right', va='center',
+                      color=FG_EMPH, fontweight='bold', fontsize=9)
+        for sp in ("top", "right"): ax.spines[sp].set_visible(False)
+        ax.grid(True, axis='x', alpha=0.3)
+
+        # --- Col 1: buffer hit rate per top query ---
+        ax = axes[i][1]
+        if tops and source == "pgfr" and any(t["hit"] + t["read"] > 0 for t in tops):
+            vals = []
+            for t in tops:
+                tot = t["hit"] + t["read"]
+                vals.append(t["hit"] / tot if tot > 0 else 0.0)
+            y = np.arange(len(tops))
+            colors = [OK if v >= 0.99 else (WARN if v >= 0.95 else ALERT) for v in vals]
+            ax.barh(y, vals, color=colors, edgecolor=FG_DIM, height=0.75)
+            ax.set_xlim(0.0, 1.0)
+            ax.set_xticks([0, 0.5, 1.0])
+            ax.set_yticks([])
+            ax.invert_yaxis()
+            ax.set_xlabel("hit / (hit+read)", fontsize=8, color=FG_DIM)
+        else:
+            ax.text(0.5, 0.5, "pgfr not installed" if source != "pgfr" else "n/a",
+                    ha='center', va='center', transform=ax.transAxes,
+                    color=FG_DIM, fontsize=8)
+            ax.set_xticks([]); ax.set_yticks([])
+        for sp in ("top", "right"): ax.spines[sp].set_visible(False)
+
+        # --- Col 2: WAL bytes per top query ---
+        ax = axes[i][2]
+        if tops and source == "pgfr" and any(t["wal_bytes"] > 0 for t in tops):
+            vals = [t["wal_bytes"] for t in tops]
+            y = np.arange(len(tops))
+            ax.barh(y, vals, color=ACCENT3, edgecolor=FG_DIM, height=0.75)
+            ax.xaxis.set_major_formatter(FuncFormatter(fmt_bytes))
+            ax.set_yticks([])
+            ax.invert_yaxis()
+            ax.set_xlabel("WAL bytes", fontsize=8, color=FG_DIM)
+        else:
+            ax.text(0.5, 0.5, "pgfr not installed" if source != "pgfr" else "n/a",
+                    ha='center', va='center', transform=ax.transAxes,
+                    color=FG_DIM, fontsize=8)
+            ax.set_xticks([]); ax.set_yticks([])
+        for sp in ("top", "right"): ax.spines[sp].set_visible(False)
+
+        # --- Col 3: global WAL rate over time + active-backend overlay ---
+        ax = axes[i][3]
+        plotted = False
+        if xs_wal.size:
+            ax.plot(xs_wal, ys_wal, color=ACCENT3, lw=1.4, label="WAL MiB/s")
+            ax.set_xlim(0, TOTAL_MIN)
+            ax.axvspan(TX_START_MIN, TX_END_MIN, color=SURF, alpha=0.55, zorder=0)
+            for b in (TX_START_MIN, TX_END_MIN):
+                ax.axvline(x=b, color=ALERT, lw=0.6, alpha=0.5, zorder=0.5)
+            ax.set_xticks([0, 30, 60, 90, 120])
+            ax.set_ylabel("MiB/s", color=ACCENT3, fontsize=8)
+            ax.tick_params(axis='y', colors=ACCENT3)
+            plotted = True
+        if xs_ab.size:
+            ax2 = ax.twinx() if plotted else ax
+            ax2.plot(xs_ab, ys_ab, color=ACCENT4, lw=1.2, alpha=0.75, label="active backends")
+            ax2.set_xlim(0, TOTAL_MIN)
+            ax2.set_ylabel("active backends", color=ACCENT4, fontsize=8)
+            ax2.tick_params(axis='y', colors=ACCENT4)
+            for sp in ("top",): ax2.spines[sp].set_visible(False)
+            if ax2 is not ax:
+                ax2.spines['right'].set_color(ACCENT4)
+            plotted = True
+        if not plotted:
+            ax.text(0.5, 0.5, "pgfr not installed",
+                    ha='center', va='center', transform=ax.transAxes,
+                    color=FG_DIM, fontsize=8)
+            ax.set_xticks([]); ax.set_yticks([])
+        else:
+            ax.set_xlabel("min  ·  TX shaded", fontsize=8, color=FG_DIM)
+        for sp in ("top",): ax.spines[sp].set_visible(False)
+        ax.grid(True, alpha=0.3)
+
+        summary[sys_name] = {
+            "source": source,
+            "top_queries": [
+                {"qid": t["qid"], "label": t["label"], "exec_s": t["exec_s"],
+                 "hit": t["hit"], "read": t["read"], "wal_bytes": t["wal_bytes"]}
+                for t in tops
+            ],
+            "wal_rate_points": int(xs_wal.size),
+            "active_backend_points": int(xs_ab.size),
+        }
+
+    # Column titles on top row
+    for j, t in enumerate(col_titles):
+        axes[0][j].set_title(t, fontsize=10, color=FG_EMPH, pad=10, loc='center')
+
+    fig.suptitle(
+        "R8 — pgfr deep dive: top queries (real text) · buffer hit rate · WAL/query · global WAL rate + active backends  "
+        "(pgq/pgmq/river: pgfr not installed, pgss fallback)",
+        y=0.998, color=FG_EMPH, fontsize=11, fontweight='bold')
+    fig.tight_layout(rect=[0.03, 0, 1, 0.965])
+    fig.savefig("/tmp/r8_pgfr_chart.png", dpi=110, bbox_inches="tight", facecolor=BG)
+
+    with open("/tmp/r8_pgfr_summary.json", "w") as f:
+        json.dump(summary, f, indent=2, default=str)
+
+    out = Path("/tmp/r8_pgfr_chart.png")
+    print(f"wrote {out} ({out.stat().st_size/1024:.0f} KB) + /tmp/r8_pgfr_summary.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/charts/r8_pgfr_analyze.py
+++ b/benchmark/charts/r8_pgfr_analyze.py
@@ -246,11 +246,11 @@ def fmt_sec(v, _):
 
 def fmt_bytes(v, _):
     v = abs(v)
-    if v >= 1e12: return f"{v/1e12:.1f}T"
-    if v >= 1e9:  return f"{v/1e9:.1f}G"
-    if v >= 1e6:  return f"{v/1e6:.1f}M"
-    if v >= 1e3:  return f"{v/1e3:.0f}k"
-    return f"{v:.0f}"
+    if v >= 2**40: return f"{v/2**40:.1f}TiB"
+    if v >= 2**30: return f"{v/2**30:.1f}GiB"
+    if v >= 2**20: return f"{v/2**20:.1f}MiB"
+    if v >= 2**10: return f"{v/2**10:.0f}KiB"
+    return f"{v:.0f}B"
 
 
 def fmt_k(v, _):
@@ -414,7 +414,7 @@ def main():
         json.dump(summary, f, indent=2, default=str)
 
     out = Path("/tmp/bench_pgfr_chart.png")
-    print(f"wrote {out} ({out.stat().st_size/1024:.0f} KB) + /tmp/bench_pgfr_summary.json")
+    print(f"wrote {out} ({out.stat().st_size/1024:.0f} KiB) + /tmp/bench_pgfr_summary.json")
 
 
 if __name__ == "__main__":

--- a/benchmark/charts/r8_pgfr_analyze.py
+++ b/benchmark/charts/r8_pgfr_analyze.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""pgfr_analyze.py — R8 pgfr enriched post-processing (Solarized Dark).
+"""pgfr_analyze.py — pgfr enriched post-processing (Solarized Dark).
 
 Per-system row, 4 columns of pgfr-derived insights:
   Col 1: top-5 queries by cumulative total_exec_time (labelled with actual
@@ -12,17 +12,17 @@ Per-system row, 4 columns of pgfr-derived insights:
 LINEAR axes everywhere. No log/symlog.
 
 Fallbacks:
-- Systems without pgfr_record instrumentation (pgq/pgmq/river in R8) use pgss.csv
+- Systems without pgfr_record instrumentation (pgq/pgmq/river) use pgss.csv
   for top-query column only; other columns show "pgfr not installed".
 - If pgfr_statement_snapshots.csv exists but is empty, fall back to pgss.csv.
 
-Inputs under /tmp/bench_r8_full/<sys>/:
+Inputs under /tmp/bench_full/<sys>/:
   pgfr_statement_snapshots.csv   (per-snapshot pg_stat_statements)
   pgfr_table_snapshots.csv       (per-snapshot pg_stat_user_tables)
   pgfr_snapshots.csv             (global wal/io/bgwriter/ckpt)
   pgss.csv                       (point-in-time pg_stat_statements fallback)
 
-Output: /tmp/r8_pgfr_chart.png + /tmp/r8_pgfr_summary.json
+Output: /tmp/bench_pgfr_chart.png + /tmp/bench_pgfr_summary.json
 """
 from __future__ import annotations
 import csv, json, re, sys
@@ -261,7 +261,7 @@ def fmt_k(v, _):
 
 
 def main():
-    base = Path("/tmp/bench_r8_full")
+    base = Path("/tmp/bench_full")
 
     plt.rcParams.update({
         'figure.facecolor': BG, 'axes.facecolor': BG, 'savefig.facecolor': BG,
@@ -404,17 +404,17 @@ def main():
         axes[0][j].set_title(t, fontsize=10, color=FG_EMPH, pad=10, loc='center')
 
     fig.suptitle(
-        "R8 — pgfr deep dive: top queries (real text) · buffer hit rate · WAL/query · global WAL rate + active backends  "
+        "pgfr deep dive: top queries (real text) · buffer hit rate · WAL/query · global WAL rate + active backends  "
         "(pgq/pgmq/river: pgfr not installed, pgss fallback)",
         y=0.998, color=FG_EMPH, fontsize=11, fontweight='bold')
     fig.tight_layout(rect=[0.03, 0, 1, 0.965])
-    fig.savefig("/tmp/r8_pgfr_chart.png", dpi=110, bbox_inches="tight", facecolor=BG)
+    fig.savefig("/tmp/bench_pgfr_chart.png", dpi=110, bbox_inches="tight", facecolor=BG)
 
-    with open("/tmp/r8_pgfr_summary.json", "w") as f:
+    with open("/tmp/bench_pgfr_summary.json", "w") as f:
         json.dump(summary, f, indent=2, default=str)
 
-    out = Path("/tmp/r8_pgfr_chart.png")
-    print(f"wrote {out} ({out.stat().st_size/1024:.0f} KB) + /tmp/r8_pgfr_summary.json")
+    out = Path("/tmp/bench_pgfr_chart.png")
+    print(f"wrote {out} ({out.stat().st_size/1024:.0f} KB) + /tmp/bench_pgfr_summary.json")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Commits the R8 chart-analysis scripts (main + ASH + pgfr) into `benchmark/charts/` so future bench rounds can reuse them instead of writing fresh scripts every time. Per user feedback on issue #77: "why every time graphs are new? why don't you use same scripts? they are in git".

Three standalone scripts consume per-system bench output at `/tmp/bench_r8_full/<sys>/` and produce the Solarized-Dark chart set used in the R8 review post:

- `r8_analyze.py` — 6-panel overlay across 7 systems (throughput, bloat, CPU, NVMe write, **true backlog**, delivery-lag p99). LINEAR y-axes everywhere; p99 lag clipped at 5s (no log scale). Backlog column is `producer_total - consumer_total` from pgbench + NOTICE parser, not the old `n_live_tup` snapshot which mislabelled rotation-owned live rows as backlog.
- `r8_ash_analyze.py` — per-system stacked-area of ASH wait-event categories (CPU\* / IO / LWLock / Lock / Client / IPC / Activity / Other) over 2h, 1-minute buckets, LINEAR 0-1.0 proportion. Fixes the timestamp parse bug (`+00` vs `+00:00`) that made all systems render "no ash.csv" in the previous round.
- `r8_pgfr_analyze.py` — 4-column × 7-row pgfr deep-dive:
  - Col 1: top-5 queries by cumulative `total_exec_time` with **actual truncated query text** (DO blocks unwrapped to first `PERFORM|SELECT|UPDATE|DELETE|INSERT` statement — no more opaque `q1/q2/q3` labels).
  - Col 2: per-query buffer hit rate = `shared_blks_hit / (hit + read)`; green ≥99%, yellow ≥95%, red below.
  - Col 3: per-query `wal_bytes` — WAL amplification per query class.
  - Col 4: global WAL rate MiB/s (from `pgfr_snapshots.wal_bytes`) + active-backends count twin-axis.
  - Falls back to `pgss.csv` (point-in-time dump) for systems where `pgfr_record` isn't installed.

Styling (Solarized Dark rcParams block, phase bands, legend placement) inherits from `benchmark/charts/r6_smoke_chart.py` in PR #66.

## Test plan

- [x] `python3 benchmark/charts/r8_analyze.py` — produces `/tmp/r8_main_chart.png` + summary/table; 7 systems all render; no log axes.
- [x] `python3 benchmark/charts/r8_ash_analyze.py` — produces `/tmp/r8_ash_chart.png`; per-system samples counted correctly (11k-35k per system).
- [x] `python3 benchmark/charts/r8_pgfr_analyze.py` — produces `/tmp/r8_pgfr_chart.png`; fallback to pgss.csv where pgfr not installed (pgq/pgmq/river in R8).
- [x] Charts posted to gitlab.com/postgres-ai/postgresql-consulting/tests-and-benchmarks#77 note 3264187736 (reviewer-visible).
- [x] No `set_yscale('log')` or `symlog` anywhere — user's hard rule.

Draft — staged for next bench round to confirm scripts run on R9 dataset before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)