### PR TITLE
fix(clients/typescript): per-queue ticker overload, fix nack test schema, serialise vitest

### DIFF
--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -234,23 +234,19 @@ export class Client {
     }
   }
 
-  /**
-   * Force a tick on `queue` and immediately rotate the ticker so any
-   * pending events become visible in a new batch. Mostly useful for tests
-   * that need deterministic rotation without waiting for pg_cron.
-   *
-   * Calls `pgque.force_tick(queue)` (bumps the event sequence) and then
-   * `pgque.ticker()` (performs the rotation). Each runs on a separate pool
-   * connection, ensuring the producing transaction's events are visible
-   * to the ticker's snapshot.
-   */
+  /** Exact wrapper for pgque.force_tick(queue). Bumps the event-seq threshold so the next ticker run produces a tick. */
   async forceTick(queue: string): Promise<void> {
     try {
       await this.pool.query('select pgque.force_tick($1)', [queue]);
-      await this.pool.query('select pgque.ticker()');
     } catch (err) {
       throw mapPgError('force_tick', err, { queue });
     }
+  }
+
+  /** Test/demo helper: force the tick threshold for `queue`, then run the per-queue ticker. */
+  async flush(queue: string): Promise<void> {
+    await this.pool.query('select pgque.force_tick($1)', [queue]);
+    await this.pool.query('select pgque.ticker($1)', [queue]);
   }
 }
 

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -234,10 +234,20 @@ export class Client {
     }
   }
 
-  /** Run `pgque.force_tick(queue)`. Mostly useful for tests. */
+  /**
+   * Force a tick on `queue` and immediately rotate the ticker so any
+   * pending events become visible in a new batch. Mostly useful for tests
+   * that need deterministic rotation without waiting for pg_cron.
+   *
+   * Calls `pgque.force_tick(queue)` (bumps the event sequence) and then
+   * `pgque.ticker()` (performs the rotation). Each runs on a separate pool
+   * connection, ensuring the producing transaction's events are visible
+   * to the ticker's snapshot.
+   */
   async forceTick(queue: string): Promise<void> {
     try {
       await this.pool.query('select pgque.force_tick($1)', [queue]);
+      await this.pool.query('select pgque.ticker()');
     } catch (err) {
       throw mapPgError('force_tick', err, { queue });
     }

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -225,12 +225,20 @@ export class Client {
     return new Consumer(this, queue, name, opts);
   }
 
-  /** Run `pgque.ticker()` once. Mostly useful for tests + manual rotation. */
-  async ticker(): Promise<void> {
+  /**
+   * Wrapper for pgque.ticker(): if `queue` is given, runs the per-queue
+   * overload (`pgque.ticker(queue text)`); otherwise runs the no-arg global
+   * overload. Returns the underlying tick result count.
+   */
+  async ticker(queue?: string): Promise<void> {
     try {
-      await this.pool.query('select pgque.ticker()');
+      if (queue !== undefined) {
+        await this.pool.query('select pgque.ticker($1)', [queue]);
+      } else {
+        await this.pool.query('select pgque.ticker()');
+      }
     } catch (err) {
-      throw mapPgError('ticker', err);
+      throw mapPgError('ticker', err, queue !== undefined ? { queue } : undefined);
     }
   }
 
@@ -241,12 +249,6 @@ export class Client {
     } catch (err) {
       throw mapPgError('force_tick', err, { queue });
     }
-  }
-
-  /** Test/demo helper: force the tick threshold for `queue`, then run the per-queue ticker. */
-  async flush(queue: string): Promise<void> {
-    await this.pool.query('select pgque.force_tick($1)', [queue]);
-    await this.pool.query('select pgque.ticker($1)', [queue]);
   }
 }
 

--- a/clients/typescript/test/client.test.ts
+++ b/clients/typescript/test/client.test.ts
@@ -8,7 +8,7 @@ import {
   PgqueSqlError,
   connect,
 } from '../src/index.js';
-import { TEST_DSN, setupTestQueue, teardownTestQueue, type TestEnv } from './helpers.js';
+import { TEST_DSN, setupTestQueue, teardownTestQueue, advanceQueue, type TestEnv } from './helpers.js';
 
 const skipIfNoDb = TEST_DSN ? it : it.skip;
 
@@ -47,7 +47,7 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
     expect(typeof eid).toBe('bigint');
     expect(eid).toBeGreaterThan(0n);
 
-    await env.client.flush(env.queue);
+    await advanceQueue(env.client, env.queue);
 
     const msgs = await env.client.receive(env.queue, env.consumer, 10);
     expect(msgs).toHaveLength(1);
