### PR TITLE
docs(README): add buyer self-qualification + HN discussion link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <p align="center">Discussion: <a href="https://news.ycombinator.com/item?id=47817349">Hacker News</a>.</p>
 
-> **For teams who want a durable event stream inside Postgres — closer to a Kafka topic than to a `SKIP LOCKED` job queue.** Shared event log, independent per-consumer cursors, zero bloat under sustained load. Pure SQL, any Postgres 14+ — managed or self-hosted, no sidecar daemon. The rest of this README walks the history, comparison, and install paths that back up the claim.
+**For teams who want a durable event stream inside Postgres — closer to a Kafka topic than to a `SKIP LOCKED` job queue.** Shared event log, independent per-consumer cursors, zero bloat under sustained load. Pure SQL, any Postgres 14+ — managed or self-hosted, no sidecar daemon. The rest of this README walks the history, comparison, and install paths that back up the claim.
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@
 
 <p align="center"><img src="docs/images/death_spiral.gif" alt="Death spiral of a SKIP LOCKED queue under sustained load — the failure mode PgQue avoids by construction" width="720"></p>
 
-**For teams who want a durable event stream inside Postgres — closer to a Kafka topic than to a `SKIP LOCKED` job queue.** Shared event log, independent per-consumer cursors, zero bloat under sustained load. Pure SQL, any Postgres 14+ — managed or self-hosted, no sidecar daemon. The rest of this README walks the history, comparison, and install paths that back up the claim.
+Discussion on [Hacker News](https://news.ycombinator.com/item?id=47817349).
+
+*For teams who want a durable event stream inside Postgres — closer to a Kafka topic than to a `SKIP LOCKED` job queue. Shared event log, independent per-consumer cursors, zero bloat under sustained load. Pure SQL, any Postgres 14+ — managed or self-hosted, no sidecar daemon. The rest of this README walks the history, comparison, and install paths that back up the claim.*
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License"></a>
   <a href="https://github.com/citusdata/pg_cron"><img src="https://img.shields.io/badge/pg__cron-optional-336791" alt="pg_cron"></a>
   <a href="https://github.com/NikolayS/pgque"><img src="https://img.shields.io/badge/anti--extension-%5Ci_and_go-orange" alt="Anti-Extension"></a>
+  <a href="https://news.ycombinator.com/item?id=47817349"><img src="https://img.shields.io/badge/Hacker%20News-discussion-ff6600?logo=ycombinator&logoColor=white" alt="Discussion on Hacker News"></a>
 </p>
 
 <p align="center"><img src="docs/images/death_spiral.gif" alt="Death spiral of a SKIP LOCKED queue under sustained load — the failure mode PgQue avoids by construction" width="720"></p>
-
-<p align="center">Discussion: <a href="https://news.ycombinator.com/item?id=47817349">Hacker News</a>.</p>
 
 **For teams who want a durable event stream inside Postgres — closer to a Kafka topic than to a `SKIP LOCKED` job queue.** Shared event log, independent per-consumer cursors, zero bloat under sustained load. Pure SQL, any Postgres 14+ — managed or self-hosted, no sidecar daemon. The rest of this README walks the history, comparison, and install paths that back up the claim.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 Discussion on [Hacker News](https://news.ycombinator.com/item?id=47817349).
 
-*For teams who want a durable event stream inside Postgres. The model is closer to Kafka (log) than to ActiveMQ or RabbitMQ (task message queue). Shared event log, independent per-consumer cursors, zero bloat under sustained load. Pure SQL, any Postgres 14+ — managed or self-hosted, no sidecar daemon. The rest of this README walks the history, comparison, and install paths that back up the claim.*
+*For teams who want a durable event stream inside Postgres. The model is closer to Kafka (log) than to ActiveMQ or RabbitMQ (task message queue). Shared event log, independent per-consumer cursors, zero bloat under sustained load. Pure SQL and PL/pgSQL, any Postgres 14+ — managed or self-hosted, no sidecar daemon. The rest of this README walks the history, comparison, and install paths that back up the claim.*
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 
 <p align="center"><img src="docs/images/death_spiral.gif" alt="Death spiral of a SKIP LOCKED queue under sustained load — the failure mode PgQue avoids by construction" width="720"></p>
 
+<p align="center">Discussion: <a href="https://news.ycombinator.com/item?id=47817349">Hacker News</a>.</p>
+
+> **For teams who want a durable Postgres queue on managed Postgres without `SKIP LOCKED` decay or another daemon in the stack** — PgQue gives you snapshot-based batching and zero-bloat hot paths in pure SQL. The rest of this README walks the history, comparison, and install paths that back up the claim.
+
 ## Contents
 
 - [Why PgQue](#why-pgque)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <p align="center">Discussion: <a href="https://news.ycombinator.com/item?id=47817349">Hacker News</a>.</p>
 
-> **For teams who want a durable Postgres queue on managed Postgres without `SKIP LOCKED` decay or another daemon in the stack** — PgQue gives you snapshot-based batching and zero-bloat hot paths in pure SQL. The rest of this README walks the history, comparison, and install paths that back up the claim.
+> **For teams who want a durable event stream inside Postgres — closer to a Kafka topic than to a `SKIP LOCKED` job queue.** Shared event log, independent per-consumer cursors, zero bloat under sustained load. Pure SQL, any Postgres 14+ — managed or self-hosted, no sidecar daemon. The rest of this README walks the history, comparison, and install paths that back up the claim.
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 Discussion on [Hacker News](https://news.ycombinator.com/item?id=47817349).
 
-*For teams who want a durable event stream inside Postgres — closer to a Kafka topic than to a `SKIP LOCKED` job queue. Shared event log, independent per-consumer cursors, zero bloat under sustained load. Pure SQL, any Postgres 14+ — managed or self-hosted, no sidecar daemon. The rest of this README walks the history, comparison, and install paths that back up the claim.*
+*For teams who want a durable event stream inside Postgres. The model is closer to Kafka (log) than to ActiveMQ or RabbitMQ (task message queue). Shared event log, independent per-consumer cursors, zero bloat under sustained load. Pure SQL, any Postgres 14+ — managed or self-hosted, no sidecar daemon. The rest of this README walks the history, comparison, and install paths that back up the claim.*
 
 ## Contents
 


### PR DESCRIPTION
## Summary

Two small additions near the top of \`README.md\`:

1. **Buyer self-qualification.** A one-line blockquote after the hero gif that names the audience ("teams who want a durable Postgres queue on managed Postgres without SKIP LOCKED decay or another daemon") and the tools ("snapshot-based batching, zero-bloat hot paths, pure SQL"). Lets a reader decide whether to keep reading before the history / comparison detail starts.
2. **HN discussion link.** Centered line below the badges + hero gif pointing at [news.ycombinator.com/item?id=47817349](https://news.ycombinator.com/item?id=47817349). First-screen visible without crowding the hero.

## Closes

#71 — nathan-widjaja's suggestion to move the switching moment above the history/comparison sections.

## Placement

```
title
tagline
badges
hero gif
HN discussion link         <- new
self-qualification line    <- new
Contents
Why PgQue → History → Comparison → ...
```

## Test plan

- [x] No SQL touched; no CI impact.
- [x] Links verified (HN thread id is the real one the issue cites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)