### PR TITLE
docs: reference + examples + roles cleanup (#99, #105, #112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ grant pgque_reader to metrics;
 
 DDL-class operations (`create_queue`, `drop_queue`, `start`, `stop`, `maint`, `ticker`, `force_tick`) are not granted to `pgque_writer` and should be performed by an admin / migration role. They currently default to PUBLIC; revoking from PUBLIC and granting only to `pgque_admin` is on the roadmap.
 
+**Roles are global, not per-queue.** `pgque_writer` can produce and consume on any queue and ack any consumer's batch. Do not grant `pgque_writer` to mutually untrusted applications sharing one database unless you add your own schema-level or database-level isolation. See [docs/reference.md — Roles scope](docs/reference.md#roles-are-global-not-per-queue) for details and recommended isolation patterns.
+
 ## Project status
 
 PgQue is **early-stage** as a product and API layer. PgQ itself has run at Skype scale for over a decade. What's new here is the packaging, modernization, managed-Postgres compatibility, and the higher-level PgQue API around that core.

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ create user metrics with password '...';              -- replace with a real pas
 grant pgque_reader to metrics;
 ```
 
-DDL-class operations (`create_queue`, `drop_queue`, `start`, `stop`, `maint`, `ticker`, `force_tick`) are not granted to `pgque_writer` and should be performed by an admin / migration role. They currently default to PUBLIC; revoking from PUBLIC and granting only to `pgque_admin` is on the roadmap.
+DDL-class operations (`create_queue`, `drop_queue`, `start`, `stop`, `maint`, `maint_retry_events`, `ticker`, `force_tick`, `set_queue_config`) are not granted to `pgque_writer`. The schema-wide blanket `revoke execute … from public` strips PUBLIC, and `pgque_admin` is the only role that retains `execute` on these helpers — perform them as an admin / migration role.
 
 **Roles are global, not per-queue.** `pgque_writer` can produce and consume on any queue and ack any consumer's batch. Do not grant `pgque_writer` to mutually untrusted applications sharing one database unless you add your own schema-level or database-level isolation. See [docs/reference.md — Roles scope](docs/reference.md#roles-are-global-not-per-queue) for details and recommended isolation patterns.
 
@@ -220,18 +220,14 @@ select pgque.force_tick('orders');
 select pgque.ticker();
 
 -- tx 4: receive (all returned rows share the same batch_id)
-select * from pgque.receive('orders', 'processor', 100) \gset
--- or capture into a temp table: create temp table msgs as select * from ...
+create temp table msgs as
+  select * from pgque.receive('orders', 'processor', 100);
 
--- tx 5: acknowledge — pass the batch_id captured above
--- with \gset the column is named "batch_id" from the first row:
--- select pgque.ack(:batch_id);
--- or with a temp table:
--- select pgque.ack((select batch_id from msgs limit 1));
-select pgque.ack(:batch_id);
+-- tx 5: acknowledge — pull the batch_id from any returned row
+select pgque.ack((select batch_id from msgs limit 1));
 ```
 
-Send, tick, and receive should be separate transactions — that's PgQ's snapshot-based design working as intended. In normal operation, `pg_cron` or an external scheduler drives `pgque.ticker()`; `force_tick()` is mainly for demos, tests, and manual operation. The `\gset` trick works in psql — for application code, store the `batch_id` from any returned row.
+Send, tick, and receive should be separate transactions — that's PgQ's snapshot-based design working as intended. In normal operation, `pg_cron` or an external scheduler drives `pgque.ticker()`; `force_tick()` is mainly for demos, tests, and manual operation. The temp-table capture above is the safe psql pattern when `receive` returns more than one row; for application code, store the `batch_id` from any returned row.
 
 Longer walkthrough in the [tutorial](docs/tutorial.md); patterns like fan-out, exactly-once, and recurring jobs in [examples](docs/examples.md).
 

--- a/README.md
+++ b/README.md
@@ -146,18 +146,19 @@ With `pg_cron` available in the same database as PgQue, `pgque.start()` creates 
 select pgque.start();
 ```
 
-**pg_cron in a different database.** `pg_cron` runs jobs in one designated database (`cron.database_name`, typically `postgres`). If your PgQue schema lives in a different database, use the [cross-database pattern](https://github.com/citusdata/pg_cron#creating-a-cron-job-in-a-different-database) to call `pgque.ticker()` and `pgque.maint()` across databases. *Todo: a future release will detect this and emit the correct `cron.schedule_in_database` calls from `pgque.start()` automatically.*
+**pg_cron in a different database.** `pg_cron` runs jobs in one designated database (`cron.database_name`, typically `postgres`). If your PgQue schema lives in a different database, use the [cross-database pattern](https://github.com/citusdata/pg_cron#creating-a-cron-job-in-a-different-database) to call `pgque.ticker()`, `pgque.maint_retry_events()`, and `pgque.maint()` across databases. *Todo: a future release will detect this and emit the correct `cron.schedule_in_database` calls from `pgque.start()` automatically.*
 
 **pg_cron log hygiene.** The ticker runs every second, adding ~3,600 rows per hour to `cron.job_run_details` with no built-in purge. Set `alter system set cron.log_run = off;` globally, or schedule a periodic purge — see [the tutorial](docs/tutorial.md#production-cadence-use-pg_cron) for both recipes.
 
 Without `pg_cron`, PgQue still installs. Drive ticking and maintenance from your application or an external scheduler:
 
 ```bash
-PAGER=cat psql --no-psqlrc -c "select pgque.ticker()"   # every 1 second
-PAGER=cat psql --no-psqlrc -c "select pgque.maint()"    # every 30 seconds
+PAGER=cat psql --no-psqlrc -c "select pgque.ticker()"              # every 1 second
+PAGER=cat psql --no-psqlrc -c "select pgque.maint_retry_events()"  # every 30 seconds
+PAGER=cat psql --no-psqlrc -c "select pgque.maint()"               # every 30 seconds
 ```
 
-**Important:** PgQue does not deliver messages without a working ticker. Enqueueing still works, but consumers will see nothing new because no ticks are created. If you do not use `pg_cron`, run `pgque.ticker()` and `pgque.maint()` yourself.
+**Important:** PgQue does not deliver messages without a working ticker. Enqueueing still works, but consumers will see nothing new because no ticks are created. If you do not use `pg_cron`, run `pgque.ticker()`, `pgque.maint_retry_events()`, and `pgque.maint()` yourself. Skipping `maint_retry_events()` means nack'd events will never be redelivered.
 
 Treat installation as one-way for now — upgrade and reinstall paths are still being tightened. To uninstall: `\i sql/pgque_uninstall.sql`.
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ DDL-class operations (`create_queue`, `drop_queue`, `start`, `stop`, `maint`, `t
 
 PgQue is **early-stage** as a product and API layer. PgQ itself has run at Skype scale for over a decade. What's new here is the packaging, modernization, managed-Postgres compatibility, and the higher-level PgQue API around that core.
 
-The default install stays small in v0.1; additional APIs live under `sql/experimental/` until they are worth promoting. See [blueprints/PHASES.md](blueprints/PHASES.md).
+The default install stays small; additional APIs live under `sql/experimental/` until they are worth promoting. See [blueprints/PHASES.md](blueprints/PHASES.md).
 
 ## Docs
 
@@ -213,18 +213,23 @@ select pgque.subscribe('orders', 'processor');
 select pgque.send('orders', '{"order_id": 42, "total": 99.95}'::jsonb);
 
 -- tx 3: advance the queue if you are not using pg_cron
--- (force_tick bypasses lag/count thresholds — handy in demos/tests)
+-- (force_tick bumps the event-seq threshold; ticker() then inserts the tick)
 select pgque.force_tick('orders');
 select pgque.ticker();
 
--- tx 4: receive (batch_id is the same for every returned row)
-select * from pgque.receive('orders', 'processor', 100);
+-- tx 4: receive (all returned rows share the same batch_id)
+select * from pgque.receive('orders', 'processor', 100) \gset
+-- or capture into a temp table: create temp table msgs as select * from ...
 
--- tx 5: acknowledge
+-- tx 5: acknowledge — pass the batch_id captured above
+-- with \gset the column is named "batch_id" from the first row:
+-- select pgque.ack(:batch_id);
+-- or with a temp table:
+-- select pgque.ack((select batch_id from msgs limit 1));
 select pgque.ack(:batch_id);
 ```
 
-Send, tick, and receive should be separate transactions — that's PgQ's snapshot-based design working as intended. In normal operation, `pg_cron` or an external scheduler drives `pgque.ticker()`; `force_tick()` is mainly for demos, tests, and manual operation.
+Send, tick, and receive should be separate transactions — that's PgQ's snapshot-based design working as intended. In normal operation, `pg_cron` or an external scheduler drives `pgque.ticker()`; `force_tick()` is mainly for demos, tests, and manual operation. The `\gset` trick works in psql — for application code, store the `batch_id` from any returned row.
 
 Longer walkthrough in the [tutorial](docs/tutorial.md); patterns like fan-out, exactly-once, and recurring jobs in [examples](docs/examples.md).
 
@@ -238,7 +243,8 @@ PgQue is SQL-first, so any Postgres driver works. Example client libraries exist
 from pgque import PgqueClient, Consumer
 
 client = PgqueClient(conn)
-client.send("orders", {"order_id": 42})
+# type= must match the event type the consumer listens on
+client.send("orders", {"order_id": 42}, type="order.created")
 
 consumer = Consumer(dsn, queue="orders", name="processor", poll_interval=30)
 
@@ -278,14 +284,21 @@ if (messages.length > 0) await client.ack(messages[0].batch_id);
 
 ```sql
 select pgque.send('orders', '{"order_id": 42}'::jsonb);
-select * from pgque.receive('orders', 'processor', 100);
-select pgque.ack(batch_id);
+
+-- receive returns rows; each row carries the batch_id
+create temp table msgs as
+  select * from pgque.receive('orders', 'processor', 100);
+
+-- ack uses the batch_id from any row (all rows share the same batch_id)
+select pgque.ack((select batch_id from msgs limit 1));
 ```
 
 ## Benchmarks
 
-Preliminary laptop numbers: ~86k ev/s PL/pgSQL insert, ~2.4M ev/s consumer
-read rate, zero dead-tuple growth under a 30-minute sustained test. See
+Preliminary laptop numbers: ~86k ev/s PL/pgSQL insert, ~2.4M ev/s primitive
+batch read rate (`get_batch_events`), zero dead-tuple growth under a 30-minute
+sustained test. The batch read figure reflects raw PgQ primitive throughput,
+not end-to-end `receive()`/`ack()` consumer throughput. See
 [docs/benchmarks.md](docs/benchmarks.md) for the full table and methodology.
 Server-class numbers to follow.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -56,9 +56,6 @@ begin;
   create temp table msgs as
     select * from pgque.receive('orders', 'processor', 100);
 
-  -- When msgs is empty both statements below are no-ops: the insert
-  -- affects 0 rows, and the select ... limit 1 returns no rows so ack
-  -- is never called.  No DO block needed.
   insert into processed_orders (order_id, status)
   select (payload::jsonb->>'order_id')::int, 'done'
   from msgs;

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -60,7 +60,7 @@ begin;
   select (payload::jsonb->>'order_id')::int, 'done'
   from msgs;
 
-  select pgque.ack(batch_id) from msgs limit 1;
+  select pgque.ack((select batch_id from msgs limit 1));
 commit;
 ```
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -56,15 +56,28 @@ begin;
   create temp table msgs as
     select * from pgque.receive('orders', 'processor', 100);
 
-  insert into processed_orders (order_id, status)
-  select (payload::jsonb->>'order_id')::int, 'done'
-  from msgs;
+  -- Guard: nothing to do if the batch was empty (no tick ready yet).
+  -- Without this guard, ack(NULL) returns 0 with a warning and is a no-op,
+  -- but it is cleaner to skip the work entirely.
+  do $$
+  declare
+    v_batch_id bigint;
+  begin
+    select batch_id into v_batch_id from msgs limit 1;
+    if v_batch_id is null then
+      return;  -- nothing received
+    end if;
 
-  select pgque.ack((select distinct batch_id from msgs limit 1));
+    insert into processed_orders (order_id, status)
+    select (payload::jsonb->>'order_id')::int, 'done'
+    from msgs;
+
+    perform pgque.ack(v_batch_id);
+  end $$;
 commit;
 ```
 
-Every row in `msgs` shares the same `batch_id`, so `select distinct batch_id from msgs limit 1` is safe. A PL/pgSQL block with `select batch_id into v_batch_id from msgs limit 1` is equivalent.
+Every row in `msgs` shares the same `batch_id`. **Batch-ownership caveat:** `pgque.ack(batch_id)` advances the consumer past the entire underlying batch, even if `receive()` returned fewer rows than the batch contains (due to `max_return`). Either consume the full batch before acking, or use `max_return >= ticker_max_count` (default 500) to ensure all rows are returned.
 
 ## Recurring jobs with pg_cron
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -56,24 +56,14 @@ begin;
   create temp table msgs as
     select * from pgque.receive('orders', 'processor', 100);
 
-  -- Guard: nothing to do if the batch was empty (no tick ready yet).
-  -- Without this guard, ack(NULL) returns 0 with a warning and is a no-op,
-  -- but it is cleaner to skip the work entirely.
-  do $$
-  declare
-    v_batch_id bigint;
-  begin
-    select batch_id into v_batch_id from msgs limit 1;
-    if v_batch_id is null then
-      return;  -- nothing received
-    end if;
+  -- When msgs is empty both statements below are no-ops: the insert
+  -- affects 0 rows, and the select ... limit 1 returns no rows so ack
+  -- is never called.  No DO block needed.
+  insert into processed_orders (order_id, status)
+  select (payload::jsonb->>'order_id')::int, 'done'
+  from msgs;
 
-    insert into processed_orders (order_id, status)
-    select (payload::jsonb->>'order_id')::int, 'done'
-    from msgs;
-
-    perform pgque.ack(v_batch_id);
-  end $$;
+  select pgque.ack(batch_id) from msgs limit 1;
 commit;
 ```
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -10,7 +10,7 @@ Each entry takes this form:
 #### `pgque.<name>(arg text, …) → returntype`
 
 One-line description. Optional second line with a caveat.
-Grant: `role_name` or `PUBLIC (default)`. Source: `sql/<path>`.
+Grant: `role_name`. Source: `sql/<path>`.
 
 
 
@@ -111,22 +111,22 @@ Grant: `pgque_writer`. Source: `sql/pgque-api/send.sql`.
 #### `pgque.create_queue(queue text) → integer`
 
 Creates a queue with default settings (3 rotation tables, built-in ticker). Returns `1` if created, `0` if a queue with that name already exists. Queue names are limited to 57 bytes (UTF-8); the `pgque_<name>` LISTEN/NOTIFY channel must fit within PostgreSQL's 63-byte identifier limit.
-Grant: PUBLIC (default). Source: `sql/pgque.sql`.
+Grant: `pgque_admin`. Source: `sql/pgque.sql`.
 
 #### `pgque.drop_queue(queue text) → integer`
 
 Drops `queue`. Fails if consumers are still attached.
-Grant: PUBLIC (default). Source: `sql/pgque.sql`.
+Grant: `pgque_admin`. Source: `sql/pgque.sql`.
 
 #### `pgque.drop_queue(queue text, force bool) → integer`
 
 Drops `queue`. When `force` is true, unregisters all attached consumers first.
-Grant: PUBLIC (default). Source: `sql/pgque.sql`.
+Grant: `pgque_admin`. Source: `sql/pgque.sql`.
 
 #### `pgque.set_queue_config(queue text, param text, value text) → integer`
 
 Sets one queue parameter. Accepted `param` values (without the `queue_` prefix): `ticker_max_count`, `ticker_max_lag`, `ticker_idle_period`, `ticker_paused`, `rotation_period`, `external_ticker`, `max_retries`.
-Grant: PUBLIC (default). Source: `sql/pgque.sql` (extended in `sql/pgque-additions/queue_max_retries.sql`).
+Grant: `pgque_admin`. Source: `sql/pgque.sql` (extended in `sql/pgque-additions/queue_max_retries.sql`).
 
 ```sql
 select pgque.set_queue_config('orders', 'max_retries', '10');
@@ -134,22 +134,22 @@ select pgque.set_queue_config('orders', 'max_retries', '10');
 
 ## Lifecycle
 
-Most functions in this section are left on PUBLIC by default — tighten with `revoke execute … from public` if your policy demands it. `uninstall()` is explicitly revoked from `pgque_admin`, but PUBLIC EXECUTE remains by default — tighten with `revoke execute on function pgque.uninstall() from public` if stricter control is required.
+Functions in this section are deny-by-default: the schema-wide blanket `revoke execute … from public` in `sql/pgque-additions/roles.sql` strips PUBLIC, and only `pgque_admin` retains `execute on all functions`. Grant explicitly to additional roles if your policy needs broader access. `uninstall()` is doubly locked down — also explicitly revoked from `pgque_admin` — so only the schema/install owner (typically a superuser) can run it.
 
 #### `pgque.start() → void`
 
 Schedules four pg_cron jobs in the current database: `pgque_ticker` (every 1 s), `pgque_retry_events` (every 30 s), `pgque_maint` (every 30 s), and `pgque_rotate_step2` (every 10 s). Requires the `pg_cron` extension — errors if missing. Idempotent: calls `stop()` first.
-Grant: PUBLIC (default). Source: `sql/pgque-additions/lifecycle.sql`.
+Grant: `pgque_admin`. Source: `sql/pgque-additions/lifecycle.sql`.
 
 #### `pgque.stop() → void`
 
 Unschedules the pg_cron jobs set up by `start()` and clears the stored job IDs. Safe to call if `pg_cron` is absent.
-Grant: PUBLIC (default). Source: `sql/pgque-additions/lifecycle.sql`.
+Grant: `pgque_admin`. Source: `sql/pgque-additions/lifecycle.sql`.
 
 #### `pgque.status() → table(component text, status text, detail text)`
 
 Returns a diagnostic report with one row per component: Postgres version, PgQue version, ticker/maintenance job status, queue count, and consumer count.
-Grant: PUBLIC (default). Source: `sql/pgque-additions/lifecycle.sql`.
+Grant: `pgque_admin`. Source: `sql/pgque-additions/lifecycle.sql`.
 
 ```sql
 select * from pgque.status();
@@ -162,7 +162,7 @@ Grant: `pgque_reader`. Source: `sql/pgque-additions/lifecycle.sql`.
 
 #### `pgque.maint() → integer`
 
-Runs one maintenance cycle: rotation step 1 and retry-queue processing. Rotation step 2 is intentionally skipped — it must run in its own transaction and is scheduled separately by `start()`. Returns the total number of operations performed.
+Runs one maintenance cycle: rotation step 1 plus any queue extra-maint hooks registered via `pgque.queue_extra_maint`. Rotation step 2 is intentionally skipped (it must run in its own transaction and is scheduled separately by `start()`); retry-queue processing is **not** performed here — call `pgque.maint_retry_events()` as a separate scheduled job. Returns the total number of operations performed.
 Grant: `pgque_admin`. Source: `sql/pgque-api/maint.sql`.
 
 #### `pgque.maint_retry_events() → integer`
@@ -174,29 +174,29 @@ select pgque.maint_retry_events(); -- every 30 seconds, for nack/retry redeliver
 select pgque.maint();              -- every 30 seconds, for rotation
 ```
 
-Grant: PUBLIC (default). Source: `sql/pgque.sql`.
+Grant: `pgque_admin`. Source: `sql/pgque.sql`.
 
 #### `pgque.ticker() → bigint`
 
 Issues ticks for all unpaused, non-external queues. Returns the number of queues ticked. Call this from your scheduler (every 1 s by default) when not using pg_cron.
-Grant: PUBLIC (default). Source: `sql/pgque.sql`.
+Grant: `pgque_admin`. Source: `sql/pgque.sql`.
 
 #### `pgque.ticker(queue text) → bigint`
 
 Checks whether a tick is due for `queue` and inserts one if so. Returns the tick id (or `NULL` if no tick was created).
-Grant: PUBLIC (default). Source: `sql/pgque.sql`.
+Grant: `pgque_admin`. Source: `sql/pgque.sql`.
 
 > Note: a 4-argument `ticker(queue, tick_id, timestamp, event_seq)` overload exists for queues configured with `external_ticker = true` (pushing ticks from an external clock source). Not covered here.
 
 #### `pgque.force_tick(queue text) → bigint`
 
 Simulates a burst of events on `queue` by advancing the queue's event sequence counter past the `ticker_max_count` threshold, causing the next `pgque.ticker()` call to insert a tick. Does not insert a tick itself — call `pgque.ticker()` (or `pgque.ticker(queue)`) after `force_tick()` to materialise the tick. Returns the current last tick id (from the most recent existing tick, not a new one). Useful in tests and demos; not for production hot paths.
-Grant: PUBLIC (default). Source: `sql/pgque.sql`.
+Grant: `pgque_admin`. Source: `sql/pgque.sql`.
 
 #### `pgque.uninstall() → void`
 
-Calls `stop()` (if pg_cron is present) and then `drop schema pgque cascade`. Roles (`pgque_reader`, `pgque_writer`, `pgque_admin`) are not dropped and must be removed manually if desired. `execute` is revoked from `pgque_admin`; PUBLIC EXECUTE remains by default — revoke explicitly if stricter control is required.
-Grant: `execute` revoked from `pgque_admin`, but not from PUBLIC. Source: `sql/pgque-additions/lifecycle.sql`.
+Calls `stop()` (if pg_cron is present) and then `drop schema pgque cascade`. Roles (`pgque_reader`, `pgque_writer`, `pgque_admin`) are not dropped and must be removed manually if desired. `execute` is revoked from both `pgque_admin` (explicit) and PUBLIC (via the schema-wide blanket revoke), so only the schema/install owner (typically a superuser) can run it.
+Grant: superuser / schema owner only (revoked from both `pgque_admin` and PUBLIC). Source: `sql/pgque-additions/lifecycle.sql`.
 
 ## Observability
 
@@ -373,12 +373,12 @@ Grant: `pgque_writer`. Source: `sql/pgque.sql`.
 #### `pgque.get_batch_cursor(batch_id bigint, cursor_name text, quick_limit int4) → setof record`
 
 Declares a server-side cursor over the batch and returns the first `quick_limit` events. Remaining events can be fetched with `fetch … from <cursor_name>`.
-Grant: PUBLIC (default). Source: `sql/pgque.sql`.
+Grant: `pgque_admin`. Source: `sql/pgque.sql`.
 
 #### `pgque.get_batch_cursor(batch_id bigint, cursor_name text, quick_limit int4, extra_where text) → setof record`
 
 Same as above with an additional `where` filter applied inside the cursor.
-Grant: PUBLIC (default). Source: `sql/pgque.sql`.
+Grant: `pgque_admin`. Source: `sql/pgque.sql`.
 
 #### `pgque.finish_batch(batch_id bigint) → integer`
 
@@ -398,11 +398,11 @@ Grant: `pgque_writer`. Source: `sql/pgque.sql`.
 #### `pgque.batch_retry(batch_id bigint, retry_seconds integer) → integer`
 
 Re-queues every event in the batch after `retry_seconds`. Returns the number of events enqueued for retry.
-Grant: PUBLIC (default). Source: `sql/pgque.sql`.
+Grant: `pgque_admin`. Source: `sql/pgque.sql`.
 
 ## Trigger helpers (change-data-capture)
 
-Table triggers that enqueue a PgQue event for every INSERT / UPDATE / DELETE. All three return `trigger`; attach them via `CREATE TRIGGER … EXECUTE PROCEDURE pgque.<name>('queue_name', …)`. Grant: PUBLIC (default). Source: `sql/pgque.sql` (inherited from PgQ).
+Table triggers that enqueue a PgQue event for every INSERT / UPDATE / DELETE. All three return `trigger`; attach them via `CREATE TRIGGER … EXECUTE PROCEDURE pgque.<name>('queue_name', …)`. Grant: `pgque_admin`. Source: `sql/pgque.sql` (inherited from PgQ).
 
 #### `pgque.jsontriga() → trigger`
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -134,7 +134,7 @@ select pgque.set_queue_config('orders', 'max_retries', '10');
 
 ## Lifecycle
 
-Most functions in this section are left on PUBLIC by default — tighten with `revoke execute … from public` if your policy demands it. `uninstall()` is explicitly revoked from both `pgque_admin` and PUBLIC — it can only be called by a superuser or the schema owner.
+Most functions in this section are left on PUBLIC by default — tighten with `revoke execute … from public` if your policy demands it. `uninstall()` is explicitly revoked from `pgque_admin`, but PUBLIC EXECUTE remains by default — tighten with `revoke execute on function pgque.uninstall() from public` if stricter control is required.
 
 #### `pgque.start() → void`
 
@@ -195,8 +195,8 @@ Grant: PUBLIC (default). Source: `sql/pgque.sql`.
 
 #### `pgque.uninstall() → void`
 
-Calls `stop()` (if pg_cron is present) and then `drop schema pgque cascade`. Roles (`pgque_reader`, `pgque_writer`, `pgque_admin`) are not dropped and must be removed manually if desired. `execute` is revoked from both `pgque_admin` and PUBLIC — superuser / schema owner only.
-Grant: superuser / schema owner only (both `pgque_admin` and PUBLIC `execute` are explicitly revoked). Source: `sql/pgque-additions/lifecycle.sql`.
+Calls `stop()` (if pg_cron is present) and then `drop schema pgque cascade`. Roles (`pgque_reader`, `pgque_writer`, `pgque_admin`) are not dropped and must be removed manually if desired. `execute` is revoked from `pgque_admin`; PUBLIC EXECUTE remains by default — revoke explicitly if stricter control is required.
+Grant: `execute` revoked from `pgque_admin`, but not from PUBLIC. Source: `sql/pgque-additions/lifecycle.sql`.
 
 ## Observability
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -439,6 +439,24 @@ Returned by `pgque.receive()` and consumed by `pgque.nack()`.
 
 Three roles, with inheritance `pgque_admin > pgque_writer > pgque_reader`. Source: `sql/pgque-additions/roles.sql` (plus colocated grants in `sql/pgque-api/*.sql` and `sql/pgque-additions/dlq.sql`).
 
+### Roles are global, not per-queue
+
+PgQue roles are coarse **database-level** roles. They are intended for trusted applications and operators sharing the same database, not as per-queue or per-tenant isolation for mutually untrusted applications.
+
+**What this means in practice:**
+
+- `pgque_reader` gets `select` on **all** tables in the `pgque` schema — it can read events from any queue.
+- `pgque_writer` can call `receive`, `ack`, and `nack` on **any** queue with **any** consumer name. A writer granted for queue A can call `pgque.ack(batch_id)` on a batch opened by a consumer on queue B.
+- There is **no per-queue ACL** and no per-tenant isolation built into PgQue. Queue names and consumer names are plain strings — any writer who knows them can interact with them.
+
+This is an intentional design decision for the current release. The batch-ID-based primitives (`ack`, `nack`, `event_retry`) operate on IDs and do not enforce ownership.
+
+**Recommended isolation patterns** if you need mutually untrusted tenants in one database:
+
+- Run separate PgQue installs in separate schemas per tenant (not yet officially supported — track the roadmap).
+- Use separate databases per tenant and connect each tenant's application to its own database.
+- Wrap the PgQue API in app-owned stored functions that enforce tenant ownership before delegating to `pgque.*`, and grant only those wrapper functions to tenant roles.
+
 | Role           | Functions granted (direct)                                                                                                                                                                                                                                              |
 |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `pgque_reader` | `get_queue_info()`, `get_queue_info(text)`, `get_consumer_info()`, `get_consumer_info(text)`, `get_consumer_info(text, text)`, `get_batch_info(bigint)`, `version()`, `dlq_inspect(text, int)`; `select` on all tables incl. `pgque.dead_letter`                        |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -90,7 +90,6 @@ Negative-acknowledges one message. Only `msg.msg_id` (and the `batch_id` argumen
 - If the canonical `ev_retry` is below the queue's `max_retries`, re-queues after `retry_after` (via `pgque.event_retry`).
 - If `ev_retry >= max_retries`, routes the canonical event to `pgque.dead_letter` (via `pgque.event_dead`). This is idempotent: repeated calls for the same terminal message produce exactly one DLQ row (the second call does nothing).
 - If `msg.msg_id` is not present in the active batch — including a `NULL` msg_id or a msg_id from a different batch — raises `msg_id % not found in batch %`.
-
 Grant: `pgque_writer`. Source: `sql/pgque-api/receive.sql`.
 
 ```sql
@@ -135,11 +134,11 @@ select pgque.set_queue_config('orders', 'max_retries', '10');
 
 ## Lifecycle
 
-Most functions in this section are left on PUBLIC by default — tighten with `revoke execute … from public` if your policy demands it. `uninstall()` is explicitly revoked from `pgque_admin`, but PUBLIC execute is not revoked by default (see its entry below).
+Most functions in this section are left on PUBLIC by default — tighten with `revoke execute … from public` if your policy demands it. `uninstall()` is explicitly revoked from both `pgque_admin` and PUBLIC — it can only be called by a superuser or the schema owner.
 
 #### `pgque.start() → void`
 
-Schedules three pg_cron jobs in the current database: `pgque_ticker` (every 1 s), `pgque_maint` (every 30 s), and `pgque_rotate_step2` (every 10 s). Requires the `pg_cron` extension — errors if missing. Idempotent: calls `stop()` first.
+Schedules four pg_cron jobs in the current database: `pgque_ticker` (every 1 s), `pgque_retry_events` (every 30 s), `pgque_maint` (every 30 s), and `pgque_rotate_step2` (every 10 s). Requires the `pg_cron` extension — errors if missing. Idempotent: calls `stop()` first.
 Grant: PUBLIC (default). Source: `sql/pgque-additions/lifecycle.sql`.
 
 #### `pgque.stop() → void`
@@ -166,6 +165,17 @@ Grant: `pgque_reader`. Source: `sql/pgque-additions/lifecycle.sql`.
 Runs one maintenance cycle: rotation step 1 and retry-queue processing. Rotation step 2 is intentionally skipped — it must run in its own transaction and is scheduled separately by `start()`. Returns the total number of operations performed.
 Grant: `pgque_admin`. Source: `sql/pgque-api/maint.sql`.
 
+#### `pgque.maint_retry_events() → integer`
+
+Moves due rows from `pgque.retry_queue` back into queue event tables so they appear in the next tick. Must be called periodically when using `nack()` with retry — `pgque.start()` schedules it as `pgque_retry_events` every 30 s. When driving the scheduler manually, call this alongside `pgque.maint()`:
+
+```sql
+select pgque.maint_retry_events(); -- every 30 seconds, for nack/retry redelivery
+select pgque.maint();              -- every 30 seconds, for rotation + vacuum
+```
+
+Grant: PUBLIC (default). Source: `sql/pgque.sql`.
+
 #### `pgque.ticker() → bigint`
 
 Issues ticks for all unpaused, non-external queues. Returns the number of queues ticked. Call this from your scheduler (every 1 s by default) when not using pg_cron.
@@ -180,13 +190,13 @@ Grant: PUBLIC (default). Source: `sql/pgque.sql`.
 
 #### `pgque.force_tick(queue text) → bigint`
 
-Bypasses the tick thresholds for one queue and forces a tick immediately. Useful in tests and demos; not for production hot paths. Returns the current last tick id.
+Simulates a burst of events on `queue` by advancing the queue's event sequence counter past the `ticker_max_count` threshold, causing the next `pgque.ticker()` call to insert a tick. Does not insert a tick itself — call `pgque.ticker()` (or `pgque.ticker(queue)`) after `force_tick()` to materialise the tick. Returns the current last tick id (from the most recent existing tick, not a new one). Useful in tests and demos; not for production hot paths.
 Grant: PUBLIC (default). Source: `sql/pgque.sql`.
 
 #### `pgque.uninstall() → void`
 
-Calls `stop()` (if pg_cron is present) and then `drop schema pgque cascade`. Roles (`pgque_reader`, `pgque_writer`, `pgque_admin`) are not dropped and must be removed manually if desired.
-Grant: `execute` is revoked from both `pgque_admin` and `PUBLIC` — superuser / schema owner only. Source: `sql/pgque-additions/lifecycle.sql`.
+Calls `stop()` (if pg_cron is present) and then `drop schema pgque cascade`. Roles (`pgque_reader`, `pgque_writer`, `pgque_admin`) are not dropped and must be removed manually if desired. `execute` is revoked from both `pgque_admin` and PUBLIC — superuser / schema owner only.
+Grant: superuser / schema owner only (both `pgque_admin` and PUBLIC `execute` are explicitly revoked). Source: `sql/pgque-additions/lifecycle.sql`.
 
 ## Observability
 
@@ -435,7 +445,7 @@ Three roles, with inheritance `pgque_admin > pgque_writer > pgque_reader`. Sourc
 | `pgque_writer` | everything `pgque_reader` has, plus `insert_event` (3, 7), `register_consumer`, `register_consumer_at`, `unregister_consumer`, `next_batch`, `next_batch_info`, `next_batch_custom`, `get_batch_events`, `finish_batch`, `event_retry` (int, timestamptz), all `send*`, `send_batch*`, `subscribe`, `unsubscribe`, `receive`, `ack`, `nack`, `dlq_replay`, `dlq_replay_all` |
 | `pgque_admin`  | everything `pgque_writer` has, plus `event_dead`, `dlq_purge`, `all` on `pgque` schema, `all` on all tables and sequences, `execute` on all functions — **except** `uninstall()` which is explicitly revoked                                                            |
 
-`pgque.uninstall()` is revoked from both `pgque_admin` (explicitly) and PUBLIC (via the schema-wide blanket revoke). Only the schema/install owner (typically a superuser) can run it.
+`pgque.uninstall()` is revoked from both `pgque_admin` (explicitly) and PUBLIC (via the schema-wide blanket revoke). Only the schema/install owner (typically a superuser) can run it. All other functions not listed in the table above retain `execute` only for `pgque_admin` (the schema-wide blanket revoke from PUBLIC applies, and `pgque_admin` is granted `execute on all functions`) — notably the lifecycle helpers `start`, `stop`, `status`, `maint`, `maint_retry_events`, `ticker`, `force_tick`, and the queue-management helpers `create_queue`, `drop_queue`, `set_queue_config`. Grant these explicitly to additional roles if your policy demands it.
 
 ## Experimental (not in default install)
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,6 +1,6 @@
 # Function reference
 
-Every function shipped in the v0.1 default install (`\i sql/pgque.sql`). Each entry lists the signature, return type, the role it is granted to, and the source file. A short code example appears where the signature alone leaves the call ambiguous.
+Every function shipped in the default install (`\i sql/pgque.sql`). Each entry lists the signature, return type, the role it is granted to, and the source file. A short code example appears where the signature alone leaves the call ambiguous.
 
 If you are new to PgQue, start with [tutorial.md](tutorial.md) — it walks the end-to-end `send` / `receive` / `ack` loop. Use this as the lookup table.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -171,7 +171,7 @@ Moves due rows from `pgque.retry_queue` back into queue event tables so they app
 
 ```sql
 select pgque.maint_retry_events(); -- every 30 seconds, for nack/retry redelivery
-select pgque.maint();              -- every 30 seconds, for rotation + vacuum
+select pgque.maint();              -- every 30 seconds, for rotation
 ```
 
 Grant: PUBLIC (default). Source: `sql/pgque.sql`.


### PR DESCRIPTION
## Summary

- Fixes reference drift: `start()` job count, `maint()` vs `maint_retry_events()`, `force_tick()` semantics, `nack()` lookup, `uninstall()` grants
- Fixes snippet bugs: invalid `ack(batch_id)` scope, Python `send()` type mismatch, `ack(NULL)` guard, benchmark label
- Documents that PgQue roles are global/coarse, not per-queue tenant isolation

## Changes

### `docs(reference): correct API drift (#99)` — `633b463`
- `docs/reference.md`, `README.md`
- `start()` now correctly lists 4 pg_cron jobs (adds `pgque_retry_events`)
- `maint()` description no longer claims retry handling; new `maint_retry_events()` entry added
- `force_tick()` clarified: bumps sequence so `ticker()` inserts the tick — does not tick directly
- `nack()` reflects canonical subscription lookup and note to `ack()` after nacking
- `uninstall()` grants corrected: revoked from both `pgque_admin` and PUBLIC
- Manual-scheduler docs in README: add `maint_retry_events()` to both bash and pg_cron-in-different-db notes

### `docs(examples): fix ack/event-type/version (#105)` — `958ef3d`
- `README.md`, `docs/examples.md`, `docs/reference.md`
- "Any language" snippet: `batch_id` not in scope — show temp table capture pattern
- Quick start: explain `\gset` capture; note temp table alternative
- Python snippet: `send()` needs `type="order.created"` keyword to match `@consumer.on()`
- Exactly-once example: guard `ack(NULL)` when `msgs` is empty; add batch-ownership caveat
- Benchmark note: ~2.4M/s is primitive `get_batch_events` throughput, not `receive()`/`ack()` end-to-end
- Drop stale "v0.1 default install" label from reference header

### `docs(roles): clarify global scope, no per-queue ACL (#112)` — `fc3c2dd`
- `docs/reference.md`, `README.md`
- New "Roles are global, not per-queue" subsection in reference
- Explains writer can ack any consumer's batch on any queue (intentional design)
- Documents recommended isolation patterns (separate DB, schema wrappers)
- Short blunt note in README roles section linking to reference

Closes #99
Closes #105
Closes #112