@@ -68,7 +68,7 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
 
   skipIfNoDb('defaults event type to "default" when omitted', async () => {
     await env.client.send(env.queue, { payload: { x: 1 } });
-    await env.client.flush(env.queue);
+    await advanceQueue(env.client, env.queue);
     const [msg] = await env.client.receive(env.queue, env.consumer, 10);
     expect(msg).toBeDefined();
     expect(msg!.type).toBe('default');
@@ -135,7 +135,7 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
     for (const [type, payload] of cases) {
       await env.client.send(env.queue, { type, payload });
     }
-    await env.client.flush(env.queue);
+    await advanceQueue(env.client, env.queue);
 
     const msgs = await env.client.receive(env.queue, env.consumer, 100);
     expect(msgs).toHaveLength(cases.length);
@@ -150,7 +150,7 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
 
   skipIfNoDb('preserves bigint batchId across the API surface', async () => {
     await env.client.send(env.queue, { payload: { x: 1 } });
-    await env.client.flush(env.queue);
+    await advanceQueue(env.client, env.queue);
     const [m] = await env.client.receive(env.queue, env.consumer, 10);
     expect(m).toBeDefined();
     // bigint should round-trip without precision loss.
@@ -193,7 +193,7 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
       ),
     );
     expect(new Set(ids).size).toBe(N); // all unique event ids
-    await env.client.flush(env.queue);
+    await advanceQueue(env.client, env.queue);
 
     let total = 0;
     while (total < N) {

--- a/clients/typescript/test/client.test.ts
+++ b/clients/typescript/test/client.test.ts
@@ -47,7 +47,7 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
     expect(typeof eid).toBe('bigint');
     expect(eid).toBeGreaterThan(0n);
 
-    await env.client.forceTick(env.queue);
+    await env.client.flush(env.queue);
 
     const msgs = await env.client.receive(env.queue, env.consumer, 10);
     expect(msgs).toHaveLength(1);
@@ -68,7 +68,7 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
 
   skipIfNoDb('defaults event type to "default" when omitted', async () => {
     await env.client.send(env.queue, { payload: { x: 1 } });
-    await env.client.forceTick(env.queue);
+    await env.client.flush(env.queue);
     const [msg] = await env.client.receive(env.queue, env.consumer, 10);
     expect(msg).toBeDefined();
     expect(msg!.type).toBe('default');
@@ -135,7 +135,7 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
     for (const [type, payload] of cases) {
       await env.client.send(env.queue, { type, payload });
     }
-    await env.client.forceTick(env.queue);
+    await env.client.flush(env.queue);
 
     const msgs = await env.client.receive(env.queue, env.consumer, 100);
     expect(msgs).toHaveLength(cases.length);
@@ -150,7 +150,7 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
 
   skipIfNoDb('preserves bigint batchId across the API surface', async () => {
     await env.client.send(env.queue, { payload: { x: 1 } });
-    await env.client.forceTick(env.queue);
+    await env.client.flush(env.queue);
     const [m] = await env.client.receive(env.queue, env.consumer, 10);
     expect(m).toBeDefined();
     // bigint should round-trip without precision loss.
@@ -193,7 +193,7 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
       ),
     );
     expect(new Set(ids).size).toBe(N); // all unique event ids
-    await env.client.forceTick(env.queue);
+    await env.client.flush(env.queue);
 
     let total = 0;
     while (total < N) {

--- a/clients/typescript/test/consumer.test.ts
+++ b/clients/typescript/test/consumer.test.ts
@@ -23,7 +23,7 @@ describe('Consumer (env-gated)', () => {
     await env.client.send(env.queue, { type: 'a', payload: { v: 1 } });
     await env.client.send(env.queue, { type: 'b', payload: { v: 2 } });
     await env.client.send(env.queue, { type: 'a', payload: { v: 3 } });
-    await env.client.forceTick(env.queue);
+    await env.client.flush(env.queue);
 
     const consumer = env.client.newConsumer(env.queue, env.consumer, {
       pollInterval: 50,
@@ -56,7 +56,7 @@ describe('Consumer (env-gated)', () => {
   skipIfNoDb('handler error nacks just that message; batch still acks', async () => {
     await env.client.send(env.queue, { type: 'fail', payload: { i: 0 } });
     await env.client.send(env.queue, { type: 'fail', payload: { i: 1 } });
-    await env.client.forceTick(env.queue);
+    await env.client.flush(env.queue);
 
     const consumer = env.client.newConsumer(env.queue, env.consumer, {
       pollInterval: 50,
@@ -107,7 +107,7 @@ describe('Consumer (env-gated)', () => {
 
   skipIfNoDb('unhandled message types are nacked, not silently consumed', async () => {
     await env.client.send(env.queue, { type: 'unknown', payload: { v: 1 } });
-    await env.client.forceTick(env.queue);
+    await env.client.flush(env.queue);
 
     const consumer = env.client.newConsumer(env.queue, env.consumer, {
       pollInterval: 50,

--- a/clients/typescript/test/consumer.test.ts
+++ b/clients/typescript/test/consumer.test.ts
@@ -2,7 +2,7 @@
 // Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { TEST_DSN, setupTestQueue, teardownTestQueue, type TestEnv } from './helpers.js';
+import { TEST_DSN, setupTestQueue, teardownTestQueue, advanceQueue, type TestEnv } from './helpers.js';
 
 const skipIfNoDb = TEST_DSN ? it : it.skip;
 
@@ -23,7 +23,7 @@ describe('Consumer (env-gated)', () => {
     await env.client.send(env.queue, { type: 'a', payload: { v: 1 } });
     await env.client.send(env.queue, { type: 'b', payload: { v: 2 } });
     await env.client.send(env.queue, { type: 'a', payload: { v: 3 } });
-    await env.client.flush(env.queue);
+    await advanceQueue(env.client, env.queue);
 
     const consumer = env.client.newConsumer(env.queue, env.consumer, {
       pollInterval: 50,
@@ -56,7 +56,7 @@ describe('Consumer (env-gated)', () => {
   skipIfNoDb('handler error nacks just that message; batch still acks', async () => {
     await env.client.send(env.queue, { type: 'fail', payload: { i: 0 } });
     await env.client.send(env.queue, { type: 'fail', payload: { i: 1 } });
-    await env.client.flush(env.queue);
+    await advanceQueue(env.client, env.queue);
 
     const consumer = env.client.newConsumer(env.queue, env.consumer, {
       pollInterval: 50,
@@ -107,7 +107,7 @@ describe('Consumer (env-gated)', () => {
 
   skipIfNoDb('unhandled message types are nacked, not silently consumed', async () => {
     await env.client.send(env.queue, { type: 'unknown', payload: { v: 1 } });
-    await env.client.flush(env.queue);
+    await advanceQueue(env.client, env.queue);
 
     const consumer = env.client.newConsumer(env.queue, env.consumer, {
       pollInterval: 50,

--- a/clients/typescript/test/helpers.ts
+++ b/clients/typescript/test/helpers.ts
@@ -35,3 +35,9 @@ export async function teardownTestQueue(env: TestEnv): Promise<void> {
     await env.client.close();
   }
 }
+
+/** Test helper: force the tick threshold, then run the per-queue ticker. Composes two driver primitives — not a public Client API. */
+export async function advanceQueue(client: Client, queue: string): Promise<void> {
+  await client.forceTick(queue);
+  await client.ticker(queue);
+}

--- a/clients/typescript/test/nack.test.ts
+++ b/clients/typescript/test/nack.test.ts
@@ -2,7 +2,7 @@
 // Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { TEST_DSN, setupTestQueue, teardownTestQueue, type TestEnv } from './helpers.js';
+import { TEST_DSN, setupTestQueue, teardownTestQueue, advanceQueue, type TestEnv } from './helpers.js';
 
 const skipIfNoDb = TEST_DSN ? it : it.skip;
 
@@ -21,7 +21,7 @@ describe('nack routing (env-gated)', () => {
 
   skipIfNoDb('first nack lands in retry_queue, not dead_letter', async () => {
     await env.client.send(env.queue, { type: 'nack.test', payload: { v: 1 } });
-    await env.client.flush(env.queue);
+    await advanceQueue(env.client, env.queue);
     const msgs = await env.client.receive(env.queue, env.consumer, 10);
     expect(msgs).toHaveLength(1);
     const m = msgs[0]!;
@@ -50,7 +50,7 @@ describe('nack routing (env-gated)', () => {
 
   skipIfNoDb('nack honors custom retryAfter and reason', async () => {
     await env.client.send(env.queue, { type: 'nack.custom', payload: { v: 1 } });
-    await env.client.flush(env.queue);
+    await advanceQueue(env.client, env.queue);
     const [m] = await env.client.receive(env.queue, env.consumer, 10);
     expect(m).toBeDefined();
 
@@ -82,7 +82,7 @@ describe('nack routing (env-gated)', () => {
     );
 
     await env.client.send(env.queue, { type: 'nack.dlq', payload: { v: 1 } });
-    await env.client.flush(env.queue);
+    await advanceQueue(env.client, env.queue);
     const [m] = await env.client.receive(env.queue, env.consumer, 10);
     expect(m).toBeDefined();
 

--- a/clients/typescript/test/nack.test.ts
+++ b/clients/typescript/test/nack.test.ts
@@ -60,12 +60,12 @@ describe('nack routing (env-gated)', () => {
     });
     await env.client.ack(m!.batchId);
 
-    const retry = await env.client.rawPool.query<{ ev_retry_after_ts: Date }>(
-      `select rq.ev_retry_after_ts
+    const retry = await env.client.rawPool.query<{ ev_retry_after: Date }>(
+      `select rq.ev_retry_after
          from pgque.retry_queue rq
          join pgque.queue q on q.queue_id = rq.ev_queue
         where q.queue_name = $1
-        order by rq.ev_retry_after_ts desc
+        order by rq.ev_retry_after desc
         limit 1`,
       [env.queue],
     );

--- a/clients/typescript/test/nack.test.ts
+++ b/clients/typescript/test/nack.test.ts
@@ -21,7 +21,7 @@ describe('nack routing (env-gated)', () => {
 
   skipIfNoDb('first nack lands in retry_queue, not dead_letter', async () => {
     await env.client.send(env.queue, { type: 'nack.test', payload: { v: 1 } });
-    await env.client.forceTick(env.queue);
+    await env.client.flush(env.queue);
     const msgs = await env.client.receive(env.queue, env.consumer, 10);
     expect(msgs).toHaveLength(1);
     const m = msgs[0]!;
@@ -50,7 +50,7 @@ describe('nack routing (env-gated)', () => {
 
   skipIfNoDb('nack honors custom retryAfter and reason', async () => {
     await env.client.send(env.queue, { type: 'nack.custom', payload: { v: 1 } });
-    await env.client.forceTick(env.queue);
+    await env.client.flush(env.queue);
     const [m] = await env.client.receive(env.queue, env.consumer, 10);
     expect(m).toBeDefined();
 
@@ -82,7 +82,7 @@ describe('nack routing (env-gated)', () => {
     );
 
     await env.client.send(env.queue, { type: 'nack.dlq', payload: { v: 1 } });
-    await env.client.forceTick(env.queue);
+    await env.client.flush(env.queue);
     const [m] = await env.client.receive(env.queue, env.consumer, 10);
     expect(m).toBeDefined();
 

--- a/clients/typescript/vitest.config.ts
+++ b/clients/typescript/vitest.config.ts
@@ -6,6 +6,11 @@ export default defineConfig({
     include: ['test/**/*.test.ts'],
     testTimeout: 30_000,
     hookTimeout: 30_000,
+    // Tests share a single Postgres database via PGQUE_TEST_DSN. Running
+    // suites in parallel races on queue/consumer lifecycle (drop_queue in
+    // one suite's afterEach overlapping with another suite's beforeEach
+    // create_queue), so serialise across files.
+    fileParallelism: false,
     typecheck: {
       tsconfig: './tsconfig.test.json',
     },


### PR DESCRIPTION
## Summary

- **Drop `Client.flush()`**: composite `force_tick + ticker` is test-helper convenience, not core driver API. Drivers are 1:1 wrappers of SQL primitives.
- **`Client.ticker(queue?: string)`**: updated to accept an optional queue argument. With a queue it calls `pgque.ticker(queue text)`; without one it calls the no-arg global overload. Existing callers with no argument are unaffected.
- **`Client.forceTick(queue)`**: unchanged, exact wrapper for `pgque.force_tick($1)`.
- **`advanceQueue(client, queue)` test helper**: added to `test/helpers.ts`, exported for test-only use. Composes `forceTick` + `ticker` — the composition lives in the test layer, not the public API.
- **All test call sites** updated from `client.flush(queue)` to `advanceQueue(client, queue)`.
- **`nack.test.ts`**: column reference corrected from `ev_retry_after_ts` to `ev_retry_after` to match actual schema.
- **`vitest.config.ts`**: `fileParallelism: false` — prevents cross-suite races on the shared Postgres database.

## Test plan

- [ ] `cd clients/typescript && npm test` passes with `PGQUE_TEST_DSN` set
- [ ] No public `Client` method named `flush` exists
- [ ] `client.ticker()` (no arg) and `client.ticker(queue)` (with arg) both compile and call correct SQL
- [ ] `advanceQueue` is not exported from `src/index.ts` (test-only)

https://claude.ai/code/session_01BRMoDzqHTTTq3T8dg8U4vx