### PR TITLE
fix(pgque.nack): canonical + idempotent DLQ terminal handling

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -85,7 +85,14 @@ Grant: `pgque_writer`. Source: `sql/pgque-api/receive.sql`.
 
 #### `pgque.nack(batch_id bigint, msg pgque.message, retry_after interval default '60 seconds', reason text default null) → integer`
 
-Negative-acknowledges one message. If `msg.retry_count` is below the queue's `max_retries`, re-queues after `retry_after`; otherwise routes the event to `pgque.dead_letter` via `pgque.event_dead`. Returns `1`.
+Negative-acknowledges one message. Only `msg.msg_id` (and the `batch_id` argument) are honored from the composite — `type`, `payload`, `retry_count`, `created_at`, and the `extra*` fields are **ignored**. `nack()` re-queries the canonical event from the active batch and uses those server-side values for all decisions and writes.
+
+- If the canonical `ev_retry` is below the queue's `max_retries`, re-queues after `retry_after` (via `pgque.event_retry`).
+- If `ev_retry >= max_retries`, routes the canonical event to `pgque.dead_letter` (via `pgque.event_dead`). This is idempotent: repeated calls for the same terminal message produce exactly one DLQ row (the second call does nothing).
+- If `msg.msg_id` is not present in the active batch — including a `NULL` msg_id or a msg_id from a different batch — raises `msg_id % not found in batch %`.
+
+**v0.2 hardening note:** Prior versions trusted the caller-supplied `retry_count` to decide DLQ routing, which was a forge vector. Configure `max_retries` via `set_queue_config` to control DLQ promotion; do not forge `retry_count` in the composite.
+
 Grant: `pgque_writer`. Source: `sql/pgque-api/receive.sql`.
 
 ```sql

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -91,8 +91,6 @@ Negative-acknowledges one message. Only `msg.msg_id` (and the `batch_id` argumen
 - If `ev_retry >= max_retries`, routes the canonical event to `pgque.dead_letter` (via `pgque.event_dead`). This is idempotent: repeated calls for the same terminal message produce exactly one DLQ row (the second call does nothing).
 - If `msg.msg_id` is not present in the active batch — including a `NULL` msg_id or a msg_id from a different batch — raises `msg_id % not found in batch %`.
 
-**v0.2 hardening note:** Prior versions trusted the caller-supplied `retry_count` to decide DLQ routing, which was a forge vector. Configure `max_retries` via `set_queue_config` to control DLQ promotion; do not forge `retry_count` in the composite.
-
 Grant: `pgque_writer`. Source: `sql/pgque-api/receive.sql`.
 
 ```sql

