### PR TITLE
fix(clients/go): Nack placeholder, eager Connect ping, Consumer panic recovery

### DIFF
--- a/clients/go/consumer.go
+++ b/clients/go/consumer.go
@@ -5,6 +5,7 @@ package pgque
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"time"
 )
@@ -29,6 +30,17 @@ type Consumer struct {
 // for now; a future release will surface them via a default handler.
 func (c *Consumer) Handle(eventType string, fn HandlerFunc) {
 	c.handlers[eventType] = fn
+}
+
+// dispatchWithRecover calls fn and converts any panic into a non-nil
+// error so that the caller can nack the message and keep polling.
+func (c *Consumer) dispatchWithRecover(ctx context.Context, fn HandlerFunc, msg Message) (retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			retErr = fmt.Errorf("handler panic: %v", r)
+		}
+	}()
+	return fn(ctx, msg)
 }
 
 // Start begins the poll loop and blocks until ctx is cancelled. On
@@ -74,8 +86,8 @@ func (c *Consumer) Start(ctx context.Context) error {
 				}
 				continue
 			}
-			if err := handler(ctx, msg); err != nil {
-				log.Printf("pgque: handler error for %s: %v", msg.Type, err)
+			if handlerErr := c.dispatchWithRecover(ctx, handler, msg); handlerErr != nil {
+				log.Printf("pgque: handler error for %s: %v", msg.Type, handlerErr)
 				if nackErr := c.client.Nack(ctx, batchID, msg); nackErr != nil {
 					log.Printf("pgque: nack error for %s: %v", msg.Type, nackErr)
 				}

--- a/clients/go/pgque.go
+++ b/clients/go/pgque.go
@@ -20,10 +20,16 @@ type Client struct {
 
 // Connect opens a pgx connection pool to the given DSN and returns a
 // ready-to-use Client. The DSN format is the standard libpq connection
-// string (postgres://user:pass@host/db?...).
+// string (postgres://user:pass@host/db?...). Connect validates
+// connectivity by pinging the pool before returning; a bad DSN or
+// unreachable host surfaces as an error here, not on the first query.
 func Connect(ctx context.Context, dsn string) (*Client, error) {
 	pool, err := pgxpool.New(ctx, dsn)
 	if err != nil {
+		return nil, fmt.Errorf("pgque: connect: %w", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
 		return nil, fmt.Errorf("pgque: connect: %w", err)
 	}
 	return &Client{pool: pool}, nil

--- a/clients/go/pgque.go
+++ b/clients/go/pgque.go
@@ -106,9 +106,11 @@ func (c *Client) Ack(ctx context.Context, batchID int64) error {
 }
 
 // Nack negatively acknowledges a single message, routing it to retry or DLQ.
+// pgque.message has 10 fields: msg_id, batch_id, type, payload, retry_count,
+// created_at, extra1, extra2, extra3, extra4 — placeholders $2..$11.
 func (c *Client) Nack(ctx context.Context, batchID int64, msg Message) error {
 	_, err := c.pool.Exec(ctx,
-		"SELECT pgque.nack($1, ROW($2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)::pgque.message, '60 seconds'::interval, null)",
+		"SELECT pgque.nack($1, ROW($2,$3,$4,$5,$6,$7,$8,$9,$10,$11)::pgque.message, '60 seconds'::interval, null)",
 		batchID, msg.MsgID, msg.BatchID, msg.Type, msg.Payload,
 		msg.RetryCount, msg.CreatedAt,
 		msg.Extra1, msg.Extra2, msg.Extra3, msg.Extra4)

--- a/clients/go/pgque_test.go
+++ b/clients/go/pgque_test.go
@@ -159,6 +159,155 @@ func TestNack(t *testing.T) {
 	}
 }
 
+// TestNackPlaceholderCount is a red/green regression for a bug where the
+// Nack() SQL string had 12 placeholders but only 11 args were passed,
+// because the ROW(...) cast targeting pgque.message (10 fields) included
+// a trailing $12 typo. pgx fails the query with "expected 12 arguments,
+// got 11". Pre-fix this test fails on the call to client.Nack(); post-fix
+// it passes. The bug shipped because client-smoke ran `go test -run
+// TestSmoke` which matched no tests, so TestNack never executed in CI.
+func TestNackPlaceholderCount(t *testing.T) {
+	ctx := context.Background()
+	client, err := pgque.Connect(ctx, getDSN())
+	if err != nil {
+		t.Skip("Cannot connect to PG:", err)
+	}
+	defer client.Close()
+	setupQueue(t, client)
+
+	if _, err = client.Send(ctx, "gotest_queue", pgque.Event{
+		Type:    "nack.placeholder",
+		Payload: map[string]any{"v": 1},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = client.Pool().Exec(ctx, "SELECT pgque.ticker()"); err != nil {
+		t.Fatal(err)
+	}
+
+	msgs, err := client.Receive(ctx, "gotest_queue", "gotest_consumer", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+
+	// The whole point: this call must succeed against a live DB.
+	if err := client.Nack(ctx, msgs[0].BatchID, msgs[0]); err != nil {
+		t.Fatalf("Nack() returned error (placeholder/arg mismatch?): %v", err)
+	}
+}
+
+// TestConnect_UnreachableHostFailsImmediately is a red/green regression
+// for Connect() accepting unreachable hosts because pgxpool.New is lazy.
+// Pre-fix Connect returns nil error; the failure surfaces only on the
+// first query, far from the call site. Post-fix Connect eagerly pings
+// the pool and returns an error within ~3s.
+func TestConnect_UnreachableHostFailsImmediately(t *testing.T) {
+	// Port 1 is reserved/unassigned and reliably refuses connections.
+	dsn := "postgres://nobody:nobody@127.0.0.1:1/none?sslmode=disable&connect_timeout=2"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	client, err := pgque.Connect(ctx, dsn)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		if client != nil {
+			client.Close()
+		}
+		t.Fatalf("expected Connect to fail for unreachable host, got nil error after %s", elapsed)
+	}
+	if elapsed > 4*time.Second {
+		t.Fatalf("Connect took %s; should fail within ~3s with eager ping", elapsed)
+	}
+}
+
+// TestConsumer_HandlerPanicRecoversAndContinues is a red/green regression
+// for Consumer.Start letting handler panics propagate, killing the poll
+// goroutine and stalling the queue. Pre-fix: the panic on the first
+// message kills the consumer goroutine; the second message never reaches
+// its handler; the test fails with "got 1, expected 2". Post-fix: the
+// consumer recovers, treats the panic as a handler error (nack), and
+// continues processing.
+//
+// The goroutine's defer recover() in this test is purely a safety net so
+// that pre-fix runs do not crash the test process — it does not mask the
+// failure mode (which is "consumer never sees the second message").
+func TestConsumer_HandlerPanicRecoversAndContinues(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client, err := pgque.Connect(ctx, getDSN())
+	if err != nil {
+		t.Skip("Cannot connect to PG:", err)
+	}
+	defer client.Close()
+	setupQueue(t, client)
+
+	for i := 0; i < 2; i++ {
+		if _, err = client.Send(ctx, "gotest_queue", pgque.Event{
+			Type:    "panic.test",
+			Payload: map[string]any{"i": i},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err = client.Pool().Exec(ctx, "SELECT pgque.ticker()"); err != nil {
+		t.Fatal(err)
+	}
+
+	var seen int32
+	consumer := client.NewConsumer("gotest_queue", "gotest_consumer",
+		pgque.WithPollInterval(100*time.Millisecond),
+	)
+	consumer.Handle("panic.test", func(ctx context.Context, msg pgque.Message) error {
+		n := atomic.AddInt32(&seen, 1)
+		if n == 1 {
+			panic("simulated handler panic")
+		}
+		return nil
+	})
+
+	consumerCtx, consumerCancel := context.WithCancel(ctx)
+	defer consumerCancel()
+	go func() {
+		// Test-side safety net: contain the panic so the test process
+		// survives pre-fix (when production code does not recover).
+		// Survival of the goroutine itself is what we are testing —
+		// detected by whether the second message gets handled.
+		defer func() { _ = recover() }()
+		_ = consumer.Start(consumerCtx)
+	}()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(&seen) >= 2 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if atomic.LoadInt32(&seen) < 2 {
+		t.Fatalf("expected handler to be called for both messages (panic recovered), got %d", seen)
+	}
+	consumerCancel()
+
+	// The panicking message should have been nack'd, not silently dropped.
+	var retryCount int
+	if err := client.Pool().QueryRow(ctx, `
+		SELECT count(*) FROM pgque.retry_queue rq
+		JOIN pgque.queue q ON q.queue_id = rq.ev_queue
+		WHERE q.queue_name = $1`, "gotest_queue").Scan(&retryCount); err != nil {
+		t.Fatal(err)
+	}
+	if retryCount != 1 {
+		t.Fatalf("expected 1 retry_queue entry (panicking message), got %d", retryCount)
+	}
+}
+
 func TestConsumerHandlerNacksOnError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/clients/go/pgque_test.go
+++ b/clients/go/pgque_test.go
@@ -26,13 +26,50 @@ func setupQueue(t *testing.T, client *pgque.Client) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Lower the ticker thresholds so tests don't have to wait 3 s for a tick.
+	// Parameter names are the column name suffix: queue_ticker_max_count →
+	// "ticker_max_count". Setting count=1 means one event is enough; lag=1ms.
+	_, err = client.Pool().Exec(ctx,
+		"SELECT pgque.set_queue_config('gotest_queue', 'ticker_max_count', '1')")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Pool().Exec(ctx,
+		"SELECT pgque.set_queue_config('gotest_queue', 'ticker_max_lag', '1ms')")
+	if err != nil {
+		t.Fatal(err)
+	}
 	_, err = client.Pool().Exec(ctx, "SELECT pgque.register_consumer('gotest_queue', 'gotest_consumer')")
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		client.Pool().Exec(ctx, "SELECT pgque.unregister_consumer('gotest_queue', 'gotest_consumer')")
-		client.Pool().Exec(ctx, "SELECT pgque.drop_queue('gotest_queue')")
+		// Open a fresh connection for cleanup: the test's defer client.Close()
+		// runs before t.Cleanup fires (defer is in the test body scope),
+		// so the outer client pool is already closed at this point.
+		cleanDSN := getDSN()
+		cleanClient, cleanErr := pgque.Connect(ctx, cleanDSN)
+		if cleanErr != nil {
+			t.Logf("setupQueue cleanup: cannot connect for teardown: %v", cleanErr)
+			return
+		}
+		defer cleanClient.Close()
+
+		// Remove retry_queue / dead_letter entries before dropping the queue
+		// so stale rows don't leak into a subsequent test that gets the same
+		// queue_id from the sequence.
+		cleanClient.Pool().Exec(ctx, `
+			DELETE FROM pgque.retry_queue rq
+			USING pgque.queue q
+			WHERE q.queue_id = rq.ev_queue
+			  AND q.queue_name = 'gotest_queue'`)
+		cleanClient.Pool().Exec(ctx, `
+			DELETE FROM pgque.dead_letter dl
+			USING pgque.queue q
+			WHERE q.queue_id = dl.dl_queue_id
+			  AND q.queue_name = 'gotest_queue'`)
+		cleanClient.Pool().Exec(ctx, "SELECT pgque.unregister_consumer('gotest_queue', 'gotest_consumer')")
+		cleanClient.Pool().Exec(ctx, "SELECT pgque.drop_queue('gotest_queue')")
 	})
 }
 


### PR DESCRIPTION
Closes #91.

## Bugs fixed

Three regressions caught by red tests written in commit `672615b`.

| # | Bug | Fix commit |
|---|-----|-----------|
| 1 | `Nack()` SQL had 11 placeholders (`$2..$12`) but `pgque.message` has 10 fields — pgx rejected the query with `42846` | `6d7b04a` |
| 2 | `Connect()` called `pgxpool.New` (lazy) and returned `nil` error for unreachable hosts — failure only surfaced on the first query | `bc4a2b9` |
| 3 | Handler panic in `Consumer.Start` killed the poll goroutine and stalled the queue — subsequent messages were never delivered | `0102caf` |

A fourth commit (`7f2797d`) improves test setup/teardown: lowers per-queue ticker thresholds, opens a fresh pool for cleanup to avoid use-after-close, and purges `retry_queue`/`dead_letter` rows before `drop_queue`.

## Full `go test` output (local PG, all green)

```
=== RUN   TestSend
--- PASS: TestSend (0.05s)
=== RUN   TestSendAndReceive
--- PASS: TestSendAndReceive (0.03s)
=== RUN   TestNack
--- PASS: TestNack (0.03s)
=== RUN   TestNackPlaceholderCount
--- PASS: TestNackPlaceholderCount (0.02s)
=== RUN   TestConnect_UnreachableHostFailsImmediately
--- PASS: TestConnect_UnreachableHostFailsImmediately (0.00s)
=== RUN   TestConsumer_HandlerPanicRecoversAndContinues
2026/04/30 02:16:44 pgque: handler error for panic.test: handler panic: simulated handler panic
--- PASS: TestConsumer_HandlerPanicRecoversAndContinues (0.07s)
=== RUN   TestConsumerHandlerNacksOnError
2026/04/30 02:16:44 pgque: handler error for fail.test: simulated handler failure
--- PASS: TestConsumerHandlerNacksOnError (0.07s)
=== RUN   TestConsumerHandlerDispatch
2026/04/30 02:16:44 pgque: receive error: pgque: receive: closed pool
--- PASS: TestConsumerHandlerDispatch (0.02s)
PASS
ok  	github.com/NikolayS/pgque/clients/go	0.675s
```

## Anti-leak confirmation

No internal GitLab, prospect, or benchmark work-item references in any changed file.