### PR TITLE
fix(pgque.batch_retry): cast NULL to xid8 not int8

### DIFF
--- a/build/transform.sh
+++ b/build/transform.sh
@@ -533,6 +533,16 @@ awk '
 
 echo "PASS: insert_event_raw raises clear error on unknown queue"
 
+# Fix batch_retry(): NULL::int8 cast into retry_queue.ev_txid which is xid8.
+# The ev_txid column was modernized to xid8 by the transform, but this explicit
+# NULL cast in the INSERT was not updated. Fix: NULL::xid8.
+# See: https://github.com/NikolayS/pgque/issues/107
+BATCH_RETRY_FILE="${OUTPUT_DIR}/functions/pgque.batch_retry.sql"
+sedi 's/b\.ev_id, b\.ev_time, NULL::int8, _s\.sub_id,/b.ev_id, b.ev_time, NULL::xid8, _s.sub_id,/' \
+  "${BATCH_RETRY_FILE}"
+
+echo "PASS: batch_retry NULL::int8 -> NULL::xid8 for ev_txid (xid8) column"
+
 # -- Assembly: build sql/pgque.sql ------------------------------------
 
 echo ""

--- a/build/transform.sh
+++ b/build/transform.sh
@@ -533,10 +533,6 @@ awk '
 
 echo "PASS: insert_event_raw raises clear error on unknown queue"
 
-# Fix batch_retry(): NULL::int8 cast into retry_queue.ev_txid which is xid8.
-# The ev_txid column was modernized to xid8 by the transform, but this explicit
-# NULL cast in the INSERT was not updated. Fix: NULL::xid8.
-# See: https://github.com/NikolayS/pgque/issues/107
 BATCH_RETRY_FILE="${OUTPUT_DIR}/functions/pgque.batch_retry.sql"
 sedi 's/b\.ev_id, b\.ev_time, NULL::int8, _s\.sub_id,/b.ev_id, b.ev_time, NULL::xid8, _s.sub_id,/' \
   "${BATCH_RETRY_FILE}"

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -2434,7 +2434,7 @@ begin
         ev_type, ev_data, ev_extra1, ev_extra2,
         ev_extra3, ev_extra4)
     select distinct _retry, _s.sub_queue,
-           b.ev_id, b.ev_time, NULL::int8, _s.sub_id, coalesce(b.ev_retry, 0) + 1,
+           b.ev_id, b.ev_time, NULL::xid8, _s.sub_id, coalesce(b.ev_retry, 0) + 1,
            b.ev_type, b.ev_data, b.ev_extra1, b.ev_extra2,
            b.ev_extra3, b.ev_extra4
       from pgque.get_batch_events(i_batch_id) b

--- a/tests/run_all.sql
+++ b/tests/run_all.sql
@@ -37,6 +37,9 @@
 \echo 'Running: test_core_retry'
 \i tests/test_core_retry.sql
 
+\echo 'Running: test_core_batch_retry'
+\i tests/test_core_batch_retry.sql
+
 \echo 'Running: test_core_rotation'
 \i tests/test_core_rotation.sql
 

--- a/tests/test_core_batch_retry.sql
+++ b/tests/test_core_batch_retry.sql
@@ -1,0 +1,110 @@
+-- test_core_batch_retry.sql -- Regression test for batch_retry() xid8 cast bug
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- Regression: batch_retry() was inserting NULL::int8 into retry_queue.ev_txid
+-- which is xid8. Fix: use NULL::xid8.
+-- See: https://github.com/NikolayS/pgque/issues/107
+
+-- Step 1: setup
+do $$
+begin
+  perform pgque.create_queue('test_batch_retry');
+  perform pgque.register_consumer('test_batch_retry', 'c1');
+end $$;
+
+-- Step 2: insert two events (separate transaction for snapshot visibility)
+do $$
+begin
+  perform pgque.insert_event('test_batch_retry', 'batch.retry.test', 'evt1');
+  perform pgque.insert_event('test_batch_retry', 'batch.retry.test', 'evt2');
+end $$;
+
+-- Step 3: tick so events are visible to consumers
+do $$
+begin
+  perform pgque.force_tick('test_batch_retry');
+  perform pgque.ticker();
+end $$;
+
+-- Step 4: batch_retry() must succeed without type mismatch error
+-- (was: ERROR: column "ev_txid" is of type xid8 but expression is of type bigint)
+do $$
+declare
+  v_batch_id bigint;
+  v_retry_cnt integer;
+begin
+  v_batch_id := pgque.next_batch('test_batch_retry', 'c1');
+  assert v_batch_id is not null, 'should get a batch';
+
+  -- This call previously failed with:
+  -- ERROR:  column "ev_txid" is of type xid8 but expression is of type bigint
+  v_retry_cnt := pgque.batch_retry(v_batch_id, 0);
+  assert v_retry_cnt = 2,
+    'batch_retry should return 2, got ' || coalesce(v_retry_cnt::text, 'NULL');
+  raise notice 'PASS: batch_retry() returned % rows (no xid8 type mismatch)', v_retry_cnt;
+end $$;
+
+-- Step 5: second call to batch_retry() on same batch must be idempotent (return 0)
+do $$
+declare
+  v_batch_id bigint;
+  v_retry_cnt integer;
+begin
+  -- Re-open same batch (still active)
+  select sub_batch into v_batch_id
+    from pgque.subscription
+   where sub_queue = 'test_batch_retry'
+     and sub_name  = 'c1';
+  assert v_batch_id is not null, 'batch should still be active';
+
+  v_retry_cnt := pgque.batch_retry(v_batch_id, 0);
+  assert v_retry_cnt = 0,
+    'second batch_retry call should be idempotent (0 rows), got '
+    || coalesce(v_retry_cnt::text, 'NULL');
+  raise notice 'PASS: batch_retry() idempotent on second call';
+end $$;
+
+-- Step 6: maintenance moves retried events back into the event table
+do $$
+begin
+  perform pgque.maint_retry_events();
+end $$;
+
+-- Step 7: re-tick so reinserted events are visible
+do $$
+begin
+  perform pgque.force_tick('test_batch_retry');
+  perform pgque.ticker();
+end $$;
+
+-- Step 8: verify retry events reappear with incremented ev_retry
+do $$
+declare
+  v_batch_id bigint;
+  v_ev_count integer;
+  v_min_retry integer;
+begin
+  v_batch_id := pgque.next_batch('test_batch_retry', 'c1');
+  assert v_batch_id is not null, 'should get a batch with retried events';
+
+  select count(*), min(ev_retry)
+    into v_ev_count, v_min_retry
+    from pgque.get_batch_events(v_batch_id);
+
+  assert v_ev_count >= 1,
+    'retried events should reappear, got ' || v_ev_count;
+  assert v_min_retry >= 1,
+    'ev_retry should be >= 1, got ' || coalesce(v_min_retry::text, 'NULL');
+  raise notice 'PASS: retried events redelivered (count=%, min ev_retry=%)',
+    v_ev_count, v_min_retry;
+
+  perform pgque.finish_batch(v_batch_id);
+end $$;
+
+-- Cleanup
+do $$
+begin
+  perform pgque.unregister_consumer('test_batch_retry', 'c1');
+  perform pgque.drop_queue('test_batch_retry');
+  raise notice 'PASS: core_batch_retry';
+end $$;

