### PR TITLE
fix(clients/python): make Consumer thread-safe and correct test xact pattern

### DIFF
--- a/clients/python/pgque/consumer.py
+++ b/clients/python/pgque/consumer.py
@@ -7,6 +7,7 @@
 import logging
 import signal
 import select
+import threading
 from typing import Callable, Optional
 
 import psycopg
@@ -92,16 +93,23 @@ class Consumer:
         """
         self._running = True
 
-        # Graceful shutdown on signals
-        original_sigterm = signal.getsignal(signal.SIGTERM)
-        original_sigint = signal.getsignal(signal.SIGINT)
+        # Graceful shutdown on signals; only main-thread invocations can
+        # install signal handlers. When the consumer is run from a worker
+        # thread (tests, embedded use), skip registration -- callers stop
+        # via Consumer.stop().
+        in_main_thread = threading.current_thread() is threading.main_thread()
+        original_sigterm = None
+        original_sigint = None
 
         def _stop(signum, frame):
             logger.info("received signal %s, shutting down", signum)
             self._running = False
 
-        signal.signal(signal.SIGTERM, _stop)
-        signal.signal(signal.SIGINT, _stop)
+        if in_main_thread:
+            original_sigterm = signal.getsignal(signal.SIGTERM)
+            original_sigint = signal.getsignal(signal.SIGINT)
+            signal.signal(signal.SIGTERM, _stop)
+            signal.signal(signal.SIGINT, _stop)
 
         try:
             with psycopg.connect(self.dsn, autocommit=True) as conn:
@@ -132,8 +140,9 @@ class Consumer:
                         pass
 
         finally:
-            signal.signal(signal.SIGTERM, original_sigterm)
-            signal.signal(signal.SIGINT, original_sigint)
+            if in_main_thread:
+                signal.signal(signal.SIGTERM, original_sigterm)
+                signal.signal(signal.SIGINT, original_sigint)
 
         logger.info("consumer %s stopped", self.name)
 

--- a/clients/python/tests/test_consumer.py
+++ b/clients/python/tests/test_consumer.py
@@ -26,6 +26,7 @@ def test_consumer_dispatches_by_event_type(dsn, conn, setup_queue):
     client = pgque.PgqueClient(conn)
     client.send(queue, {"i": 1}, type="evt.a")
     client.send(queue, {"i": 2}, type="evt.b")
+    conn.commit()
     conn.execute("select pgque.force_tick(%s)", (queue,))
     conn.execute("select pgque.ticker()")
     conn.commit()
@@ -55,6 +56,7 @@ def test_consumer_default_handler_catches_unknown(dsn, conn, setup_queue):
     queue, consumer_name = setup_queue
     client = pgque.PgqueClient(conn)
     client.send(queue, {"x": 99}, type="never.registered.type")
+    conn.commit()
     conn.execute("select pgque.force_tick(%s)", (queue,))
     conn.execute("select pgque.ticker()")
     conn.commit()
@@ -79,6 +81,7 @@ def test_consumer_nacks_on_handler_error(dsn, conn, setup_queue):
     queue, consumer_name = setup_queue
     client = pgque.PgqueClient(conn)
     client.send(queue, {"i": 1}, type="evt.fail")
+    conn.commit()
     conn.execute("select pgque.force_tick(%s)", (queue,))
     conn.execute("select pgque.ticker()")
     conn.commit()

--- a/clients/python/tests/test_nack.py
+++ b/clients/python/tests/test_nack.py
@@ -9,6 +9,7 @@ import pgque
 
 def _enqueue_and_receive(client, queue, consumer, payload):
     client.send(queue, payload)
+    client.conn.commit()
     client.conn.execute("select pgque.force_tick(%s)", (queue,))
     client.conn.execute("select pgque.ticker()")
     client.conn.commit()
@@ -48,16 +49,17 @@ def test_nack_routes_to_dlq_at_max_retries(conn, setup_queue):
     queue, consumer = setup_queue
     client = pgque.PgqueClient(conn)
 
-    # Set a tiny max_retries=1 so the second attempt routes to DLQ.
+    # Set max_retries=0 so the first nack routes straight to the DLQ.
+    # nack() reads ev_retry from the canonical event row, ignoring any
+    # client-supplied retry_count, so synthesising a retried message in
+    # Python alone has no effect on routing.
     conn.execute(
-        "update pgque.queue set queue_max_retries = 1 where queue_name = %s",
+        "update pgque.queue set queue_max_retries = 0 where queue_name = %s",
         (queue,),
     )
     conn.commit()
 
     msg = _enqueue_and_receive(client, queue, consumer, {"k": "doomed"})
-    # Synthesize "this is already a retry" by setting retry_count=1
-    msg.retry_count = 1
     client.nack(msg.batch_id, msg, retry_after=0, reason="poison pill")
     client.ack(msg.batch_id)
     conn.commit()

--- a/clients/python/tests/test_receive.py
+++ b/clients/python/tests/test_receive.py
@@ -19,6 +19,7 @@ def test_receive_returns_messages_after_tick(conn, setup_queue):
     queue, consumer = setup_queue
     client = pgque.PgqueClient(conn)
     client.send(queue, {"key": "value"})
+    conn.commit()
     conn.execute("select pgque.force_tick(%s)", (queue,))
     conn.execute("select pgque.ticker()")
     conn.commit()
@@ -38,6 +39,7 @@ def test_ack_advances_position(conn, setup_queue):
     queue, consumer = setup_queue
     client = pgque.PgqueClient(conn)
     client.send(queue, {"k": 1})
+    conn.commit()
     conn.execute("select pgque.force_tick(%s)", (queue,))
     conn.execute("select pgque.ticker()")
     conn.commit()
@@ -55,6 +57,7 @@ def test_receive_returns_at_most_max_messages(conn, setup_queue):
     client = pgque.PgqueClient(conn)
     for i in range(5):
         client.send(queue, {"i": i})
+    conn.commit()
     conn.execute("select pgque.force_tick(%s)", (queue,))
     conn.execute("select pgque.ticker()")
     conn.commit()
@@ -69,6 +72,7 @@ def test_receive_preserves_event_type(conn, setup_queue):
     client = pgque.PgqueClient(conn)
     client.send(queue, {"a": 1}, type="evt.alpha")
     client.send(queue, {"b": 2}, type="evt.beta")
+    conn.commit()
     conn.execute("select pgque.force_tick(%s)", (queue,))
     conn.execute("select pgque.ticker()")
     conn.commit()
@@ -87,6 +91,7 @@ def test_message_timestamp_round_trip(conn, setup_queue):
     client = pgque.PgqueClient(conn)
     before = dt.datetime.now(dt.timezone.utc)
     client.send(queue, {"x": 1})
+    conn.commit()
     conn.execute("select pgque.force_tick(%s)", (queue,))
     conn.execute("select pgque.ticker()")
     conn.commit()

--- a/clients/python/tests/test_send.py
+++ b/clients/python/tests/test_send.py
@@ -50,6 +50,7 @@ def test_send_unicode_payload(conn, setup_queue):
     client = pgque.PgqueClient(conn)
     payload = {"text": "héllo wörld 🎉 — ünicode тест"}
     client.send(queue, payload)
+    conn.commit()
     conn.execute("select pgque.force_tick(%s)", (queue,))
     conn.execute("select pgque.ticker()")
     conn.commit()
@@ -67,6 +68,7 @@ def test_send_large_payload(conn, setup_queue):
     client = pgque.PgqueClient(conn)
     big = {"data": "x" * 100_000}
     client.send(queue, big)
+    conn.commit()
     conn.execute("select pgque.force_tick(%s)", (queue,))
     conn.execute("select pgque.ticker()")
     conn.commit()
@@ -144,6 +146,7 @@ def test_jsonb_payload_round_trip(conn, setup_queue, payload, expected):
     queue, consumer = setup_queue
     client = pgque.PgqueClient(conn)
     client.send(queue, payload)
+    conn.commit()
     conn.execute("select pgque.force_tick(%s)", (queue,))
     conn.execute("select pgque.ticker()")
     conn.commit()

--- a/clients/python/tests/test_smoke.py
+++ b/clients/python/tests/test_smoke.py
@@ -7,6 +7,7 @@ import pgque
 
 def test_smoke_send_receive_ack(dsn, queue_name, consumer_name):
     with pgque.connect(dsn) as client:
+        client.conn.execute("select pgque.create_queue(%s)", (queue_name,))
         client.conn.execute("select pgque.subscribe(%s, %s)",
                              (queue_name, consumer_name))
         client.conn.commit()


### PR DESCRIPTION
## Why

PR #84 turns on real per-client driver tests against live Postgres. The Python suite exposes a real driver bug plus a handful of test patterns that always failed against a live ticker:

- `Consumer.start()` registered SIGTERM/SIGINT signal handlers unconditionally. `signal.signal()` raises `ValueError` when called from a non-main thread, so any caller that runs the consumer from a worker thread (the standard pattern for tests, embedded use, and most multi-consumer apps) crashed before doing any work.
- The send/receive tests interleaved `pgque.send()` and `pgque.ticker()` inside one transaction, then committed. The ticker's snapshot excludes the producing xact's own writes, so the resulting tick references no events and `receive()` returns `[]`. Worked in isolation only because `force_tick()` advances the sequence — it does not actually rotate.
- `test_smoke` called `pgque.subscribe()` without first creating the queue.
- `test_nack_routes_to_dlq_at_max_retries` synthesised a retried message by setting `Message.retry_count = 1` in Python. Per #98, `pgque.nack()` reads `ev_retry` from the canonical batch row and ignores caller-supplied values, so the assertion never fired.

## What changes

- `clients/python/pgque/consumer.py`: detect non-main-thread invocation and skip signal registration; callers stop via `Consumer.stop()` in that case.
- `clients/python/tests/test_send.py`, `test_receive.py`, `test_nack.py`, `test_consumer.py`: commit between `client.send()` and `pgque.force_tick()` so the ticker sees the new events.
- `clients/python/tests/test_smoke.py`: add the missing `pgque.create_queue()` before `subscribe()`.
- `clients/python/tests/test_nack.py`: set `queue_max_retries = 0` so the first nack routes to DLQ, instead of relying on a client-side `retry_count` mutation that the SQL ignores.

## Coordination

Depends on #84 for live-PG CI to actually exercise these tests. Once merged, the Python job on PR #84 should go green on rebase.

## Test plan

- [x] `PGQUE_TEST_DSN=... pytest -v clients/python/tests/` -> 39 passed locally on PG 16
- [x] CI run on this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01BRMoDzqHTTTq3T8dg8U4vx)_