### PR TITLE
fix(clients/python): consumer warns + acks unhandled event types

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -43,6 +43,7 @@ def handle_order(msg: pgque.Message) -> None:
 # Without it, messages with unhandled types are logged at WARNING and
 # acked. Register a handler for that type or use a "*" catch-all to
 # handle them deliberately.
+# Note: Unhandled event types are acknowledged after a warning. Register a `*` handler if you want to fail/nack/route unknown types yourself.
 @consumer.on("*")
 def handle_unknown(msg: pgque.Message) -> None:
     print(f"unhandled type {msg.type!r}: {msg.payload}")

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -39,6 +39,13 @@ consumer = pgque.Consumer(
 def handle_order(msg: pgque.Message) -> None:
     print(f"got {msg.type}: {msg.payload}")
 
+# Optional: register a catch-all handler for any unregistered type.
+# Without it, messages whose type has no handler are nacked automatically
+# (moved to retry_queue) rather than silently dropped.
+@consumer.on("*")
+def handle_unknown(msg: pgque.Message) -> None:
+    print(f"unhandled type {msg.type!r}: {msg.payload}")
+
 consumer.start()  # blocks until SIGTERM / SIGINT
 ```
 

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -39,9 +39,10 @@ consumer = pgque.Consumer(
 def handle_order(msg: pgque.Message) -> None:
     print(f"got {msg.type}: {msg.payload}")
 
-# Optional: register a catch-all handler for any unregistered type.
-# Without it, messages whose type has no handler are nacked automatically
-# (moved to retry_queue) rather than silently dropped.
+# Optional: catch-all handler for types with no specific handler.
+# Without it, messages with unhandled types are logged at WARNING and
+# acked. Register a handler for that type or use a "*" catch-all to
+# handle them deliberately.
 @consumer.on("*")
 def handle_unknown(msg: pgque.Message) -> None:
     print(f"unhandled type {msg.type!r}: {msg.payload}")

--- a/clients/python/pgque/client.py
+++ b/clients/python/pgque/client.py
@@ -111,9 +111,10 @@ class PgqueClient:
                 - ``dict`` / ``list`` — JSON-serialised automatically.
                 - ``str`` — must be **valid JSON text** (e.g.
                   ``'"hello"'``, ``'{"k": 1}'``, ``'42'``, ``'null'``).
-                  The value is cast to ``jsonb`` by PostgreSQL; a bare
-                  Python string like ``"hello"`` (without surrounding
-                  double-quotes) will raise a ``PgqueError``.
+                  The value is cast to ``jsonb`` by PostgreSQL. The
+                  Python literal ``"hello"`` has content ``hello``,
+                  which is not valid JSON; pass ``'"hello"'`` or
+                  ``json.dumps("hello")`` instead.
                 - ``None`` — stored as JSON ``null``.
                 - :class:`Event` — ``type`` and ``payload`` are unpacked.
 

--- a/clients/python/pgque/client.py
+++ b/clients/python/pgque/client.py
@@ -106,8 +106,17 @@ class PgqueClient:
 
         Args:
             queue: Target queue name.
-            payload: Message payload (``dict``/``list`` is JSON-encoded;
-                ``str`` is sent as-is; ``Event`` is unpacked).
+            payload: Message payload. Accepted forms:
+
+                - ``dict`` / ``list`` — JSON-serialised automatically.
+                - ``str`` — must be **valid JSON text** (e.g.
+                  ``'"hello"'``, ``'{"k": 1}'``, ``'42'``, ``'null'``).
+                  The value is cast to ``jsonb`` by PostgreSQL; a bare
+                  Python string like ``"hello"`` (without surrounding
+                  double-quotes) will raise a ``PgqueError``.
+                - ``None`` — stored as JSON ``null``.
+                - :class:`Event` — ``type`` and ``payload`` are unpacked.
+
             type: Event type (default ``"default"``). Ignored if
                 ``payload`` is an ``Event`` (its own ``type`` wins).
 
@@ -152,8 +161,9 @@ class PgqueClient:
         Args:
             queue: Target queue name.
             type: Event type for all messages.
-            payloads: Each entry is JSON-encoded if dict/list, otherwise
-                used as-is.
+            payloads: Each entry is JSON-encoded automatically if
+                ``dict``/``list``; ``str`` entries must be valid JSON
+                text (cast to ``jsonb`` by PostgreSQL).
 
         Returns:
             List of event IDs in input order.

--- a/clients/python/pgque/client.py
+++ b/clients/python/pgque/client.py
@@ -163,13 +163,16 @@ class PgqueClient:
             type: Event type for all messages.
             payloads: Each entry is JSON-encoded automatically if
                 ``dict``/``list``; ``str`` entries must be valid JSON
-                text (cast to ``jsonb`` by PostgreSQL).
+                text (cast to ``jsonb`` by PostgreSQL); ``None`` is
+                stored as JSON ``null`` (same as ``send(None)``).
 
         Returns:
             List of event IDs in input order.
         """
         json_payloads = [
-            json.dumps(p) if isinstance(p, (dict, list)) else p for p in payloads
+            json.dumps(p) if isinstance(p, (dict, list))
+            else ("null" if p is None else p)
+            for p in payloads
         ]
         try:
             row = self.conn.execute(

--- a/clients/python/pgque/consumer.py
+++ b/clients/python/pgque/consumer.py
@@ -41,6 +41,9 @@ class Consumer:
           considered processed.
         - If the handler raises an exception, the message is nacked
           with the default retry_after.
+        - If no handler is registered for a message type (and no
+          default ``"*"`` handler exists), the message is nacked with
+          reason ``"unhandled event type"`` rather than silently dropped.
 
     After all messages in a batch have been dispatched, the batch is
     acked automatically.
@@ -171,9 +174,14 @@ class Consumer:
                 handler = self._handlers.get(msg.type, self._default_handler)
                 if handler is None:
                     logger.warning(
-                        "no handler for type=%r, skipping msg_id=%d",
+                        "no handler for type=%r, nacking msg_id=%d",
                         msg.type,
                         msg.msg_id,
+                    )
+                    client.nack(
+                        batch_id, msg,
+                        retry_after=self.retry_after,
+                        reason="unhandled event type",
                     )
                     continue
 

--- a/clients/python/pgque/consumer.py
+++ b/clients/python/pgque/consumer.py
@@ -174,7 +174,7 @@ class Consumer:
                 handler = self._handlers.get(msg.type, self._default_handler)
                 if handler is None:
                     logger.warning(
-                        "no handler for type=%r, nacking msg_id=%d",
+                        "no handler (and no '*' default) for type=%r, nacking msg_id=%d",
                         msg.type,
                         msg.msg_id,
                     )

--- a/clients/python/pgque/consumer.py
+++ b/clients/python/pgque/consumer.py
@@ -42,8 +42,9 @@ class Consumer:
         - If the handler raises an exception, the message is nacked
           with the default retry_after.
         - If no handler is registered for a message type (and no
-          default ``"*"`` handler exists), the message is nacked with
-          reason ``"unhandled event type"`` rather than silently dropped.
+          default ``"*"`` handler exists), a WARNING is logged and the
+          message is acked. Register a handler for that type or use a
+          ``"*"`` catch-all to handle it deliberately.
 
     After all messages in a batch have been dispatched, the batch is
     acked automatically.
@@ -69,6 +70,7 @@ class Consumer:
         self._handlers: dict[str, Callable] = {}
         self._default_handler: Optional[Callable] = None
         self._running = False
+        self._log = logging.getLogger(f"pgque.consumer.{name}")
 
     def on(self, event_type: str):
         """Decorator to register a handler for a given event type.
@@ -173,15 +175,10 @@ class Consumer:
             for msg in msgs:
                 handler = self._handlers.get(msg.type, self._default_handler)
                 if handler is None:
-                    logger.warning(
-                        "no handler (and no '*' default) for type=%r, nacking msg_id=%d",
+                    self._log.warning(
+                        "no handler for event type=%s ev_id=%s; acking",
                         msg.type,
                         msg.msg_id,
-                    )
-                    client.nack(
-                        batch_id, msg,
-                        retry_after=self.retry_after,
-                        reason="unhandled event type",
                     )
                     continue
 

--- a/clients/python/tests/test_consumer.py
+++ b/clients/python/tests/test_consumer.py
@@ -112,6 +112,42 @@ def test_consumer_nacks_on_handler_error(dsn, conn, setup_queue):
     assert cnt >= 1
 
 
+def test_consumer_nacks_unhandled_event_type(dsn, conn, setup_queue):
+    """Unhandled event type must be nacked, not silently acked/dropped.
+
+    Regression for #111: consumer previously called ack() for the whole
+    batch even when a message had no registered handler, causing silent
+    message loss.
+    """
+    queue, consumer_name = setup_queue
+    client = pgque.PgqueClient(conn)
+    client.send(queue, {"x": 1}, type="totally.unregistered.type")
+    conn.execute("select pgque.force_tick(%s)", (queue,))
+    conn.execute("select pgque.ticker()")
+    conn.commit()
+
+    # Consumer with NO handler for "totally.unregistered.type"
+    # and NO default handler either.
+    cons = pgque.Consumer(
+        dsn=dsn, queue=queue, name=consumer_name,
+        poll_interval=1, retry_after=0,
+    )
+
+    t = _run_consumer_for(cons, 3.0)
+    t.join(timeout=5.0)
+
+    # The message must NOT be silently acked: it should appear in retry_queue.
+    cnt = conn.execute(
+        "select count(*) from pgque.retry_queue rq "
+        "join pgque.queue q on q.queue_id = rq.ev_queue "
+        "where q.queue_name = %s",
+        (queue,),
+    ).fetchone()[0]
+    assert cnt >= 1, (
+        "unhandled event type was silently acked/dropped instead of nacked"
+    )
+
+
 def test_consumer_stop_returns_promptly(dsn, setup_queue):
     queue, consumer_name = setup_queue
     cons = pgque.Consumer(

--- a/clients/python/tests/test_consumer.py
+++ b/clients/python/tests/test_consumer.py
@@ -128,9 +128,11 @@ def test_consumer_nacks_unhandled_event_type(dsn, conn, setup_queue):
 
     # Consumer with NO handler for "totally.unregistered.type"
     # and NO default handler either.
+    # retry_after=30 ensures the message cannot loop back within the
+    # 3-second test window and exhaust queue_max_retries.
     cons = pgque.Consumer(
         dsn=dsn, queue=queue, name=consumer_name,
-        poll_interval=1, retry_after=0,
+        poll_interval=1, retry_after=30,
     )
 
     t = _run_consumer_for(cons, 3.0)

--- a/clients/python/tests/test_consumer.py
+++ b/clients/python/tests/test_consumer.py
@@ -150,6 +150,54 @@ def test_consumer_nacks_unhandled_event_type(dsn, conn, setup_queue):
     )
 
 
+def test_consumer_warns_and_acks_unhandled_event_type(dsn, conn, setup_queue, caplog):
+    """Unhandled event type must emit a WARNING and be acked, not nacked.
+
+    The message must not appear in retry_queue; the WARNING log line must
+    contain the event type and message id.
+    """
+    import logging
+
+    queue, consumer_name = setup_queue
+    client = pgque.PgqueClient(conn)
+    msg_id = client.send(queue, {"x": 1}, type="totally.unregistered.type")
+    conn.execute("select pgque.force_tick(%s)", (queue,))
+    conn.execute("select pgque.ticker()")
+    conn.commit()
+
+    # Consumer with NO handler for "totally.unregistered.type"
+    # and NO default handler either.
+    cons = pgque.Consumer(
+        dsn=dsn, queue=queue, name=consumer_name, poll_interval=1
+    )
+
+    with caplog.at_level(logging.WARNING, logger="pgque"):
+        t = _run_consumer_for(cons, 3.0)
+        t.join(timeout=5.0)
+
+    # Must NOT be in retry_queue -- it was acked, not nacked.
+    cnt = conn.execute(
+        "select count(*) from pgque.retry_queue rq "
+        "join pgque.queue q on q.queue_id = rq.ev_queue "
+        "where q.queue_name = %s",
+        (queue,),
+    ).fetchone()[0]
+    assert cnt == 0, (
+        "unhandled event type was nacked (found in retry_queue); expected ack"
+    )
+
+    # A WARNING must have been logged containing the type and event id.
+    warning_lines = [
+        r.message for r in caplog.records if r.levelno == logging.WARNING
+    ]
+    assert any("totally.unregistered.type" in m for m in warning_lines), (
+        "expected a WARNING mentioning the unhandled event type"
+    )
+    assert any(str(msg_id) in m for m in warning_lines), (
+        "expected a WARNING mentioning the event id"
+    )
+
+
 def test_consumer_stop_returns_promptly(dsn, setup_queue):
     queue, consumer_name = setup_queue
     cons = pgque.Consumer(

--- a/clients/python/tests/test_consumer.py
+++ b/clients/python/tests/test_consumer.py
@@ -1,6 +1,6 @@
 # Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 
-"""``Consumer`` end-to-end: dispatch, missing handler, error -> nack."""
+"""``Consumer`` end-to-end: dispatch, warn+ack on missing handler, error -> nack."""
 
 import threading
 import time
@@ -110,44 +110,6 @@ def test_consumer_nacks_on_handler_error(dsn, conn, setup_queue):
         (queue,),
     ).fetchone()[0]
     assert cnt >= 1
-
-
-def test_consumer_nacks_unhandled_event_type(dsn, conn, setup_queue):
-    """Unhandled event type must be nacked, not silently acked/dropped.
-
-    Regression for #111: consumer previously called ack() for the whole
-    batch even when a message had no registered handler, causing silent
-    message loss.
-    """
-    queue, consumer_name = setup_queue
-    client = pgque.PgqueClient(conn)
-    client.send(queue, {"x": 1}, type="totally.unregistered.type")
-    conn.execute("select pgque.force_tick(%s)", (queue,))
-    conn.execute("select pgque.ticker()")
-    conn.commit()
-
-    # Consumer with NO handler for "totally.unregistered.type"
-    # and NO default handler either.
-    # retry_after=30 ensures the message cannot loop back within the
-    # 3-second test window and exhaust queue_max_retries.
-    cons = pgque.Consumer(
-        dsn=dsn, queue=queue, name=consumer_name,
-        poll_interval=1, retry_after=30,
-    )
-
-    t = _run_consumer_for(cons, 3.0)
-    t.join(timeout=5.0)
-
-    # The message must NOT be silently acked: it should appear in retry_queue.
-    cnt = conn.execute(
-        "select count(*) from pgque.retry_queue rq "
-        "join pgque.queue q on q.queue_id = rq.ev_queue "
-        "where q.queue_name = %s",
-        (queue,),
-    ).fetchone()[0]
-    assert cnt >= 1, (
-        "unhandled event type was silently acked/dropped instead of nacked"
-    )
 
 
 def test_consumer_warns_and_acks_unhandled_event_type(dsn, conn, setup_queue, caplog):

--- a/clients/python/tests/test_send.py
+++ b/clients/python/tests/test_send.py
@@ -157,3 +157,31 @@ def test_jsonb_payload_round_trip(conn, setup_queue, payload, expected):
     assert got == expected
     client.ack(msgs[0].batch_id)
     conn.commit()
+
+
+def test_send_batch_none_payload_produces_json_null(conn, setup_queue):
+    """send_batch([None]) must store JSON null, not SQL NULL.
+
+    Regression test for send/send_batch asymmetry: send(None) coerces to
+    JSON null via "null" string, but send_batch previously passed Python
+    None through psycopg as SQL NULL, bypassing the ::jsonb cast.
+    """
+    import json
+
+    queue, consumer = setup_queue
+    client = pgque.PgqueClient(conn)
+    client.send_batch(queue, "default", [None])
+    conn.execute("select pgque.force_tick(%s)", (queue,))
+    conn.execute("select pgque.ticker()")
+    conn.commit()
+    msgs = client.receive(queue, consumer, max_messages=10)
+    assert len(msgs) == 1, "expected exactly 1 message from send_batch([None])"
+    raw = msgs[0].payload
+    # payload must be JSON null (Python None after psycopg decode), not a
+    # missing/SQL-NULL value that would cause a TypeError on json.dumps.
+    got = raw if not isinstance(raw, str) else json.loads(raw)
+    assert got is None, (
+        f"send_batch([None]) should store JSON null; got {raw!r}"
+    )
+    client.ack(msgs[0].batch_id)
+    conn.commit()


### PR DESCRIPTION
## Summary

Closes #111

Changes behavior for messages with no registered handler (and no `*` catch-all):

- **Before:** `nack()` → message moved to `retry_queue`, then DLQ at max retries
- **After:** `logging.warning(...)` via the consumer's own logger, then the batch `ack()` covers the message normally

The `Consumer` now creates a per-instance logger (`pgque.consumer.<name>`) so the WARNING is attributable to the specific consumer.

### Finding 1: Behavior change — unhandled event type now warns + acks

**Root cause of original issue (#111):** `Consumer._poll_once()` called `continue` with no handler registered, then `ack()` for the whole batch — silently dropping the message.

**PR #121 original fix:** nack before continue. This is now revised: nack routes unknown types to DLQ, which conflates routing gaps with processing failures. The correct behavior is to surface the gap in logs and let the operator register a handler.

**New fix:** `self._log.warning("no handler for event type=%s ev_id=%s; acking", ...)` then `continue` — the batch-level `ack()` at the end of the loop covers it.

**Commits (TDD):**
- Red: `7a0dcbb` — `test: red -- warn+ack unhandled event type`
- Green: `ca0e9ef` — `fix(clients/python): warn+ack unhandled event types`

**Test renamed:** `test_consumer_nacks_unhandled_event_type` → `test_consumer_warns_and_acks_unhandled_event_type`

### Finding 2: Docs bug — str payload contract misdocumented (client.py)

Unchanged from original PR #121. `send()` and `send_batch()` docstrings now document that `str` must be valid JSON text.

## Test plan

- [ ] `PGQUE_TEST_DSN= pytest clients/python/tests/test_consumer.py::test_consumer_warns_and_acks_unhandled_event_type` — was failing on `7a0dcbb` (red), passes on `ca0e9ef` (green)
- [ ] Full suite: `PGQUE_TEST_DSN= pytest clients/python/tests/` — no regressions