### PR TITLE
test(clients/python): commit before force_tick in 2 tests

### DIFF
--- a/clients/python/tests/test_consumer.py
+++ b/clients/python/tests/test_consumer.py
@@ -123,6 +123,7 @@ def test_consumer_warns_and_acks_unhandled_event_type(dsn, conn, setup_queue, ca
     queue, consumer_name = setup_queue
     client = pgque.PgqueClient(conn)
     msg_id = client.send(queue, {"x": 1}, type="totally.unregistered.type")
+    conn.commit()
     conn.execute("select pgque.force_tick(%s)", (queue,))
     conn.execute("select pgque.ticker()")
     conn.commit()

--- a/clients/python/tests/test_send.py
+++ b/clients/python/tests/test_send.py
@@ -171,6 +171,7 @@ def test_send_batch_none_payload_produces_json_null(conn, setup_queue):
     queue, consumer = setup_queue
     client = pgque.PgqueClient(conn)
     client.send_batch(queue, "default", [None])
+    conn.commit()
     conn.execute("select pgque.force_tick(%s)", (queue,))
     conn.execute("select pgque.ticker()")
     conn.commit()


### PR DESCRIPTION
## Summary

Two Python tests regressed on the live-pg test job because they call `pgque.force_tick` + `pgque.ticker` in the same transaction as the preceding `client.send` / `client.send_batch`, without committing in between. `pgque.ticker()` captures a snapshot of currently-committed xacts, so an event inserted in the same still-open xact is not visible to the tick. The subsequent `pgque.receive` therefore returns an empty batch, and the dependent assertions fail.

The other tests in the same files already commit between send and tick; this brings the two regressed tests in line with that pattern.

Failing tests fixed:
- `tests/test_consumer.py::test_consumer_warns_and_acks_unhandled_event_type`
- `tests/test_send.py::test_send_batch_none_payload_produces_json_null`

No driver code is changed; both failures were test-only bugs about pgque snapshot semantics.

## Test plan

- [x] `pytest -v clients/python/tests/` against a live PG with `pgque.sql` from `main` -> 41/41 pass
- [ ] CI `Python client tests` job goes green

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRMoDzqHTTTq3T8dg8U4vx)_