### PR TITLE
docs(README): mention benchmark/ directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,11 @@ read rate, zero dead-tuple growth under a 30-minute sustained test. See
 [docs/benchmarks.md](docs/benchmarks.md) for the full table and methodology.
 Server-class numbers to follow.
 
+Preliminary cross-system measurements live in [`benchmark/`](benchmark/).
+Numbers there are for reference and exploration, not a final verdict —
+benchmarking Postgres queues is hard (cf. Brendan Gregg) and the
+methodology continues to evolve.
+
 ## Architecture
 
 PgQue keeps PgQ's proven core architecture — snapshot-based batch isolation, three-table TRUNCATE rotation on the hot path, separate retry / delayed / dead-letter tables, and independent per-consumer cursors — and adds a modern API layer on top. See [blueprints/SPECx.md](blueprints/SPECx.md) for the full specification and [docs/pgq-concepts.md](docs/pgq-concepts.md) for the batch/tick/rotation glossary.


### PR DESCRIPTION
Closes #87.

## Summary

Adds a brief pointer to `benchmark/` in the existing `## Benchmarks` section. Numbers there are framed as reference and exploration, not a final verdict (cf. Brendan Gregg — benchmarking is hard).

## Why scope was reduced

Earlier iterations attempted a full hero rewrite with an inline benchmark table and methodology line. The maintainer pulled it back to a minimal mention given the methodology refinements still in flight (#123, #124, #127). The architectural framing of pgque's xmin-horizon immunity remains the responsibility of the existing README sections.

## Scope

- `README.md` only (~5 lines added inside the existing `## Benchmarks` section).
- No code changes.
- No bench numbers or methodology specifics inlined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)