--- a/tests/test_core_batch_retry.sql
+++ b/tests/test_core_batch_retry.sql
@@ -50,11 +50,13 @@ declare
   v_batch_id bigint;
   v_retry_cnt integer;
 begin
-  -- Re-open same batch (still active)
-  select sub_batch into v_batch_id
-    from pgque.subscription
-   where sub_queue = 'test_batch_retry'
-     and sub_name  = 'c1';
+  -- Re-open same batch (still active): look up by queue name + consumer name
+  select s.sub_batch into v_batch_id
+    from pgque.subscription s
+    join pgque.queue       q  on q.queue_id  = s.sub_queue
+    join pgque.consumer    c  on c.co_id     = s.sub_consumer
+   where q.queue_name = 'test_batch_retry'
+     and c.co_name    = 'c1';
   assert v_batch_id is not null, 'batch should still be active';
 
   v_retry_cnt := pgque.batch_retry(v_batch_id, 0);
@@ -62,6 +64,20 @@ begin
     'second batch_retry call should be idempotent (0 rows), got '
     || coalesce(v_retry_cnt::text, 'NULL');
   raise notice 'PASS: batch_retry() idempotent on second call';
+end $$;
+
+-- Step 5b: finish the original batch (batch_retry does not finish it)
+do $$
+declare
+  v_batch_id bigint;
+begin
+  select s.sub_batch into v_batch_id
+    from pgque.subscription s
+    join pgque.queue       q  on q.queue_id  = s.sub_queue
+    join pgque.consumer    c  on c.co_id     = s.sub_consumer
+   where q.queue_name = 'test_batch_retry'
+     and c.co_name    = 'c1';
+  perform pgque.finish_batch(v_batch_id);
 end $$;
 
 -- Step 6: maintenance moves retried events back into the event table


### PR DESCRIPTION
Closes #107

## Summary

`pgque.batch_retry()` was inserting `NULL::int8` into `retry_queue.ev_txid`, which is an `xid8` column (modernized from `bigint` during the PgQ→PgQue transform). PostgreSQL 14+ has no implicit cast from `int8` to `xid8`, so every call to `batch_retry()` failed with:

```
ERROR: column "ev_txid" is of type xid8 but expression is of type bigint
```

## Fix

Changed `NULL::int8` → `NULL::xid8` in `pgque.batch_retry()`:

- **`sql/pgque.sql`** line 2437: the actual runtime fix
- **`build/transform.sh`**: added a post-transform `sedi` patch so future regenerations from the PgQ submodule apply the same correction automatically

No other `NULL::int8` casts into `xid8` columns were found in the codebase (audited via `grep -rn "NULL::int8\|NULL::bigint"`).

## Test

Added `tests/test_core_batch_retry.sql` (also wired into `tests/run_all.sql`) covering:

1. `batch_retry(batch_id, 0)` returns event count without type mismatch (the core regression)
2. Second call is idempotent (returns 0)
3. `maint_retry_events()` + tick re-delivers events with `ev_retry >= 1`

**Red commit** `7c4b286` — test fails with exact error from #107  
**Green commit** `1774de5` — all tests pass

```
Running: test_core_batch_retry
NOTICE:  PASS: batch_retry() returned 2 rows (no xid8 type mismatch)
NOTICE:  PASS: batch_retry() idempotent on second call
NOTICE:  PASS: retried events redelivered (count=2, min ev_retry=1)
NOTICE:  PASS: core_batch_retry
...
=== ALL TESTS PASSED ===
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)