### PR TITLE
fix(pgque.create_queue): reject queue names > 57 bytes

### DIFF
--- a/build/transform.sh
+++ b/build/transform.sh
@@ -476,6 +476,7 @@ awk '
 /^    if i_queue_name is null then$/ {
   print
   in_null_check = 1
+  next
 }
 in_null_check && /^    end if;$/ {
   q = "\047"

--- a/build/transform.sh
+++ b/build/transform.sh
@@ -478,15 +478,16 @@ awk '
   in_null_check = 1
 }
 in_null_check && /^    end if;$/ {
+  q = "\047"
   print
   print ""
   print "    -- pg_notify channel names are limited to 63 bytes by PostgreSQL."
-  print "    -- PgQue prefixes them with '\''pgque_'\'' (6 bytes), leaving 57 bytes for"
+  print "    -- PgQue prefixes them with " q "pgque_" q " (6 bytes), leaving 57 bytes for"
   print "    -- the queue name.  Reject names that would overflow the channel name"
   print "    -- before any state is written, so callers get a clear error."
   print "    if octet_length(i_queue_name) > 57 then"
-  print "        raise exception '\''queue name too long: % bytes (max 57). '\"'\"'"
-  print "            '\''pg_notify channel '\''pgque_<queue_name>'\'' must fit in 63 bytes.'\'','\"'\"'"
+  print "        raise exception " q "queue name too long: % bytes (max 57). " q
+  print "            " q "pg_notify channel " q q "pgque_<queue_name>" q q " must fit in 63 bytes." q ","
   print "            octet_length(i_queue_name);"
   print "    end if;"
   in_null_check = 0

--- a/build/transform.sh
+++ b/build/transform.sh
@@ -466,6 +466,38 @@ awk '
 
 echo "PASS: pg_notify injected into ticker function"
 
+# Patch create_queue: validate queue name length before any state is written.
+# pg_notify channel names are limited to 63 bytes by PostgreSQL.  PgQue
+# prefixes them with 'pgque_' (6 bytes), so queue names > 57 bytes would
+# overflow the channel name and produce a cryptic PG error in ticker().
+# Inject the length check right after the existing NULL guard.
+CREATE_QUEUE_FILE="${OUTPUT_DIR}/functions/pgque.create_queue.sql"
+awk '
+/^    if i_queue_name is null then$/ {
+  print
+  in_null_check = 1
+}
+in_null_check && /^    end if;$/ {
+  print
+  print ""
+  print "    -- pg_notify channel names are limited to 63 bytes by PostgreSQL."
+  print "    -- PgQue prefixes them with '\''pgque_'\'' (6 bytes), leaving 57 bytes for"
+  print "    -- the queue name.  Reject names that would overflow the channel name"
+  print "    -- before any state is written, so callers get a clear error."
+  print "    if octet_length(i_queue_name) > 57 then"
+  print "        raise exception '\''queue name too long: % bytes (max 57). '\"'\"'"
+  print "            '\''pg_notify channel '\''pgque_<queue_name>'\'' must fit in 63 bytes.'\'','\"'\"'"
+  print "            octet_length(i_queue_name);"
+  print "    end if;"
+  in_null_check = 0
+  next
+}
+in_null_check { print; next }
+{ print }
+' "${CREATE_QUEUE_FILE}" > "${CREATE_QUEUE_FILE}.tmp" && mv "${CREATE_QUEUE_FILE}.tmp" "${CREATE_QUEUE_FILE}"
+
+echo "PASS: create_queue queue name length check added"
+
 # Fix inherited PgQ copy-paste bug: sqltriga comment says logutriga
 sedi 's/Function: pgque.logutriga()/Function: pgque.sqltriga()/' "${OUTPUT_DIR}/lowlevel_pl/sqltriga.sql"
 
@@ -626,6 +658,7 @@ echo "--   4. pg_current_xact_id() cast to ::text::bigint (xid8→bigint)" >> "$
 echo "--   5. SECURITY DEFINER functions get SET search_path = pgque, pg_catalog" >> "${INSTALL_FILE}"
 echo "--   6. pgq_node/Londiste hooks removed from maint_operations" >> "${INSTALL_FILE}"
 echo "--   7. pg_notify() injected into ticker for LISTEN/NOTIFY wakeup" >> "${INSTALL_FILE}"
+echo "--   8. create_queue() rejects queue names > 57 bytes (pg_notify limit)" >> "${INSTALL_FILE}"
 echo "-- ======================================================================" >> "${INSTALL_FILE}"
 echo "" >> "${INSTALL_FILE}"
 

--- a/build/transform.sh
+++ b/build/transform.sh
@@ -466,11 +466,6 @@ awk '
 
 echo "PASS: pg_notify injected into ticker function"
 
-# Patch create_queue: validate queue name length before any state is written.
-# pg_notify channel names are limited to 63 bytes by PostgreSQL.  PgQue
-# prefixes them with 'pgque_' (6 bytes), so queue names > 57 bytes would
-# overflow the channel name and produce a cryptic PG error in ticker().
-# Inject the length check right after the existing NULL guard.
 CREATE_QUEUE_FILE="${OUTPUT_DIR}/functions/pgque.create_queue.sql"
 awk '
 /^    if i_queue_name is null then$/ {

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -106,7 +106,7 @@ Grant: `pgque_writer`. Source: `sql/pgque-api/send.sql`.
 
 #### `pgque.create_queue(queue text) → integer`
 
-Creates a queue with default settings (3 rotation tables, built-in ticker). Returns `1` if created, `0` if a queue with that name already exists.
+Creates a queue with default settings (3 rotation tables, built-in ticker). Returns `1` if created, `0` if a queue with that name already exists. Queue names are limited to 57 bytes (UTF-8); the `pgque_<name>` LISTEN/NOTIFY channel must fit within PostgreSQL's 63-byte identifier limit.
 Grant: PUBLIC (default). Source: `sql/pgque.sql`.
 
 #### `pgque.drop_queue(queue text) → integer`
@@ -474,7 +474,7 @@ OTel-compatible metric export rows.
 
 #### `pgque.create_queue(queue text, options jsonb) → integer`
 
-Sugar overload: calls `create_queue(queue)` then applies each key in `options` via `set_queue_config`. Recognized keys include `max_retries`, `rotation_period`, `ticker_max_count`, `ticker_max_lag`, `ticker_idle_period`, `ticker_paused`.
+Sugar overload: calls `create_queue(queue)` then applies each key in `options` via `set_queue_config`. Recognized keys include `max_retries`, `rotation_period`, `ticker_max_count`, `ticker_max_lag`, `ticker_idle_period`, `ticker_paused`. The 57-byte queue name limit applies here too (see the 1-arg overload above).
 
 #### `pgque.pause_queue(queue text) → void`
 

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -254,6 +254,7 @@ create index if not exists rq_retry_idx on pgque.retry_queue (ev_retry_after);
 --   5. SECURITY DEFINER functions get SET search_path = pgque, pg_catalog
 --   6. pgq_node/Londiste hooks removed from maint_operations
 --   7. pg_notify() injected into ticker for LISTEN/NOTIFY wakeup
+--   8. create_queue() rejects queue names > 57 bytes (pg_notify limit)
 -- ======================================================================
 
 
@@ -1450,6 +1451,16 @@ declare
 begin
     if i_queue_name is null then
         raise exception 'Invalid NULL value';
+    end if;
+
+    -- pg_notify channel names are limited to 63 bytes by PostgreSQL.
+    -- PgQue prefixes them with 'pgque_' (6 bytes), leaving 57 bytes for
+    -- the queue name.  Reject names that would overflow the channel name
+    -- before any state is written, so callers get a clear error.
+    if octet_length(i_queue_name) > 57 then
+        raise exception 'queue name too long: % bytes (max 57). '
+            'pg_notify channel ''pgque_<queue_name>'' must fit in 63 bytes.',
+            octet_length(i_queue_name);
     end if;
 
     -- check if exists

--- a/tests/run_all.sql
+++ b/tests/run_all.sql
@@ -52,6 +52,9 @@
 \echo 'Running: test_notify'
 \i tests/test_notify.sql
 
+\echo 'Running: test_queue_name_length'
+\i tests/test_queue_name_length.sql
+
 \echo 'Running: test_api_send'
 \i tests/test_api_send.sql
 

--- a/tests/test_queue_name_length.sql
+++ b/tests/test_queue_name_length.sql
@@ -1,0 +1,58 @@
+-- test_queue_name_length.sql -- Queue name length validation (issue #109)
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- pg_notify channel names are limited to 63 bytes (PostgreSQL identifier limit).
+-- PgQue prefixes them with 'pgque_' (6 bytes), leaving 57 bytes for the queue name.
+-- Names > 57 bytes must be rejected with a clear error before the notify fires.
+
+do $$
+declare
+  v_ok bool;
+begin
+  -- 57-byte name should succeed: length('pgque_' || name) = 63
+  perform pgque.create_queue(repeat('q', 57));
+  assert exists (
+    select 1 from pgque.get_queue_info()
+    where queue_name = repeat('q', 57)
+  ), '57-byte queue name should be created successfully';
+  perform pgque.drop_queue(repeat('q', 57));
+
+  raise notice 'PASS: 57-byte queue name accepted';
+end $$;
+
+do $$
+declare
+  v_caught bool := false;
+  v_msg    text;
+begin
+  -- 58-byte name must be rejected: length('pgque_' || name) = 64 > 63
+  begin
+    perform pgque.create_queue(repeat('q', 58));
+  exception when others then
+    v_caught := true;
+    v_msg := sqlerrm;
+  end;
+
+  assert v_caught,
+    '58-byte queue name should raise an error, got none';
+  assert v_msg like '%queue name too long%' or v_msg like '%57%',
+    'error message should mention queue name length limit, got: ' || v_msg;
+
+  raise notice 'PASS: 58-byte queue name rejected with: %', v_msg;
+end $$;
+
+do $$
+declare
+  v_caught bool := false;
+begin
+  -- 63-byte name must also be rejected
+  begin
+    perform pgque.create_queue(repeat('x', 63));
+  exception when others then
+    v_caught := true;
+  end;
+
+  assert v_caught, '63-byte queue name should raise an error';
+
+  raise notice 'PASS: 63-byte queue name rejected';
+end $$;

--- a/tests/test_queue_name_length.sql
+++ b/tests/test_queue_name_length.sql
@@ -56,3 +56,52 @@ begin
 
   raise notice 'PASS: 63-byte queue name rejected';
 end $$;
+
+-- Multi-byte UTF-8 boundary: octet_length vs length differ for non-ASCII chars.
+-- 19 × 3-byte char (日) = 57 bytes → accept (locks in octet_length semantics).
+do $$
+begin
+  perform pgque.create_queue(repeat('日', 19));
+  assert exists (
+    select 1 from pgque.get_queue_info()
+    where queue_name = repeat('日', 19)
+  ), '57-byte UTF-8 queue name (19 × 3-byte char) should be created successfully';
+  perform pgque.drop_queue(repeat('日', 19));
+
+  raise notice 'PASS: 57-byte UTF-8 queue name (19 × 3-byte char) accepted';
+end $$;
+
+-- 20 × 3-byte char (日) = 60 bytes → reject.
+do $$
+declare
+  v_caught bool := false;
+begin
+  begin
+    perform pgque.create_queue(repeat('日', 20));
+  exception when others then
+    v_caught := true;
+  end;
+
+  assert v_caught, '60-byte UTF-8 queue name (20 × 3-byte char) should raise an error';
+
+  raise notice 'PASS: 60-byte UTF-8 queue name (20 × 3-byte char) rejected';
+end $$;
+
+-- No partial state: a rejected create_queue must not insert into pgque.queue.
+do $$
+declare
+  v_caught bool := false;
+begin
+  begin
+    perform pgque.create_queue(repeat('q', 58));
+  exception when others then
+    v_caught := true;
+  end;
+
+  assert v_caught, '58-byte queue name should raise an error';
+  assert not exists (
+    select 1 from pgque.queue where queue_name = repeat('q', 58)
+  ), 'rejected queue must not leave partial state in pgque.queue';
+
+  raise notice 'PASS: rejected create_queue leaves no partial state';
+end $$;


### PR DESCRIPTION
## Summary

Closes #109

Queue names longer than 57 bytes fail at `ticker()` with PostgreSQL's own
opaque `channel name too long` error because `pg_notify('pgque_' || name, ...)`
produces a channel name > 63 bytes.

**Option A chosen (fail-fast validation):** Validate the queue name length at
the top of `create_queue()` before any sequences, tables, or rows are created.
This gives callers a clear, actionable error and matches PostgreSQL's own
identifier-length convention (e.g. `NAMEDATALEN - 1 = 63`).

The limit is 57 bytes: `63 (PG channel max) - 6 (len('pgque_'))`.

## Changes

- `sql/pgque.sql`: `octet_length(i_queue_name) > 57` check in `create_queue()`,
  raises `queue name too long: N bytes (max 57)` before any state is written.
- `build/transform.sh`: corresponding post-transform patch so future `./build/transform.sh`
  runs keep the fix.

## Test output

```
PASS: 57-byte queue name accepted
PASS: 58-byte queue name rejected with: queue name too long: 58 bytes (max 57). pg_notify channel 'pgque_<queue_name>' must fit in 63 bytes.
PASS: 63-byte queue name rejected
=== ALL TESTS PASSED ===
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)