### PR TITLE
fix(pgque.receive): reject max_return < 1 and document batch-ownership

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -69,12 +69,14 @@ The consume API wraps `pgque.next_batch`, `pgque.get_batch_events`, `pgque.finis
 
 #### `pgque.receive(queue text, consumer text, max_return int default 100) → setof pgque.message`
 
-Pulls the next batch for `consumer` on `queue` and streams up to `max_return` messages. Returns an empty set if no batch is available. Each row is a `pgque.message` composite (see [§Message type](#message-type)).
+Pulls the next batch for `consumer` on `queue` and streams up to `max_return` messages. `max_return` must be >= 1; passing 0 or a negative value raises an error. Returns an empty set if no batch is available. Each row is a `pgque.message` composite (see [§Message type](#message-type)).
 Grant: `pgque_writer`. Source: `sql/pgque-api/receive.sql`.
 
 ```sql
 select * from pgque.receive('orders', 'processor', 100);
 ```
+
+**Batch-ownership caveat.** `max_return` limits the number of rows returned to the caller, but `ack(batch_id)` advances the consumer cursor past the entire underlying batch. If `max_return < ticker_max_count`, calling `ack()` after a partial receive will drop the unreturned rows from the consumer's perspective. Either consume the full batch before acking, or use `max_return >= ticker_max_count` for safe pagination.
 
 #### `pgque.ack(batch_id bigint) → integer`
 

--- a/sql/pgque-api/receive.sql
+++ b/sql/pgque-api/receive.sql
@@ -32,6 +32,10 @@ declare
     ev record;
     cnt int := 0;
 begin
+    if i_max_return < 1 then
+        raise exception 'pgque.receive: max_return must be >= 1, got %', i_max_return;
+    end if;
+
     -- Get next batch (may return NULL if no events)
     v_batch_id := pgque.next_batch(i_queue, i_consumer);
     if v_batch_id is null then

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -4580,6 +4580,10 @@ declare
     ev record;
     cnt int := 0;
 begin
+    if i_max_return < 1 then
+        raise exception 'pgque.receive: max_return must be >= 1, got %', i_max_return;
+    end if;
+
     -- Get next batch (may return NULL if no events)
     v_batch_id := pgque.next_batch(i_queue, i_consumer);
     if v_batch_id is null then

--- a/tests/test_api_receive.sql
+++ b/tests/test_api_receive.sql
@@ -179,6 +179,29 @@ begin
   raise notice 'PASS: send(text) preserves payload byte-for-byte (incl. untyped literal)';
 end $$;
 
+-- Step 8: max_return < 1 must raise an error
+do $$
+begin
+  perform pgque.create_queue('test_recv_maxzero');
+  perform pgque.register_consumer('test_recv_maxzero', 'c1');
+end $$;
+
+do $$
+declare
+  v_raised boolean := false;
+begin
+  begin
+    perform * from pgque.receive('test_recv_maxzero', 'c1', 0);
+  exception
+    when others then
+      v_raised := true;
+      assert sqlerrm like '%max_return must be >= 1%',
+        'expected max_return validation error, got: ' || sqlerrm;
+  end;
+  assert v_raised, 'receive(..., 0) must raise an error';
+  raise notice 'PASS: receive rejects max_return < 1';
+end $$;
+
 -- Cleanup
 do $$
 begin
@@ -188,5 +211,7 @@ begin
   perform pgque.drop_queue('test_recv_partial');
   perform pgque.unregister_consumer('test_recv_text', 'c1');
   perform pgque.drop_queue('test_recv_text');
+  perform pgque.unregister_consumer('test_recv_maxzero', 'c1');
+  perform pgque.drop_queue('test_recv_maxzero');
   raise notice 'PASS: receive + ack semantics';
 end $$;


### PR DESCRIPTION
## Summary

Closes #95.

Two related issues in `pgque.receive(queue, consumer, max_return)` are fixed or documented in this PR:

- **Input validation (fix):** `max_return < 1` now raises `pgque.receive: max_return must be >= 1, got <n>` immediately, before any batch is opened. This eliminates the off-by-one where `max_return = 0` silently returned 1 row.
- **Batch-ownership caveat (docs):** A warning is added to `docs/reference.md` clarifying that `ack(batch_id)` always advances the consumer cursor past the full underlying batch, regardless of how many rows `receive()` returned. Changing batch semantics is deferred to v0.3.

## Test evidence

Red commit confirmed failure before fix:
```
psql:tests/test_api_receive.sql:203: ERROR:  receive(..., 0) must raise an error
CONTEXT:  PL/pgSQL function inline_code_block line 13 at ASSERT
```

Green after fix — full suite output:
```
=== pgque regression test suite ===
...
psql:tests/test_api_receive.sql:203: NOTICE:  PASS: receive rejects max_return < 1
psql:tests/test_api_receive.sql:217: NOTICE:  PASS: receive + ack semantics
...
=== ALL TESTS PASSED ===
```

## Commits

1. `test:` red regression test asserting `receive(..., 0)` raises an error
2. `fix:` input guard in `sql/pgque.sql` — `raise exception` when `i_max_return < 1`
3. `docs:` batch-ownership caveat added to `docs/reference.md` under `pgque.receive()`