--- a/sql/pgque-additions/dlq.sql
+++ b/sql/pgque-additions/dlq.sql
@@ -41,7 +41,14 @@ create table if not exists pgque.dead_letter (
 create index if not exists dl_queue_time_idx
     on pgque.dead_letter (dl_queue_id, dl_time);
 
+-- Unique index: one DLQ row per (queue, consumer, original ev_id).
+-- Required for idempotent insert in event_dead() (#104).
+create unique index if not exists dl_queue_consumer_ev_idx
+    on pgque.dead_letter (dl_queue_id, dl_consumer_id, ev_id);
+
 -- pgque.event_dead() -- move event to DLQ (called by nack() when max retries exceeded)
+-- The insert uses ON CONFLICT DO NOTHING so that repeated nack() calls for
+-- the same terminal message are idempotent (fix for #104).
 create or replace function pgque.event_dead(
     i_batch_id bigint,
     i_event_id bigint,
@@ -66,7 +73,8 @@ begin
         raise exception 'batch not found: %', i_batch_id;
     end if;
 
-    -- Insert into dead letter table (no re-query of batch events)
+    -- Idempotent insert: if the same (queue, consumer, ev_id) tuple already
+    -- exists (repeated nack() before ack()), silently skip the duplicate.
     insert into pgque.dead_letter (
         dl_queue_id, dl_consumer_id, dl_reason,
         ev_id, ev_time, ev_txid, ev_retry, ev_type, ev_data,
@@ -74,7 +82,8 @@ begin
     values (
         v_sub.sub_queue, v_sub.sub_consumer, i_reason,
         i_event_id, i_ev_time, i_ev_txid, i_ev_retry, i_ev_type, i_ev_data,
-        i_ev_extra1, i_ev_extra2, i_ev_extra3, i_ev_extra4);
+        i_ev_extra1, i_ev_extra2, i_ev_extra3, i_ev_extra4)
+    on conflict (dl_queue_id, dl_consumer_id, ev_id) do nothing;
 
     return 1;
 end;

--- a/sql/pgque-api/receive.sql
+++ b/sql/pgque-api/receive.sql
@@ -69,6 +69,15 @@ end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
 -- pgque.nack() -- retry or route to DLQ based on retry_count vs max_retries
+--
+-- Fix #98: re-query the canonical event row from the active batch using
+-- msg_id, instead of trusting caller-supplied pgque.message fields.
+-- A caller with an active batch could otherwise forge DLQ rows by
+-- supplying arbitrary ev_id / ev_type / ev_data in the composite.
+--
+-- Fix #104: DLQ insert is idempotent via ON CONFLICT in event_dead().
+-- Repeated nack() calls for the same terminal message produce exactly one
+-- dead_letter row.
 create or replace function pgque.nack(
     i_batch_id bigint,
     i_msg pgque.message,
@@ -77,8 +86,9 @@ create or replace function pgque.nack(
 returns integer as $$
 declare
     v_max_retries int4;
+    v_ev          record;
 begin
-    -- Single lookup: subscription -> queue config
+    -- Lookup: subscription -> queue config
     select coalesce(q.queue_max_retries, 5) into v_max_retries
     from pgque.subscription s
     join pgque.queue q on q.queue_id = s.sub_queue
@@ -88,16 +98,30 @@ begin
         raise exception 'batch not found: %', i_batch_id;
     end if;
 
-    if coalesce(i_msg.retry_count, 0) >= v_max_retries then
-        -- Move to dead letter queue (pass event fields, no re-query)
-        perform pgque.event_dead(i_batch_id, i_msg.msg_id,
+    -- Re-query the canonical event from the active batch (#98).
+    -- This ignores caller-supplied payload/type/extras and uses the real
+    -- values stored in the queue data tables.
+    select ev_id, ev_time, ev_txid, ev_retry, ev_type, ev_data,
+           ev_extra1, ev_extra2, ev_extra3, ev_extra4
+    into v_ev
+    from pgque.get_batch_events(i_batch_id)
+    where ev_id = i_msg.msg_id;
+
+    if not found then
+        raise exception 'msg_id % not found in batch %', i_msg.msg_id, i_batch_id;
+    end if;
+
+    if coalesce(v_ev.ev_retry, 0) >= v_max_retries then
+        -- Move to dead letter queue using canonical event data (#98).
+        -- event_dead() uses ON CONFLICT DO NOTHING for idempotency (#104).
+        perform pgque.event_dead(i_batch_id, v_ev.ev_id,
             coalesce(i_reason, 'max retries exceeded'),
-            i_msg.created_at, null::xid8, i_msg.retry_count,
-            i_msg.type, i_msg.payload,
-            i_msg.extra1, i_msg.extra2, i_msg.extra3, i_msg.extra4);
+            v_ev.ev_time, v_ev.ev_txid::text::xid8, v_ev.ev_retry,
+            v_ev.ev_type, v_ev.ev_data,
+            v_ev.ev_extra1, v_ev.ev_extra2, v_ev.ev_extra3, v_ev.ev_extra4);
     else
         -- Retry after delay
-        perform pgque.event_retry(i_batch_id, i_msg.msg_id,
+        perform pgque.event_retry(i_batch_id, v_ev.ev_id,
             extract(epoch from i_retry_after)::integer);
     end if;
     return 1;

--- a/sql/pgque-api/receive.sql
+++ b/sql/pgque-api/receive.sql
@@ -114,6 +114,8 @@ begin
     if coalesce(v_ev.ev_retry, 0) >= v_max_retries then
         -- Move to dead letter queue using canonical event data (#98).
         -- event_dead() uses ON CONFLICT DO NOTHING for idempotency (#104).
+        -- ev_txid is bigint in get_batch_events (legacy PgQ signature); text
+        -- round-trip is the codebase convention to widen to xid8 without loss.
         perform pgque.event_dead(i_batch_id, v_ev.ev_id,
             coalesce(i_reason, 'max retries exceeded'),
             v_ev.ev_time, v_ev.ev_txid::text::xid8, v_ev.ev_retry,

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -4316,7 +4316,14 @@ create table if not exists pgque.dead_letter (
 create index if not exists dl_queue_time_idx
     on pgque.dead_letter (dl_queue_id, dl_time);
 
+-- Unique index: one DLQ row per (queue, consumer, original ev_id).
+-- Required for idempotent insert in event_dead() (#104).
+create unique index if not exists dl_queue_consumer_ev_idx
+    on pgque.dead_letter (dl_queue_id, dl_consumer_id, ev_id);
+
 -- pgque.event_dead() -- move event to DLQ (called by nack() when max retries exceeded)
+-- The insert uses ON CONFLICT DO NOTHING so that repeated nack() calls for
+-- the same terminal message are idempotent (fix for #104).
 create or replace function pgque.event_dead(
     i_batch_id bigint,
     i_event_id bigint,
@@ -4341,7 +4348,8 @@ begin
         raise exception 'batch not found: %', i_batch_id;
     end if;
 
-    -- Insert into dead letter table (no re-query of batch events)
+    -- Idempotent insert: if the same (queue, consumer, ev_id) tuple already
+    -- exists (repeated nack() before ack()), silently skip the duplicate.
     insert into pgque.dead_letter (
         dl_queue_id, dl_consumer_id, dl_reason,
         ev_id, ev_time, ev_txid, ev_retry, ev_type, ev_data,
@@ -4349,7 +4357,8 @@ begin
     values (
         v_sub.sub_queue, v_sub.sub_consumer, i_reason,
         i_event_id, i_ev_time, i_ev_txid, i_ev_retry, i_ev_type, i_ev_data,
-        i_ev_extra1, i_ev_extra2, i_ev_extra3, i_ev_extra4);
+        i_ev_extra1, i_ev_extra2, i_ev_extra3, i_ev_extra4)
+    on conflict (dl_queue_id, dl_consumer_id, ev_id) do nothing;
 
     return 1;
 end;
@@ -4617,6 +4626,15 @@ end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
 -- pgque.nack() -- retry or route to DLQ based on retry_count vs max_retries
+--
+-- Fix #98: re-query the canonical event row from the active batch using
+-- msg_id, instead of trusting caller-supplied pgque.message fields.
+-- A caller with an active batch could otherwise forge DLQ rows by
+-- supplying arbitrary ev_id / ev_type / ev_data in the composite.
+--
+-- Fix #104: DLQ insert is idempotent via ON CONFLICT in event_dead().
+-- Repeated nack() calls for the same terminal message produce exactly one
+-- dead_letter row.
 create or replace function pgque.nack(
     i_batch_id bigint,
     i_msg pgque.message,
@@ -4625,8 +4643,9 @@ create or replace function pgque.nack(
 returns integer as $$
 declare
     v_max_retries int4;
+    v_ev          record;
 begin
-    -- Single lookup: subscription -> queue config
+    -- Lookup: subscription -> queue config
     select coalesce(q.queue_max_retries, 5) into v_max_retries
     from pgque.subscription s
     join pgque.queue q on q.queue_id = s.sub_queue
@@ -4636,16 +4655,30 @@ begin
         raise exception 'batch not found: %', i_batch_id;
     end if;
 
-    if coalesce(i_msg.retry_count, 0) >= v_max_retries then
-        -- Move to dead letter queue (pass event fields, no re-query)
-        perform pgque.event_dead(i_batch_id, i_msg.msg_id,
+    -- Re-query the canonical event from the active batch (#98).
+    -- This ignores caller-supplied payload/type/extras and uses the real
+    -- values stored in the queue data tables.
+    select ev_id, ev_time, ev_txid, ev_retry, ev_type, ev_data,
+           ev_extra1, ev_extra2, ev_extra3, ev_extra4
+    into v_ev
+    from pgque.get_batch_events(i_batch_id)
+    where ev_id = i_msg.msg_id;
+
+    if not found then
+        raise exception 'msg_id % not found in batch %', i_msg.msg_id, i_batch_id;
+    end if;
+
+    if coalesce(v_ev.ev_retry, 0) >= v_max_retries then
+        -- Move to dead letter queue using canonical event data (#98).
+        -- event_dead() uses ON CONFLICT DO NOTHING for idempotency (#104).
+        perform pgque.event_dead(i_batch_id, v_ev.ev_id,
             coalesce(i_reason, 'max retries exceeded'),
-            i_msg.created_at, null::xid8, i_msg.retry_count,
-            i_msg.type, i_msg.payload,
-            i_msg.extra1, i_msg.extra2, i_msg.extra3, i_msg.extra4);
+            v_ev.ev_time, v_ev.ev_txid::text::xid8, v_ev.ev_retry,
+            v_ev.ev_type, v_ev.ev_data,
+            v_ev.ev_extra1, v_ev.ev_extra2, v_ev.ev_extra3, v_ev.ev_extra4);
     else
         -- Retry after delay
-        perform pgque.event_retry(i_batch_id, i_msg.msg_id,
+        perform pgque.event_retry(i_batch_id, v_ev.ev_id,
             extract(epoch from i_retry_after)::integer);
     end if;
     return 1;

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -4671,6 +4671,8 @@ begin
     if coalesce(v_ev.ev_retry, 0) >= v_max_retries then
         -- Move to dead letter queue using canonical event data (#98).
         -- event_dead() uses ON CONFLICT DO NOTHING for idempotency (#104).
+        -- ev_txid is bigint in get_batch_events (legacy PgQ signature); text
+        -- round-trip is the codebase convention to widen to xid8 without loss.
         perform pgque.event_dead(i_batch_id, v_ev.ev_id,
             coalesce(i_reason, 'max retries exceeded'),
             v_ev.ev_time, v_ev.ev_txid::text::xid8, v_ev.ev_retry,

--- a/tests/run_all.sql
+++ b/tests/run_all.sql
@@ -61,6 +61,8 @@
 \echo 'Running: test_api_dlq'
 \i tests/test_api_dlq.sql
 
+\echo 'Running: test_nack_dlq_canonical'
+\i tests/test_nack_dlq_canonical.sql
 
 \echo ''
 \echo '=== ALL TESTS PASSED ==='

--- a/tests/test_api_dlq.sql
+++ b/tests/test_api_dlq.sql
@@ -55,14 +55,18 @@ begin
 end $$;
 
 -- ========================================
--- Test 2: nack with retry_count >= max_retries -> DLQ
+-- Test 2: nack with ev_retry >= max_retries -> DLQ
 -- ========================================
+-- Use max_retries=0 so the very first nack routes to DLQ without
+-- needing to forge retry_count in the caller composite. Forging
+-- retry_count was the #98 vulnerability; nack() now re-queries the
+-- canonical ev_retry from the active batch.
 
 -- Setup
 do $$
 begin
   perform pgque.create_queue('test_dlq2');
-  perform pgque.set_queue_config('test_dlq2', 'max_retries', '2');
+  perform pgque.set_queue_config('test_dlq2', 'max_retries', '0');
   perform pgque.register_consumer('test_dlq2', 'c1');
 end $$;
 
@@ -78,7 +82,7 @@ begin
   perform pgque.ticker();
 end $$;
 
--- Receive, forge retry_count, nack -> DLQ
+-- Receive, nack -> DLQ (max_retries=0, ev_retry=0, so 0 >= 0 -> DLQ)
 do $$
 declare
   v_msg pgque.message;
@@ -86,10 +90,7 @@ declare
 begin
   select * into v_msg from pgque.receive('test_dlq2', 'c1', 1) limit 1;
 
-  -- Forge retry_count to simulate prior retries (unit test approach)
-  v_msg.retry_count := 2;
-
-  -- Nack should route to DLQ (retry_count=2 >= max_retries=2)
+  -- Nack should route to DLQ: canonical ev_retry=0 >= max_retries=0
   perform pgque.nack(v_msg.batch_id, v_msg, '0 seconds'::interval, 'max retries');
   perform pgque.ack(v_msg.batch_id);
 

--- a/tests/test_nack_dlq_canonical.sql
+++ b/tests/test_nack_dlq_canonical.sql
@@ -63,8 +63,11 @@ begin
     );
     -- If we get here, the forge was NOT blocked -> test failure
     assert false, 'FAIL #98: nack() should have rejected forged msg_id 999999';
-  exception when others then
-    -- Expected: function raised an error
+  exception when raise_exception then
+    -- Narrow match: must be the specific msg_id-not-found error, not some
+    -- other failure (e.g., a regression in get_batch_events).
+    assert sqlerrm like 'msg_id % not found in batch %',
+      format('FAIL #98: unexpected error message: %s', sqlerrm);
     v_ok := true;
   end;
 
@@ -91,7 +94,160 @@ begin
 end $$;
 
 -- ========================================
+-- Test 1b: valid msg_id with forged payload/type/retry_count
+-- ========================================
+-- nack() must use canonical row values (realtype / realpayload / ev_retry=0)
+-- even when the caller supplies forged type/payload/retry_count in the
+-- composite. This is the primary #98 attack vector.
+
+-- Setup
+do $$
+begin
+  perform pgque.create_queue('test_nack_forge_payload');
+  perform pgque.set_queue_config('test_nack_forge_payload', 'max_retries', '0');
+  perform pgque.register_consumer('test_nack_forge_payload', 'c');
+end $$;
+
+do $$
+begin
+  perform pgque.insert_event('test_nack_forge_payload', 'realtype', 'realpayload');
+end $$;
+
+do $$
+begin
+  perform pgque.ticker();
+end $$;
+
+do $$
+declare
+  v_msg     pgque.message;
+  v_forged  pgque.message;
+  v_dl      pgque.dead_letter;
+begin
+  select * into v_msg from pgque.receive('test_nack_forge_payload', 'c', 1) limit 1;
+  assert v_msg.msg_id is not null, 'should receive a message';
+
+  -- Build a forged composite: real msg_id but fake type/payload/retry_count
+  v_forged := row(
+    v_msg.msg_id,        -- real msg_id
+    v_msg.batch_id,
+    'forgetype',         -- forged type
+    'forgepayload',      -- forged payload
+    999,                 -- forged retry_count (would skip DLQ routing if trusted)
+    now(),
+    'fe1', 'fe2', 'fe3', 'fe4'  -- forged extras
+  )::pgque.message;
+
+  -- nack() must accept (real msg_id), but write canonical values to DLQ
+  perform pgque.nack(v_msg.batch_id, v_forged, interval '0 seconds', 'test1b');
+  perform pgque.ack(v_msg.batch_id);
+
+  -- Verify DLQ row contains canonical values, not forged ones
+  select * into v_dl
+  from pgque.dead_letter
+  where dl_queue_id = (
+    select queue_id from pgque.queue where queue_name = 'test_nack_forge_payload'
+  );
+
+  assert v_dl.ev_id = v_msg.msg_id,
+    format('FAIL 1b: expected ev_id=%s, got %s', v_msg.msg_id, v_dl.ev_id);
+  assert v_dl.ev_type = 'realtype',
+    format('FAIL 1b: expected ev_type=realtype, got %s', v_dl.ev_type);
+  assert v_dl.ev_data = 'realpayload',
+    format('FAIL 1b: expected ev_data=realpayload, got %s', v_dl.ev_data);
+  assert coalesce(v_dl.ev_retry, 0) = 0,
+    format('FAIL 1b: expected ev_retry=0, got %s', v_dl.ev_retry);
+  assert v_dl.ev_extra1 is null,
+    format('FAIL 1b: expected ev_extra1=null (canonical), got %s', v_dl.ev_extra1);
+
+  raise notice 'PASS 1b: canonical values in DLQ, forged payload/type ignored';
+end $$;
+
+-- Cleanup test 1b
+do $$
+begin
+  perform pgque.unregister_consumer('test_nack_forge_payload', 'c');
+  perform pgque.drop_queue('test_nack_forge_payload');
+end $$;
+
+-- ========================================
+-- Test 1c: NULL msg_id must error gracefully
+-- ========================================
+-- When i_msg.msg_id is NULL the where ev_id = NULL yields no rows, so
+-- nack() raises 'msg_id <NULL> not found in batch %'. Verify it errors
+-- cleanly and does not insert a DLQ row.
+
+-- Setup
+do $$
+begin
+  perform pgque.create_queue('test_nack_null_id');
+  perform pgque.set_queue_config('test_nack_null_id', 'max_retries', '0');
+  perform pgque.register_consumer('test_nack_null_id', 'c');
+end $$;
+
+do $$
+begin
+  perform pgque.insert_event('test_nack_null_id', 'mytype', 'mypayload');
+end $$;
+
+do $$
+begin
+  perform pgque.ticker();
+end $$;
+
+do $$
+declare
+  v_msg   pgque.message;
+  v_null  pgque.message;
+  v_ok    boolean := false;
+begin
+  select * into v_msg from pgque.receive('test_nack_null_id', 'c', 1) limit 1;
+  assert v_msg.msg_id is not null, 'should receive a message';
+
+  -- Build composite with NULL msg_id
+  v_null := row(
+    null,              -- NULL msg_id
+    v_msg.batch_id,
+    'mytype', 'mypayload', 0, now(), null, null, null, null
+  )::pgque.message;
+
+  begin
+    perform pgque.nack(v_msg.batch_id, v_null, interval '0 seconds', 'null-id');
+    assert false, 'FAIL 1c: nack() should have raised for NULL msg_id';
+  exception when raise_exception then
+    assert sqlerrm like 'msg_id % not found in batch %',
+      format('FAIL 1c: unexpected error: %s', sqlerrm);
+    v_ok := true;
+  end;
+
+  assert v_ok, 'FAIL 1c: nack() did not raise for NULL msg_id';
+
+  -- DLQ must be empty
+  assert (
+    select count(*) = 0 from pgque.dead_letter
+    where dl_queue_id = (
+      select queue_id from pgque.queue where queue_name = 'test_nack_null_id'
+    )
+  ), 'FAIL 1c: DLQ row inserted for NULL msg_id';
+
+  -- Clean up batch
+  perform pgque.ack(v_msg.batch_id);
+  raise notice 'PASS 1c: NULL msg_id raised gracefully, DLQ is clean';
+end $$;
+
+-- Cleanup test 1c
+do $$
+begin
+  perform pgque.unregister_consumer('test_nack_null_id', 'c');
+  perform pgque.drop_queue('test_nack_null_id');
+end $$;
+
+-- ========================================
 -- Test 2 (#104): repeated nack() must not create duplicate DLQ rows
+-- Note: this covers serial-only double-nack. The concurrent case
+-- (two sessions both pass get_batch_events, both call event_dead) is
+-- reasoned safe via the unique index + ON CONFLICT DO NOTHING on
+-- (dl_queue_id, dl_consumer_id, ev_id); concurrent testing deferred.
 -- ========================================
 -- With max_retries=0, two consecutive nack() calls for the same message
 -- must result in exactly one DLQ row, not two.

--- a/tests/test_nack_dlq_canonical.sql
+++ b/tests/test_nack_dlq_canonical.sql
@@ -1,0 +1,151 @@
+\set ON_ERROR_STOP on
+
+-- test_nack_dlq_canonical.sql
+-- Red/green regression tests for:
+--   #98  -- nack() DLQ path trusts caller-supplied pgque.message (forge)
+--   #104 -- repeated nack() creates duplicate DLQ rows
+--
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+-- ========================================
+-- Test 1 (#98): forged msg_id must be rejected
+-- ========================================
+-- nack() must verify the msg_id actually belongs to the active batch.
+-- Previously it trusted caller-supplied composite and inserted fake DLQ rows.
+
+-- Setup
+do $$
+begin
+  perform pgque.create_queue('test_nack_forge');
+  perform pgque.set_queue_config('test_nack_forge', 'max_retries', '0');
+  perform pgque.register_consumer('test_nack_forge', 'c');
+end $$;
+
+do $$
+begin
+  perform pgque.insert_event('test_nack_forge', 'realtype', 'realpayload');
+end $$;
+
+do $$
+begin
+  perform pgque.ticker();
+end $$;
+
+-- Receive to get an active batch
+do $$
+declare
+  v_msg   pgque.message;
+  v_batch bigint;
+  v_ok    boolean := false;
+begin
+  select * into v_msg from pgque.receive('test_nack_forge', 'c', 1) limit 1;
+  assert v_msg.msg_id is not null, 'should receive a message';
+
+  v_batch := v_msg.batch_id;
+
+  -- Attempt to nack with a forged msg_id that is not in the batch.
+  -- This MUST raise an exception after the fix. Before the fix it inserts a
+  -- fake DLQ row silently.
+  begin
+    perform pgque.nack(
+      v_batch,
+      row(
+        999999,           -- forged msg_id (not in this batch)
+        v_batch,
+        'forgedtype',
+        'forgedpayload',
+        999,              -- forged retry_count
+        now(),
+        null, null, null, null
+      )::pgque.message,
+      interval '0 seconds',
+      'forged'
+    );
+    -- If we get here, the forge was NOT blocked -> test failure
+    assert false, 'FAIL #98: nack() should have rejected forged msg_id 999999';
+  exception when others then
+    -- Expected: function raised an error
+    v_ok := true;
+  end;
+
+  assert v_ok, 'FAIL #98: nack() did not reject forged msg_id';
+
+  -- DLQ must be empty -- no forged row inserted
+  assert (
+    select count(*) = 0 from pgque.dead_letter
+    where dl_queue_id = (
+      select queue_id from pgque.queue where queue_name = 'test_nack_forge'
+    )
+  ), 'FAIL #98: forged DLQ row was inserted';
+
+  -- Clean up batch
+  perform pgque.ack(v_batch);
+  raise notice 'PASS #98: nack() rejected forged msg_id and DLQ is clean';
+end $$;
+
+-- Cleanup test 1
+do $$
+begin
+  perform pgque.unregister_consumer('test_nack_forge', 'c');
+  perform pgque.drop_queue('test_nack_forge');
+end $$;
+
+-- ========================================
+-- Test 2 (#104): repeated nack() must not create duplicate DLQ rows
+-- ========================================
+-- With max_retries=0, two consecutive nack() calls for the same message
+-- must result in exactly one DLQ row, not two.
+
+-- Setup
+do $$
+begin
+  perform pgque.create_queue('test_nack_dup');
+  perform pgque.set_queue_config('test_nack_dup', 'max_retries', '0');
+  perform pgque.register_consumer('test_nack_dup', 'c');
+end $$;
+
+do $$
+begin
+  perform pgque.insert_event('test_nack_dup', 'mytype', 'mypayload');
+end $$;
+
+do $$
+begin
+  perform pgque.ticker();
+end $$;
+
+-- Receive, then call nack() twice before ack()
+do $$
+declare
+  v_msg       pgque.message;
+  v_dlq_count bigint;
+begin
+  select * into v_msg from pgque.receive('test_nack_dup', 'c', 1) limit 1;
+  assert v_msg.msg_id is not null, 'should receive a message';
+
+  -- First nack: msg is DLQ-bound (max_retries=0, retry_count=0)
+  perform pgque.nack(v_msg.batch_id, v_msg, interval '0 seconds', 'dead1');
+
+  -- Second nack for same message, same batch: must be idempotent
+  perform pgque.nack(v_msg.batch_id, v_msg, interval '0 seconds', 'dead2');
+
+  perform pgque.ack(v_msg.batch_id);
+
+  select count(*) into v_dlq_count
+  from pgque.dead_letter
+  where dl_queue_id = (
+    select queue_id from pgque.queue where queue_name = 'test_nack_dup'
+  );
+
+  assert v_dlq_count = 1,
+    format('FAIL #104: expected 1 DLQ row, got %s', v_dlq_count);
+
+  raise notice 'PASS #104: repeated nack() is idempotent (1 DLQ row)';
+end $$;
+
+-- Cleanup test 2
+do $$
+begin
+  perform pgque.unregister_consumer('test_nack_dup', 'c');
+  perform pgque.drop_queue('test_nack_dup');
+end $$;


### PR DESCRIPTION
## Summary

Fixes two related bugs in `pgque.nack()` / DLQ flow, tracked in the umbrella #113.

- Closes #98
- Closes #104

### Fix #98 — nack() DLQ path trusts caller-supplied pgque.message (forge)

**Root cause:** `nack()` passed caller-supplied composite fields (`i_msg.type`, `i_msg.payload`, etc.) directly to `event_dead()` without verifying the `msg_id` actually belonged to the active batch. Any writer with an active batch could forge a `pgque.message` with an arbitrary `ev_id`, payload, type, or retry count, inserting fake DLQ rows.

**Fix:** `nack()` now calls `get_batch_events(i_batch_id)` and looks up the row by `ev_id = i_msg.msg_id`. If `msg_id` is not found in the batch, it raises `msg_id % not found in batch %`. Only canonical fields from the batch data tables reach `event_dead()`.

**Red test evidence:**
```
psql:tests/test_nack_dlq_canonical.sql:84: ERROR:
  FAIL #98: nack() should have rejected forged msg_id 999999
```

**Green (after fix):**
```
NOTICE:  PASS #98: nack() rejected forged msg_id and DLQ is clean
```

### Fix #104 — repeated nack() creates duplicate replayable DLQ rows

**Root cause:** `event_dead()` used a plain `INSERT` with no duplicate guard. Calling `nack()` twice before `ack()` on the same terminal message inserted two `dead_letter` rows, causing `dlq_replay_all()` to replay the payload twice.

**Fix:** Added unique index `dl_queue_consumer_ev_idx` on `(dl_queue_id, dl_consumer_id, ev_id)` and changed the `INSERT` in `event_dead()` to `ON CONFLICT (dl_queue_id, dl_consumer_id, ev_id) DO NOTHING`. Repeated terminal `nack()` calls are now idempotent.

**Red test evidence:**
```
NOTICE:  DLQ row count: 2
ERROR:  FAIL #104: expected 1 DLQ row, got 2
```

**Green (after fix):**
```
NOTICE:  PASS #104: repeated nack() is idempotent (1 DLQ row)
```

## Changes

| File | Change |
|------|--------|
| `sql/pgque-api/receive.sql` | `nack()` re-queries canonical event via `get_batch_events`; raises on unknown `msg_id` |
| `sql/pgque-additions/dlq.sql` | New unique index `dl_queue_consumer_ev_idx`; `event_dead()` insert uses `ON CONFLICT DO NOTHING` |
| `sql/pgque.sql` | Regenerated (both changes above) |
| `tests/test_nack_dlq_canonical.sql` | New red/green regression tests for both bugs |
| `tests/test_api_dlq.sql` | Test 2 updated: no longer forges `retry_count` (was the #98 hole); uses `max_retries=0` instead |
| `tests/run_all.sql` | Added `test_nack_dlq_canonical` to suite |

## Test plan

- [x] Red tests confirmed failing on `main` before fix
- [x] Green tests pass after fix
- [x] Full suite (`tests/run_all.sql`) passes — all tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)