### PR TITLE
fix(pgque.receive): finish empty batch instead of stranding consumer

### DIFF
--- a/sql/pgque-api/receive.sql
+++ b/sql/pgque-api/receive.sql
@@ -24,6 +24,17 @@ exception when duplicate_object then null;
 end $$;
 
 -- pgque.receive() -- wraps next_batch + get_batch_events
+--
+-- Fix for issue #103 — empty-batch trap:
+-- next_batch() opens a batch even when the tick window contains zero visible
+-- events. Before this fix, receive() would return [] while leaving sub_batch
+-- set, permanently stranding the consumer: subsequent calls kept returning
+-- the same empty batch and could never see later events.
+--
+-- Fix: after iterating get_batch_events(), if no rows were yielded, call
+-- finish_batch() immediately to advance the consumer's cursor. The caller
+-- still receives [], but the consumer is no longer stranded; the next
+-- receive() call will pick up the following tick window normally.
 create or replace function pgque.receive(
     i_queue text, i_consumer text, i_max_return int default 100)
 returns setof pgque.message as $$
@@ -36,7 +47,7 @@ begin
         raise exception 'pgque.receive: max_return must be >= 1, got %', i_max_return;
     end if;
 
-    -- Get next batch (may return NULL if no events)
+    -- Get next batch (may return NULL if no tick window is ready)
     v_batch_id := pgque.next_batch(i_queue, i_consumer);
     if v_batch_id is null then
         return;
@@ -56,6 +67,14 @@ begin
         cnt := cnt + 1;
         exit when cnt >= i_max_return;
     end loop;
+
+    -- Issue #103: if the batch had zero visible events, finish it now so the
+    -- consumer is not stranded. Callers receive [] either way; the difference
+    -- is that sub_batch is cleared here rather than being left open forever.
+    if cnt = 0 then
+        perform pgque.finish_batch(v_batch_id);
+    end if;
+
     return;
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;

--- a/sql/pgque-api/receive.sql
+++ b/sql/pgque-api/receive.sql
@@ -24,17 +24,6 @@ exception when duplicate_object then null;
 end $$;
 
 -- pgque.receive() -- wraps next_batch + get_batch_events
---
--- Fix for issue #103 — empty-batch trap:
--- next_batch() opens a batch even when the tick window contains zero visible
--- events. Before this fix, receive() would return [] while leaving sub_batch
--- set, permanently stranding the consumer: subsequent calls kept returning
--- the same empty batch and could never see later events.
---
--- Fix: after iterating get_batch_events(), if no rows were yielded, call
--- finish_batch() immediately to advance the consumer's cursor. The caller
--- still receives [], but the consumer is no longer stranded; the next
--- receive() call will pick up the following tick window normally.
 create or replace function pgque.receive(
     i_queue text, i_consumer text, i_max_return int default 100)
 returns setof pgque.message as $$
@@ -68,9 +57,7 @@ begin
         exit when cnt >= i_max_return;
     end loop;
 
-    -- Issue #103: if the batch had zero visible events, finish it now so the
-    -- consumer is not stranded. Callers receive [] either way; the difference
-    -- is that sub_batch is cleared here rather than being left open forever.
+    -- Empty batch: finish immediately to advance the consumer cursor.
     if cnt = 0 then
         perform pgque.finish_batch(v_batch_id);
     end if;

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -4581,17 +4581,6 @@ exception when duplicate_object then null;
 end $$;
 
 -- pgque.receive() -- wraps next_batch + get_batch_events
---
--- Fix for issue #103 — empty-batch trap:
--- next_batch() opens a batch even when the tick window contains zero visible
--- events. Before this fix, receive() would return [] while leaving sub_batch
--- set, permanently stranding the consumer: subsequent calls kept returning
--- the same empty batch and could never see later events.
---
--- Fix: after iterating get_batch_events(), if no rows were yielded, call
--- finish_batch() immediately to advance the consumer's cursor. The caller
--- still receives [], but the consumer is no longer stranded; the next
--- receive() call will pick up the following tick window normally.
 create or replace function pgque.receive(
     i_queue text, i_consumer text, i_max_return int default 100)
 returns setof pgque.message as $$
@@ -4625,9 +4614,7 @@ begin
         exit when cnt >= i_max_return;
     end loop;
 
-    -- Issue #103: if the batch had zero visible events, finish it now so the
-    -- consumer is not stranded. Callers receive [] either way; the difference
-    -- is that sub_batch is cleared here rather than being left open forever.
+    -- Empty batch: finish immediately to advance the consumer cursor.
     if cnt = 0 then
         perform pgque.finish_batch(v_batch_id);
     end if;

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -4581,6 +4581,17 @@ exception when duplicate_object then null;
 end $$;
 
 -- pgque.receive() -- wraps next_batch + get_batch_events
