### PR TITLE
fix: follow-ups to #75 (quote_ident, dlq partial-success, Nack tests)

### DIFF
--- a/build/transform.sh
+++ b/build/transform.sh
@@ -500,6 +500,39 @@ sedi "s|batch.tx_start := rec.id1;|batch.tx_start := rec.id1::text::bigint;|" \
 
 echo "PASS: xid8 casts added to batch_event_sql for ev_txid comparisons"
 
+# Fix upstream upgrade_schema(): use explicit grants instead of "in role" (the
+# original "create role pgque_admin in role pgque_reader, pgque_writer" works
+# but is harder to read and the role-creation case in PR review surfaced it as
+# inverted-looking). Also return the actual mutation count instead of a
+# hard-coded 0.
+UPGRADE_SCHEMA_FILE="${OUTPUT_DIR}/functions/pgque.upgrade_schema.sql"
+awk '
+/create role pgque_admin in role pgque_reader, pgque_writer;/ {
+  sub(/create role pgque_admin in role pgque_reader, pgque_writer;/, "create role pgque_admin;\n        grant pgque_reader to pgque_admin;\n        grant pgque_writer to pgque_admin;")
+}
+{ print }
+' "${UPGRADE_SCHEMA_FILE}" > "${UPGRADE_SCHEMA_FILE}.tmp" && mv "${UPGRADE_SCHEMA_FILE}.tmp" "${UPGRADE_SCHEMA_FILE}"
+sedi 's|^    return 0;$|    return cnt;|' "${UPGRADE_SCHEMA_FILE}"
+
+echo "PASS: upgrade_schema role grants flattened, return cnt"
+
+# Fix upstream insert_event_raw(): raise a clear "queue not found" error when
+# the queue lookup misses, instead of falling through to a NULL-deref later.
+INSERT_EVENT_FILE="${OUTPUT_DIR}/lowlevel_pl/insert_event.sql"
+awk '
+/from pgque\.queue q where q\.queue_name = _qname into qstate;/ {
+  print
+  print ""
+  print "    if not found then"
+  print "        raise exception '\''queue not found: %'\'', _qname;"
+  print "    end if;"
+  next
+}
+{ print }
+' "${INSERT_EVENT_FILE}" > "${INSERT_EVENT_FILE}.tmp" && mv "${INSERT_EVENT_FILE}.tmp" "${INSERT_EVENT_FILE}"
+
+echo "PASS: insert_event_raw raises clear error on unknown queue"
+
 # -- Assembly: build sql/pgque.sql ------------------------------------
 
 echo ""