+--
+-- Fix for issue #103 — empty-batch trap:
+-- next_batch() opens a batch even when the tick window contains zero visible
+-- events. Before this fix, receive() would return [] while leaving sub_batch
+-- set, permanently stranding the consumer: subsequent calls kept returning
+-- the same empty batch and could never see later events.
+--
+-- Fix: after iterating get_batch_events(), if no rows were yielded, call
+-- finish_batch() immediately to advance the consumer's cursor. The caller
+-- still receives [], but the consumer is no longer stranded; the next
+-- receive() call will pick up the following tick window normally.
 create or replace function pgque.receive(
     i_queue text, i_consumer text, i_max_return int default 100)
 returns setof pgque.message as $$
@@ -4593,7 +4604,7 @@ begin
         raise exception 'pgque.receive: max_return must be >= 1, got %', i_max_return;
     end if;
 
-    -- Get next batch (may return NULL if no events)
+    -- Get next batch (may return NULL if no tick window is ready)
     v_batch_id := pgque.next_batch(i_queue, i_consumer);
     if v_batch_id is null then
         return;
@@ -4613,6 +4624,14 @@ begin
         cnt := cnt + 1;
         exit when cnt >= i_max_return;
     end loop;
+
+    -- Issue #103: if the batch had zero visible events, finish it now so the
+    -- consumer is not stranded. Callers receive [] either way; the difference
+    -- is that sub_batch is cleared here rather than being left open forever.
+    if cnt = 0 then
+        perform pgque.finish_batch(v_batch_id);
+    end if;
+
     return;
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;

--- a/tests/run_all.sql
+++ b/tests/run_all.sql
@@ -64,5 +64,8 @@
 \echo 'Running: test_nack_dlq_canonical'
 \i tests/test_nack_dlq_canonical.sql
 
+\echo 'Running: test_receive_empty_batch'
+\i tests/test_receive_empty_batch.sql
+
 \echo ''
 \echo '=== ALL TESTS PASSED ==='