--- a/clients/go/pgque_test.go
+++ b/clients/go/pgque_test.go
@@ -2,7 +2,9 @@ package pgque_test
 
 import (
 	"context"
+	"errors"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -95,6 +97,133 @@ func TestSendAndReceive(t *testing.T) {
 	err = client.Ack(ctx, msgs[0].BatchID)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestNack(t *testing.T) {
+	ctx := context.Background()
+	client, err := pgque.Connect(ctx, getDSN())
+	if err != nil {
+		t.Skip("Cannot connect to PG:", err)
+	}
+	defer client.Close()
+	setupQueue(t, client)
+
+	if _, err = client.Send(ctx, "gotest_queue", pgque.Event{
+		Type:    "nack.test",
+		Payload: map[string]any{"v": 1},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = client.Pool().Exec(ctx, "SELECT pgque.ticker()"); err != nil {
+		t.Fatal(err)
+	}
+
+	msgs, err := client.Receive(ctx, "gotest_queue", "gotest_consumer", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+
+	// retry_count starts at null which coalesces to 0; default queue_max_retries
+	// is 5; so this nack should route to retry_queue, not the DLQ.
+	if err := client.Nack(ctx, msgs[0].BatchID, msgs[0]); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Ack(ctx, msgs[0].BatchID); err != nil {
+		t.Fatal(err)
+	}
+
+	var retryCount int
+	if err := client.Pool().QueryRow(ctx, `
+		SELECT count(*) FROM pgque.retry_queue rq
+		JOIN pgque.queue q ON q.queue_id = rq.ev_queue
+		WHERE q.queue_name = $1`, "gotest_queue").Scan(&retryCount); err != nil {
+		t.Fatal(err)
+	}
+	if retryCount != 1 {
+		t.Fatalf("expected 1 row in retry_queue, got %d", retryCount)
+	}
+
+	var dlqCount int
+	if err := client.Pool().QueryRow(ctx, `
+		SELECT count(*) FROM pgque.dead_letter dl
+		JOIN pgque.queue q ON q.queue_id = dl.dl_queue_id
+		WHERE q.queue_name = $1`, "gotest_queue").Scan(&dlqCount); err != nil {
+		t.Fatal(err)
+	}
+	if dlqCount != 0 {
+		t.Fatalf("expected 0 rows in DLQ (under retry limit), got %d", dlqCount)
+	}
+}
+
+func TestConsumerHandlerNacksOnError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client, err := pgque.Connect(ctx, getDSN())
+	if err != nil {
+		t.Skip("Cannot connect to PG:", err)
+	}
+	defer client.Close()
+	setupQueue(t, client)
+
+	// Two messages in the same batch: first handler errors, second succeeds.
+	// The failing one should be nack'd individually; the successful one should
+	// still complete; the batch overall should be ack'd.
+	for i := 0; i < 2; i++ {
+		if _, err = client.Send(ctx, "gotest_queue", pgque.Event{
+			Type:    "fail.test",
+			Payload: map[string]any{"i": i},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err = client.Pool().Exec(ctx, "SELECT pgque.ticker()"); err != nil {
+		t.Fatal(err)
+	}
+
+	var seen int32
+	consumer := client.NewConsumer("gotest_queue", "gotest_consumer",
+		pgque.WithPollInterval(100*time.Millisecond),
+	)
+	consumer.Handle("fail.test", func(ctx context.Context, msg pgque.Message) error {
+		n := atomic.AddInt32(&seen, 1)
+		if n == 1 {
+			return errors.New("simulated handler failure")
+		}
+		return nil
+	})
+
+	consumerCtx, consumerCancel := context.WithCancel(ctx)
+	defer consumerCancel()
+	go consumer.Start(consumerCtx)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(&seen) >= 2 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if atomic.LoadInt32(&seen) < 2 {
+		t.Fatalf("expected handler to be called for both messages, got %d", seen)
+	}
+	consumerCancel()
+
+	// The failing message should have landed in retry_queue (per-message nack),
+	// not been silently dropped along with the batch.
+	var retryCount int
+	if err := client.Pool().QueryRow(ctx, `
+		SELECT count(*) FROM pgque.retry_queue rq
+		JOIN pgque.queue q ON q.queue_id = rq.ev_queue
+		WHERE q.queue_name = $1`, "gotest_queue").Scan(&retryCount); err != nil {
+		t.Fatal(err)
+	}
+	if retryCount != 1 {
+		t.Fatalf("expected 1 retry_queue entry (the failing message), got %d", retryCount)
 	}
 }
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -287,9 +287,16 @@ Grant: `pgque_reader`. Source: `sql/pgque-additions/dlq.sql`.
 Re-inserts one dead-letter entry into its original queue and deletes it from `pgque.dead_letter`. Returns the new event id.
 Grant: `pgque_writer`. Source: `sql/pgque-additions/dlq.sql`.
 
-#### `pgque.dlq_replay_all(queue text) → integer`
+#### `pgque.dlq_replay_all(queue text) → (replayed bigint, failed bigint, first_error text)`
 
-Replays every dead-letter entry for `queue`. Returns the number of events replayed.
+Replays every dead-letter entry for `queue`. Per-event failures are isolated (one bad row does not abort the rest), surfaced via `raise warning`, and counted in `failed`; `first_error` carries the first failure's `dl_id` and `sqlerrm` for diagnostics.
+
+Breaking change in v0.2: previously returned a single `integer` count. Existing callers should switch to:
+
+```sql
+select replayed, failed, first_error from pgque.dlq_replay_all('orders');
+```
+
 Grant: `pgque_writer`. Source: `sql/pgque-additions/dlq.sql`.
 
 #### `pgque.dlq_purge(queue text, older_than interval default '30 days') → integer`

--- a/sql/pgque-additions/dlq.sql
+++ b/sql/pgque-additions/dlq.sql
@@ -123,13 +123,33 @@ begin
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
--- pgque.dlq_replay_all() -- replay all DLQ events for a queue
-create or replace function pgque.dlq_replay_all(i_queue_name text)
-returns integer as $$
+-- pgque.dlq_replay_all() -- replay all DLQ events for a queue.
+--
+-- Returns a single row (replayed, failed, first_error). Per-event failures are
+-- caught so one bad event does not abort the rest, and surfaced via raise
+-- warning (visible at the default log_min_messages = warning, unlike notice
+-- which is hidden under many production configs). Callers can check
+-- failed > 0 to detect partial success programmatically.
+--
+-- Return-type change from v0.1's bare integer count to a record is a breaking
+-- API change accepted at the v0.2 cut. Callers previously doing
+--   select pgque.dlq_replay_all('q')          -- returned int
+-- should switch to
+--   select replayed from pgque.dlq_replay_all('q')
+-- or destructure all three columns.
+--
+-- Drop first so upgrades from v0.1 do not hit "cannot change return type".
+drop function if exists pgque.dlq_replay_all(text);
+create or replace function pgque.dlq_replay_all(i_queue_name text,
+    out replayed bigint, out failed bigint, out first_error text)
+returns record as $$
 declare
     v_dl record;
-    v_cnt integer := 0;
 begin
+    replayed := 0;
+    failed := 0;
+    first_error := null;
+
     for v_dl in
         select dl.dl_id, dl.ev_type, dl.ev_data,
                dl.ev_extra1, dl.ev_extra2, dl.ev_extra3, dl.ev_extra4,
@@ -142,14 +162,16 @@ begin
             perform pgque.insert_event(v_dl.queue_name, v_dl.ev_type, v_dl.ev_data,
                 v_dl.ev_extra1, v_dl.ev_extra2, v_dl.ev_extra3, v_dl.ev_extra4);
             delete from pgque.dead_letter where dl_id = v_dl.dl_id;
-            v_cnt := v_cnt + 1;
+            replayed := replayed + 1;
         exception when others then
-            raise notice 'dlq_replay_all: failed to replay dl_id=%, error: %',
+            failed := failed + 1;
+            if first_error is null then
+                first_error := format('dl_id=%s: %s', v_dl.dl_id, sqlerrm);
+            end if;
+            raise warning 'dlq_replay_all: failed to replay dl_id=%, error: %',
                 v_dl.dl_id, sqlerrm;
         end;
     end loop;
-
-    return v_cnt;
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 

--- a/sql/pgque-api/maint.sql
+++ b/sql/pgque-api/maint.sql
@@ -22,7 +22,12 @@ begin
         if f.func_name = 'pgque.maint_rotate_tables_step2' then
             continue;
         elsif f.func_name = 'vacuum' then
-            sql := 'vacuum ' || quote_ident(f.func_arg);
+            -- func_arg is "schema.table" (see pgque.maint_tables_to_vacuum).
+            -- Split and quote each side; quote_ident on the joined string
+            -- would yield "schema.table" (one identifier with a literal dot).
+            sql := format('vacuum %I.%I',
+                split_part(f.func_arg, '.', 1),
+                split_part(f.func_arg, '.', 2));
             execute sql;
             total := total + 1;
         elsif f.func_arg is not null then

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -4398,13 +4398,33 @@ begin
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
--- pgque.dlq_replay_all() -- replay all DLQ events for a queue
-create or replace function pgque.dlq_replay_all(i_queue_name text)
-returns integer as $$
+-- pgque.dlq_replay_all() -- replay all DLQ events for a queue.
+--
+-- Returns a single row (replayed, failed, first_error). Per-event failures are
+-- caught so one bad event does not abort the rest, and surfaced via raise
+-- warning (visible at the default log_min_messages = warning, unlike notice
+-- which is hidden under many production configs). Callers can check
+-- failed > 0 to detect partial success programmatically.
+--
+-- Return-type change from v0.1's bare integer count to a record is a breaking
+-- API change accepted at the v0.2 cut. Callers previously doing
+--   select pgque.dlq_replay_all('q')          -- returned int
+-- should switch to
+--   select replayed from pgque.dlq_replay_all('q')
+-- or destructure all three columns.
+--
+-- Drop first so upgrades from v0.1 do not hit "cannot change return type".
+drop function if exists pgque.dlq_replay_all(text);
+create or replace function pgque.dlq_replay_all(i_queue_name text,
+    out replayed bigint, out failed bigint, out first_error text)
+returns record as $$
 declare
     v_dl record;
-    v_cnt integer := 0;
 begin
+    replayed := 0;
+    failed := 0;
+    first_error := null;
+
     for v_dl in
         select dl.dl_id, dl.ev_type, dl.ev_data,
                dl.ev_extra1, dl.ev_extra2, dl.ev_extra3, dl.ev_extra4,
@@ -4417,14 +4437,16 @@ begin
             perform pgque.insert_event(v_dl.queue_name, v_dl.ev_type, v_dl.ev_data,
                 v_dl.ev_extra1, v_dl.ev_extra2, v_dl.ev_extra3, v_dl.ev_extra4);
             delete from pgque.dead_letter where dl_id = v_dl.dl_id;
-            v_cnt := v_cnt + 1;
+            replayed := replayed + 1;
         exception when others then
-            raise notice 'dlq_replay_all: failed to replay dl_id=%, error: %',
+            failed := failed + 1;
+            if first_error is null then
+                first_error := format('dl_id=%s: %s', v_dl.dl_id, sqlerrm);
+            end if;
+            raise warning 'dlq_replay_all: failed to replay dl_id=%, error: %',
                 v_dl.dl_id, sqlerrm;
         end;
     end loop;
-
-    return v_cnt;
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
@@ -4502,7 +4524,12 @@ begin
         if f.func_name = 'pgque.maint_rotate_tables_step2' then
             continue;
         elsif f.func_name = 'vacuum' then
-            sql := 'vacuum ' || f.func_arg;
+            -- func_arg is "schema.table" (see pgque.maint_tables_to_vacuum).
+            -- Split and quote each side; quote_ident on the joined string
+            -- would yield "schema.table" (one identifier with a literal dot).
+            sql := format('vacuum %I.%I',
+                split_part(f.func_arg, '.', 1),
+                split_part(f.func_arg, '.', 2));
             execute sql;
             total := total + 1;
         elsif f.func_arg is not null then


### PR DESCRIPTION
Follow-up to #75 addressing review items and a build-pipeline reconciliation that #75 missed.

## Why a follow-up rather than rewriting #75

#75 landed three valuable fixes from @hobostay — Go consumer per-message nack, `dlq_replay_all` exception isolation, queue-existence check in `insert_event_raw`. The substantive logic is correct; the issues are at the edges (one regression, one visibility gap, missing test, and several edits placed in an auto-generated file). Merging #75 as-is preserved their commits cleanly; this PR layers the fixes on top.

## What this PR does

### `sql/pgque-api/maint.sql` — quote_ident regression on schema-qualified VACUUM

`quote_ident(f.func_arg)` is wrong. `func_arg` comes from `pgque.maint_tables_to_vacuum()` as `"schema.table"` — one string with a literal dot — so `quote_ident` wraps the whole thing as a single identifier and produces `vacuum "pgque.event_0"` instead of `vacuum "pgque"."event_0"`. The latter is what PostgreSQL actually needs. Fix: split on the dot and quote each side via `format('vacuum %I.%I', ...)`. Safer than the pre-#75 raw concatenation and correct under quoting.

The bug is invisible to existing tests because `maint_tables_to_vacuum()` returns nothing when `autovacuum = on` (the default) — flagged in the original review.

### `sql/pgque-additions/dlq.sql` — `dlq_replay_all` partial-success visibility

The per-event exception block used `raise notice`. NOTICE is hidden under most production configs (`log_min_messages = warning` by default), so partial failures became silent. Two changes:

1. Switch to `raise warning` — visible in default logs.
2. Change the return type from bare `integer` to a record `(replayed bigint, failed bigint, first_error text)` so callers can detect partial success programmatically.

`drop function if exists` added before the `create or replace` because PG doesn't allow CREATE OR REPLACE to change a function's return type. `docs/reference.md` updated.

**Breaking change:** Existing callers doing `select pgque.dlq_replay_all('q')` need to switch to `select replayed from pgque.dlq_replay_all('q')` (or destructure all three columns). Acceptable at the v0.2 cut. No existing tests called this function.

### `clients/go/pgque_test.go` — Nack and per-message nack coverage

Adds `TestNack` and `TestConsumerHandlerNacksOnError` covering the behavior #75 introduced. Verifies that a failing handler nacks its own message into `pgque.retry_queue` (not the DLQ — `retry_count` starts below `max_retries`) without aborting the rest of the batch. Env-gated via `PGQUE_TEST_DSN`, matching the existing test style.

### `build/transform.sh` — reconcile direct edits to the generated `pgque.sql`

Two of #75's source-level changes were applied directly to `sql/pgque.sql`:

- `upgrade_schema()` — flattened `create role pgque_admin in role pgque_reader, pgque_writer` into explicit `grant ... to pgque_admin` calls; changed `return 0` to `return cnt`.
- `insert_event_raw()` — raises `queue not found: %` when the lookup misses, instead of falling through to a NULL-deref later.

`sql/pgque.sql` is auto-generated from `pgq/` + `sql/pgque-additions/` + `sql/pgque-api/` by `build/transform.sh`. Direct edits to it get clobbered on the next rebuild. Re-applied both as post-transform patches in `transform.sh` so the changes survive.

### `sql/pgque.sql` — regenerated

Verification runner reports all checks pass: schema rename, search_path on every SECURITY DEFINER, no `queue_per_tx_limit`/`default_with_oids` leakage, idempotent CREATE TABLE/SEQUENCE/INDEX.

## Build pipeline note

Anyone editing `sql/pgque.sql` should instead edit the corresponding source under `sql/pgque-additions/`, `sql/pgque-api/`, or add a patch in `build/transform.sh`. The build's self-verification catches transformation drift but does not catch direct edits to the generated file that lack a source.

## Test plan

- [ ] CI green across PG14–18
- [ ] `client-smoke` job green (Go test compilation; integration tests env-gated)
- [ ] `verify` job green (transform.sh reproducibility check)
- [ ] Manual: `\i sql/pgque.sql` succeeds against a fresh PG18
- [ ] Manual: `select * from pgque.dlq_replay_all('q')` returns the expected three-column shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)