--- a/tests/test_receive_empty_batch.sql
+++ b/tests/test_receive_empty_batch.sql
@@ -1,0 +1,108 @@
+\set ON_ERROR_STOP on
+
+-- Test: receive() must not strand consumer on empty active batch (#103)
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- Reproduces the bug: force an empty tick (no events in the window), then
+-- call receive().  On the buggy version receive() opens a batch, finds 0
+-- events, returns [], but leaves sub_batch set (the active batch is never
+-- finished).  A second receive() call returns the *same* empty batch again
+-- even after a new event arrives and a second tick fires.
+--
+-- After the fix: the first receive() must finish the empty batch internally
+-- so the second receive() can see the new event.
+--
+-- See also: Issue #103 minimal repro in sql/pgque-api/receive.sql header.
+
+-- Setup
+do $$
+begin
+  perform pgque.create_queue('test_empty_batch');
+  perform pgque.register_consumer('test_empty_batch', 'c1');
+end $$;
+
+-- Fire a tick that captures zero events (empty tick window).
+do $$
+begin
+  perform pgque.force_tick('test_empty_batch');
+  perform pgque.ticker();
+end $$;
+
+-- receive() on an empty tick window: must return 0 rows AND not strand the
+-- consumer (i.e. must finish the empty batch internally).
+do $$
+declare
+  v_msg   pgque.message;
+  v_count int := 0;
+  v_batch bigint;
+  v_sub   record;
+begin
+  for v_msg in select * from pgque.receive('test_empty_batch', 'c1', 100)
+  loop
+    v_count := v_count + 1;
+    v_batch := v_msg.batch_id;
+  end loop;
+
+  -- Correct: 0 rows returned for the empty window.
+  assert v_count = 0, 'empty tick window should yield 0 messages, got ' || v_count;
+
+  -- Key assertion: sub_batch must be NULL after receive() on an empty window.
+  -- If the bug is present, sub_batch will still be set here, proving the
+  -- consumer is stranded on the empty batch.
+  select s.sub_batch into v_sub
+  from pgque.subscription s
+  join pgque.queue q on q.queue_id = s.sub_queue
+  join pgque.consumer c on c.co_id = s.sub_consumer
+  where q.queue_name = 'test_empty_batch'
+    and c.co_name = 'c1';
+
+  assert v_sub.sub_batch is null,
+    'BUG #103: receive() left sub_batch set after returning 0 rows — '
+    || 'consumer is stranded on empty batch id ' || coalesce(v_sub.sub_batch::text, 'NULL');
+
+  raise notice 'PASS: receive() on empty tick window returns 0 rows and does not strand consumer';
+end $$;
+
+-- Now send a real event and tick it in.
+do $$
+begin
+  perform pgque.send('test_empty_batch', 'hello', 'world');
+end $$;
+
+do $$
+begin
+  perform pgque.force_tick('test_empty_batch');
+  perform pgque.ticker();
+end $$;
+
+-- Second receive() call must see the new event — not get stuck on the
+-- previously empty batch.
+do $$
+declare
+  v_msg   pgque.message;
+  v_count int := 0;
+  v_batch bigint;
+begin
+  for v_msg in select * from pgque.receive('test_empty_batch', 'c1', 100)
+  loop
+    v_count := v_count + 1;
+    v_batch := v_msg.batch_id;
+  end loop;
+
+  assert v_count = 1,
+    'second receive() should return the later event; got ' || v_count
+    || ' rows (0 = still stuck on empty batch — Bug #103)';
+
+  assert v_msg.type = 'hello', 'unexpected type: ' || coalesce(v_msg.type, 'NULL');
+
+  perform pgque.ack(v_batch);
+  raise notice 'PASS: second receive() sees new event after empty-batch window';
+end $$;
+
+-- Cleanup
+do $$
+begin
+  perform pgque.unregister_consumer('test_empty_batch', 'c1');
+  perform pgque.drop_queue('test_empty_batch');
+  raise notice 'PASS: receive() empty-batch trap regression test (#103)';
+end $$;


### PR DESCRIPTION
## Summary

Closes #103

### Root cause confirmed

`pgque.receive()` calls `next_batch()`, which opens a batch (sets `sub_batch`) for
every available tick window — even tick windows that contain zero visible events.
The old code then iterated `get_batch_events()`, returned `[]` with no rows, and
returned without calling `finish_batch()`.

Result: `sub_batch` stayed set. Every subsequent call to `receive()` hit the same
empty batch (because `next_batch()` sees `sub_batch IS NOT NULL` and returns the
existing batch_id immediately). The consumer was permanently stranded: zero rows
forever, even after new events arrived and a fresh tick fired. The caller had no
`batch_id` to `ack()` because no rows were returned.

This is the root cause of the empty-receive pattern in the Python (19 failed) and
TypeScript (6 failed) test suites reported in issue #90 / PR #84.

### Fix

In `pgque.receive()`, after iterating `get_batch_events()`, if `cnt == 0` (no
rows yielded), immediately call `finish_batch(v_batch_id)`. This advances
`sub_last_tick` and clears `sub_batch`, so the next `receive()` call can pick up
the following tick window normally.

The fix composes existing PgQ primitives only — no new state or logic —
satisfying design rule #3 ("modern API functions must reduce cleanly to PgQ
primitives").

Files changed:
- `sql/pgque-api/receive.sql` — source: added empty-batch auto-finish with comment
- `sql/pgque.sql` — assembled output: same fix reflected
- `tests/test_receive_empty_batch.sql` — new regression test (red → green)
- `tests/run_all.sql` — new test added to suite

### Red test output (before fix)

```
ERROR:  BUG #103: receive() left sub_batch set after returning 0 rows —
        consumer is stranded on empty batch id 10
CONTEXT:  PL/pgSQL function inline_code_block line 27 at ASSERT
```

### Green test output (after fix)

```
NOTICE:  PASS: receive() on empty tick window returns 0 rows and does not strand consumer
NOTICE:  PASS: second receive() sees new event after empty-batch window
NOTICE:  PASS: receive() empty-batch trap regression test (#103)
=== ALL TESTS PASSED ===
```

Full `tests/run_all.sql` passes locally (PG 16, macOS).

### Python / TypeScript test suites (PR #84 / issue #90)

The empty-receive pattern in both driver suites is caused by this same bug:
`receive()` opens an empty batch on the first call (initial tick before events
are visible), returns `[]`, and every subsequent call returns the same empty
batch. After this fix, the empty batch is finished internally and the next call
correctly sees newly arrived events.

The fix unblocks the failing tests listed in PR #84's CI run
(https://github.com/NikolayS/pgque/actions/runs/25158408976):

- Python: all `test_receive.py`, `test_nack.py`, `test_consumer.py`,
  `test_send.py::test_jsonb_payload_round_trip` failures are downstream of
  empty-receive
- TypeScript: all `client.test.ts` and `consumer.test.ts` receive-after-send
  failures are downstream of empty-receive; `nack.test.ts` failures are
  downstream (no batch_id to nack when receive returns [])

## Test plan

- [x] Red test `tests/test_receive_empty_batch.sql` fails on `main` with exact
  bug message
- [x] Green: same test passes after fix
- [x] Full `tests/run_all.sql` passes with fix
- [ ] CI: Go/Python/TypeScript driver tests via PR #84 (expect pass after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)