### PR TITLE
fix(clients): v0.2.0 data-safety + consumer alignment

### DIFF
--- a/clients/README.md
+++ b/clients/README.md
@@ -1,0 +1,64 @@
+# PgQue clients
+
+Driver libraries for [PgQue](https://github.com/NikolayS/pgque) — the
+PgQ-based universal PostgreSQL queue. Each client is a thin 1:1 wrapper
+over the `pgque-api` SQL surface (`send`, `receive`, `ack`, `nack`,
+`subscribe`, `unsubscribe`, plus `ticker` / `force_tick` for tests) with
+an idiomatic high-level `Consumer` poll loop layered on top.
+
+| Driver | Path | Status |
+|---|---|---|
+| Python | [`python/`](./python/) | v0.2.0 |
+| Go | [`go/`](./go/) | v0.2.0 |
+| TypeScript | [`typescript/`](./typescript/) | v0.2.0 |
+
+## Cross-driver capability matrix (v0.2.0)
+
+This table captures the runtime contract every driver must honour. The
+SQL surface is shared; the differences below are language-idiom shaping
+(e.g. variadic options vs. keyword args), never differences in semantics
+against the underlying `pgque.*` functions.
+
+| Capability | Python | Go | TypeScript |
+|---|---|---|---|
+| `send(queue, payload, type=...)` -> `id` | yes | yes (`Send`) | yes |
+| `send_batch(queue, type, payloads)` -> `[]id` | yes | yes (`SendBatch`) | deferred (#141) |
+| `receive(queue, consumer, max)` | yes | yes | yes |
+| `ack(batch_id)` | yes | yes | yes |
+| `nack(batch_id, msg, retry_after, reason)` | yes (kwargs) | yes (variadic options) | yes (opts object) |
+| `subscribe(queue, consumer)` | yes | deferred (#138) | yes |
+| `unsubscribe(queue, consumer)` | yes | deferred (#138) | yes |
+| `ticker()` / `ticker(queue)` | via raw SQL | deferred (#138) | yes (overload) |
+| `force_tick(queue)` | via raw SQL | deferred (#138) | yes |
+| Consumer: dispatch by type | yes | yes | yes |
+| Consumer: nack on handler error | yes | yes | yes |
+| Consumer: nack-default for unknown types | **yes** | **yes** | **yes** |
+| Consumer: opt-in ack-on-unknown | `unknown_handler="ack"` | `WithUnknownHandlerPolicy(AckUnknown)` | `unknownHandlerPolicy: 'ack'` |
+| Consumer: skip batch ack if any nack fails | yes (tx rollback) | yes (`nackFailed` flag) | yes (`nackFailed` flag) |
+| Consumer: default `max_messages` | `500` | `500` | `500` |
+| Top-level `undefined`/`None` payload -> JSON null | yes | yes | yes |
+
+The data-safety contract is fixed: by default no driver may silently
+drop a message because of a missing handler or a Nack failure. The
+`ack`-policy opt-in (and, in Python, registering a `*` catch-all) is the
+only way to discard unhandled types on purpose.
+
+## Deferred to v0.2.1+
+
+The following items are tracked for a follow-up release:
+
+- #138 (Go): `Subscribe`, `Unsubscribe`, `Ticker`, `ForceTick` wrappers
+- #140: typed errors for `consumer not found` / DLQ paths in all drivers
+- #141 (TS): `send_text` / `send_json` convenience wrappers
+- #143: NULL `type` / NULL `payload` round-trips
+- #145 (TS): scoped `bigint` parser instead of process-global mutation
+- #147 (TS): native `LISTEN` wakeup for the consumer
+- #148: `ack` no-op vs. real-finish result code surfaced by drivers
+- #150: transactional consumer (single-tx `receive`+handler+ack pattern)
+- #151 (TS): expose `pgque.ticker()` return value (events ticked count)
+
+See the GitHub issues for design notes.
+
+## License
+
+Apache-2.0. Copyright 2026 Nikolay Samokhvalov.

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -48,7 +48,11 @@ func main() {
     }
 
     // Consumer side
-    consumer := client.NewConsumer("orders", "order_worker")
+    consumer := client.NewConsumer("orders", "order_worker",
+        // pgque.WithPollInterval(30 * time.Second),
+        // pgque.WithMaxMessages(500),                      // default
+        // pgque.WithUnknownHandlerPolicy(pgque.NackUnknown), // default
+    )
     consumer.Handle("order.created", func(ctx context.Context, msg pgque.Message) error {
         log.Printf("got %s: %s", msg.Type, msg.Payload)
         return nil
@@ -58,6 +62,40 @@ func main() {
     }
 }
 ```
+
+### Consumer configuration
+
+| Option | Default | Notes |
+|---|---|---|
+| `WithPollInterval(d)` | `30s` | Time between polls when LISTEN/NOTIFY is silent. |
+| `WithMaxMessages(n)` | `500` | Max messages requested per `pgque.receive`. **Keep `>= queue_ticker_max_count`** (default 500) so a single Receive drains the batch. |
+| `WithUnknownHandlerPolicy(p)` | `NackUnknown` | `NackUnknown` (data-safe default) routes unhandled types to retry/DLQ. `AckUnknown` logs + acks instead. |
+
+### Per-message Nack options
+
+`Client.Nack` accepts variadic options:
+
+```go
+client.Nack(ctx, batchID, msg,
+    pgque.WithRetryAfter(5 * time.Minute),
+    pgque.WithReason("payment.declined"),
+)
+```
+
+Defaults: `retry_after = 60s`, `reason = NULL`.
+
+### Batch send
+
+```go
+ids, err := client.SendBatch(ctx, "orders", "order.created",
+    []any{
+        map[string]any{"id": 1},
+        map[string]any{"id": 2},
+        map[string]any{"id": 3},
+    })
+```
+
+Wraps `pgque.send_batch(text, text, jsonb[])` 1:1.
 
 ## Tests
 

--- a/clients/go/consumer.go
+++ b/clients/go/consumer.go
@@ -11,23 +11,30 @@ import (
 )
 
 // HandlerFunc processes a single message. Returning a non-nil error
-// causes the entire batch to be NOT acked, so PgQue redelivers it on
-// the next Receive.
+// causes that message to be Nacked individually (routed to retry/DLQ
+// per the queue's retry policy) while sibling messages in the same
+// batch continue to be processed. The batch is then Acked, but only
+// if every required Nack succeeded; if any Nack failed the batch is
+// left unfinished so PgQ redelivers it.
 type HandlerFunc func(ctx context.Context, msg Message) error
 
 // Consumer polls a queue and dispatches messages to registered
 // handlers. Create one via Client.NewConsumer.
 type Consumer struct {
-	client       *Client
-	queue        string
-	name         string
-	pollInterval time.Duration
-	handlers     map[string]HandlerFunc
+	client        *Client
+	queue         string
+	name          string
+	pollInterval  time.Duration
+	maxMessages   int
+	handlers      map[string]HandlerFunc
+	unknownPolicy UnknownHandlerPolicy
 }
 
 // Handle registers fn as the handler for messages whose Type matches
-// eventType. Messages with no registered handler are silently skipped
-// for now; a future release will surface them via a default handler.
+// eventType. Messages whose Type has no registered handler are
+// dispatched to the configured UnknownHandlerPolicy: by default they
+// are Nacked (routed to retry/DLQ); pass WithUnknownHandlerPolicy to
+// override.
 func (c *Consumer) Handle(eventType string, fn HandlerFunc) {
 	c.handlers[eventType] = fn
 }
@@ -45,8 +52,14 @@ func (c *Consumer) dispatchWithRecover(ctx context.Context, fn HandlerFunc, msg 
 
 // Start begins the poll loop and blocks until ctx is cancelled. On
 // receive errors it logs and retries after the configured poll
-// interval. A batch is acked only if every handled message in it
-// returned nil.
+// interval. For each batch:
+//   - every message is dispatched to its handler (or routed by the
+//     UnknownHandlerPolicy if no handler is registered);
+//   - per-message failures (handler error, panic, unknown type under
+//     NackUnknown) trigger an individual Nack;
+//   - the batch is Acked only if every Nack call that was required
+//     succeeded. If any Nack failed, the batch is left unfinished so
+//     PgQ redelivers it via the existing batch lifecycle.
 func (c *Consumer) Start(ctx context.Context) error {
 	for {
 		select {
@@ -55,7 +68,7 @@ func (c *Consumer) Start(ctx context.Context) error {
 		default:
 		}
 
-		msgs, err := c.client.Receive(ctx, c.queue, c.name, 100)
+		msgs, err := c.client.Receive(ctx, c.queue, c.name, c.maxMessages)
 		if err != nil {
 			log.Printf("pgque: receive error: %v", err)
 			select {
@@ -76,13 +89,19 @@ func (c *Consumer) Start(ctx context.Context) error {
 		}
 
 		var batchID int64
+		nackFailed := false
 		for _, msg := range msgs {
 			batchID = msg.BatchID
 			handler, ok := c.handlers[msg.Type]
 			if !ok {
-				log.Printf("pgque: no handler registered for event type %q, nacking message %d", msg.Type, msg.MsgID)
-				if nackErr := c.client.Nack(ctx, batchID, msg); nackErr != nil {
+				if c.unknownPolicy == AckUnknown {
+					log.Printf("pgque: no handler registered for event type %q, acking msg %d (AckUnknown policy)", msg.Type, msg.MsgID)
+					continue
+				}
+				log.Printf("pgque: no handler registered for event type %q, nacking msg %d", msg.Type, msg.MsgID)
+				if nackErr := c.client.Nack(ctx, batchID, msg, WithReason(fmt.Sprintf("no handler for type=%s", msg.Type))); nackErr != nil {
 					log.Printf("pgque: nack error for unhandled type %s: %v", msg.Type, nackErr)
+					nackFailed = true
 				}
 				continue
 			}
@@ -90,12 +109,17 @@ func (c *Consumer) Start(ctx context.Context) error {
 				log.Printf("pgque: handler error for %s: %v", msg.Type, handlerErr)
 				if nackErr := c.client.Nack(ctx, batchID, msg); nackErr != nil {
 					log.Printf("pgque: nack error for %s: %v", msg.Type, nackErr)
+					nackFailed = true
 				}
 				continue
 			}
 		}
 
 		if batchID != 0 {
+			if nackFailed {
+				log.Printf("pgque: skipping batch %d ack: one or more nacks failed; PgQ will redeliver", batchID)
+				continue
+			}
 			if err := c.client.Ack(ctx, batchID); err != nil {
 				log.Printf("pgque: ack error: %v", err)
 			}

--- a/clients/go/options.go
+++ b/clients/go/options.go
@@ -14,3 +14,36 @@ type Option func(*Consumer)
 func WithPollInterval(d time.Duration) Option {
 	return func(c *Consumer) { c.pollInterval = d }
 }
+
+// WithMaxMessages sets the upper bound on messages requested per
+// pgque.receive call. Default is 500, which matches the default
+// pgque.queue.queue_ticker_max_count so a single Receive can drain a
+// full batch. Setting maxMessages below the queue's ticker_max_count
+// risks leaving rows from a batch unreturned for the rest of that
+// batch's lifetime, so callers should keep maxMessages >=
+// ticker_max_count.
+func WithMaxMessages(n int) Option {
+	return func(c *Consumer) { c.maxMessages = n }
+}
+
+// UnknownHandlerPolicy controls what the Consumer does when a message
+// arrives with no registered handler.
+type UnknownHandlerPolicy int
+
+const (
+	// NackUnknown (default) nacks the message with a reason of
+	// "no handler for type=X". The message is routed to the retry
+	// queue (or dead-letter queue if past the retry limit), never
+	// silently dropped.
+	NackUnknown UnknownHandlerPolicy = iota
+	// AckUnknown logs a warning and lets the batch ack consume the
+	// message. Use this when handler registration is intentionally an
+	// allow-list filter and unhandled types should be discarded.
+	AckUnknown
+)
+
+// WithUnknownHandlerPolicy selects the policy applied to messages whose
+// Type has no registered handler. Default is NackUnknown.
+func WithUnknownHandlerPolicy(p UnknownHandlerPolicy) Option {
+	return func(c *Consumer) { c.unknownPolicy = p }
+}

--- a/clients/go/pgque.go
+++ b/clients/go/pgque.go
@@ -66,6 +66,43 @@ func (c *Client) Send(ctx context.Context, queue string, ev Event) (int64, error
 	return eid, nil
 }
 
+// SendBatch publishes a batch of events of the same Type and returns
+// the assigned event IDs in input order. Each payload is
+// JSON-marshalled. An empty typ defaults to "default". Wraps the SQL
+// pgque.send_batch(text, text, jsonb[]) function.
+func (c *Client) SendBatch(ctx context.Context, queue, typ string, payloads []any) ([]int64, error) {
+	if typ == "" {
+		typ = "default"
+	}
+	encoded := make([]string, len(payloads))
+	for i, p := range payloads {
+		raw, err := json.Marshal(p)
+		if err != nil {
+			return nil, fmt.Errorf("pgque: marshal payload[%d]: %w", i, err)
+		}
+		encoded[i] = string(raw)
+	}
+	rows, err := c.pool.Query(ctx,
+		"SELECT pgque.send_batch($1, $2, $3::jsonb[])", queue, typ, encoded)
+	if err != nil {
+		return nil, fmt.Errorf("pgque: send_batch: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []int64
+	for rows.Next() {
+		var got []int64
+		if err := rows.Scan(&got); err != nil {
+			return nil, fmt.Errorf("pgque: send_batch scan: %w", err)
+		}
+		ids = append(ids, got...)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("pgque: send_batch rows: %w", err)
+	}
+	return ids, nil
+}
+
 // Receive fetches up to maxMessages from the next batch for the named
 // consumer. Returns an empty slice when no batch is available; in that
 // case the caller should sleep before polling again. Each returned
@@ -111,15 +148,49 @@ func (c *Client) Ack(ctx context.Context, batchID int64) error {
 	return nil
 }
 
+// NackOption configures a single Nack call. See WithRetryAfter and
+// WithReason.
+type NackOption func(*nackConfig)
+
+type nackConfig struct {
+	retryAfter time.Duration
+	reason     *string
+}
+
+// WithRetryAfter sets the retry delay for this Nack. Default is 60s.
+// The interval is passed to PostgreSQL as a positive number of seconds.
+func WithRetryAfter(d time.Duration) NackOption {
+	return func(c *nackConfig) { c.retryAfter = d }
+}
+
+// WithReason sets the reason text recorded on the dead-letter row when
+// the retry limit is exceeded. Default is empty (NULL).
+func WithReason(reason string) NackOption {
+	return func(c *nackConfig) { c.reason = &reason }
+}
+
 // Nack negatively acknowledges a single message, routing it to retry or DLQ.
 // pgque.message has 10 fields: msg_id, batch_id, type, payload, retry_count,
 // created_at, extra1, extra2, extra3, extra4 — placeholders $2..$11.
-func (c *Client) Nack(ctx context.Context, batchID int64, msg Message) error {
+//
+// Defaults: retry_after = 60s, reason = NULL. Override via the variadic
+// options (WithRetryAfter, WithReason).
+func (c *Client) Nack(ctx context.Context, batchID int64, msg Message, opts ...NackOption) error {
+	cfg := nackConfig{retryAfter: 60 * time.Second}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	interval := fmt.Sprintf("%d seconds", int64(cfg.retryAfter/time.Second))
+	var reason any
+	if cfg.reason != nil {
+		reason = *cfg.reason
+	}
 	_, err := c.pool.Exec(ctx,
-		"SELECT pgque.nack($1, ROW($2,$3,$4,$5,$6,$7,$8,$9,$10,$11)::pgque.message, '60 seconds'::interval, null)",
+		"SELECT pgque.nack($1, ROW($2,$3,$4,$5,$6,$7,$8,$9,$10,$11)::pgque.message, $12::interval, $13)",
 		batchID, msg.MsgID, msg.BatchID, msg.Type, msg.Payload,
 		msg.RetryCount, msg.CreatedAt,
-		msg.Extra1, msg.Extra2, msg.Extra3, msg.Extra4)
+		msg.Extra1, msg.Extra2, msg.Extra3, msg.Extra4,
+		interval, reason)
 	if err != nil {
 		return fmt.Errorf("pgque: nack: %w", err)
 	}
@@ -128,15 +199,24 @@ func (c *Client) Nack(ctx context.Context, batchID int64, msg Message) error {
 
 // NewConsumer creates a Consumer that polls the given queue under the
 // given consumer name. The consumer must already be registered in PgQue
-// (e.g. via pgque.register_consumer). Default poll interval is 30s; use
-// WithPollInterval to override.
+// (e.g. via pgque.register_consumer).
+//
+// Defaults:
+//   - pollInterval = 30s         (override with WithPollInterval)
+//   - maxMessages = 500          (override with WithMaxMessages; matches
+//     the default queue_ticker_max_count, so a single Receive can drain
+//     a full batch — keep maxMessages >= ticker_max_count to avoid
+//     skipping unreturned rows)
+//   - unknownPolicy = NackUnknown (override with WithUnknownHandlerPolicy)
 func (c *Client) NewConsumer(queue, name string, opts ...Option) *Consumer {
 	consumer := &Consumer{
-		client:       c,
-		queue:        queue,
-		name:         name,
-		pollInterval: 30 * time.Second,
-		handlers:     make(map[string]HandlerFunc),
+		client:        c,
+		queue:         queue,
+		name:          name,
+		pollInterval:  30 * time.Second,
+		maxMessages:   500,
+		handlers:      make(map[string]HandlerFunc),
+		unknownPolicy: NackUnknown,
 	}
 	for _, opt := range opts {
 		opt(consumer)

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -40,16 +40,31 @@ def handle_order(msg: pgque.Message) -> None:
     print(f"got {msg.type}: {msg.payload}")
 
 # Optional: catch-all handler for types with no specific handler.
-# Without it, messages with unhandled types are logged at WARNING and
-# acked. Register a handler for that type or use a "*" catch-all to
-# handle them deliberately.
-# Note: Unhandled event types are acknowledged after a warning. Register a `*` handler if you want to fail/nack/route unknown types yourself.
+# By default, messages whose type has no registered handler are
+# **nacked** (routed to retry_queue, then dead_letter). Pass
+# `unknown_handler="ack"` to the Consumer to log + ack instead — useful
+# when handler registration is intentionally an allow-list filter.
 @consumer.on("*")
 def handle_unknown(msg: pgque.Message) -> None:
     print(f"unhandled type {msg.type!r}: {msg.payload}")
 
 consumer.start()  # blocks until SIGTERM / SIGINT
 ```
+
+### Consumer configuration
+
+Important defaults:
+
+- `max_messages=500` — matches the default `pgque.ticker_max_count` so a
+  single `receive` can drain a full batch. **Set `max_messages >=
+  ticker_max_count`** to avoid leaving rows undelivered for the rest of
+  the batch's lifetime.
+- `unknown_handler="nack"` — unhandled event types are nacked (data-safe
+  default). Pass `"ack"` to opt into the previous warn+ack behaviour.
+- `poll_interval=30` — seconds between polls when LISTEN/NOTIFY does not
+  fire.
+- `retry_after=60` — seconds before a nacked message becomes available
+  again.
 
 ## Tests
 

--- a/clients/python/pgque/consumer.py
+++ b/clients/python/pgque/consumer.py
@@ -8,7 +8,7 @@ import logging
 import signal
 import select
 import threading
-from typing import Callable, Optional
+from typing import Callable, Literal, Optional
 
 import psycopg
 from psycopg import sql
@@ -42,12 +42,22 @@ class Consumer:
         - If the handler raises an exception, the message is nacked
           with the default retry_after.
         - If no handler is registered for a message type (and no
-          default ``"*"`` handler exists), a WARNING is logged and the
-          message is acked. Register a handler for that type or use a
-          ``"*"`` catch-all to handle it deliberately.
+          default ``"*"`` handler exists) the behaviour is controlled
+          by the ``unknown_handler`` constructor argument:
+
+          * ``"nack"`` (default) -- nack with reason
+            ``"no handler for type=X"``. This is the data-safe default:
+            messages with no handler are routed to the retry queue (and
+            eventually the dead-letter queue), never silently dropped.
+          * ``"ack"`` -- log a WARNING and let the batch ack consume the
+            message. Choose this when handler registration acts as an
+            allow-list filter and unhandled types should be discarded
+            on purpose.
 
     After all messages in a batch have been dispatched, the batch is
-    acked automatically.
+    acked automatically -- but only if every required nack call
+    succeeded. If any nack fails, the batch is left unfinished so PgQ
+    redelivers it on the next cycle.
     """
 
     def __init__(
@@ -57,15 +67,21 @@ class Consumer:
         queue: str,
         name: str,
         poll_interval: int = 30,
-        max_messages: int = 100,
+        max_messages: int = 500,
         retry_after: int = 60,
+        unknown_handler: Literal["ack", "nack"] = "nack",
     ):
+        if unknown_handler not in ("ack", "nack"):
+            raise ValueError(
+                f"unknown_handler must be 'ack' or 'nack', got {unknown_handler!r}"
+            )
         self.dsn = dsn
         self.queue = queue
         self.name = name
         self.poll_interval = poll_interval
         self.max_messages = max_messages
         self.retry_after = retry_after
+        self.unknown_handler = unknown_handler
 
         self._handlers: dict[str, Callable] = {}
         self._default_handler: Optional[Callable] = None
@@ -175,10 +191,25 @@ class Consumer:
             for msg in msgs:
                 handler = self._handlers.get(msg.type, self._default_handler)
                 if handler is None:
+                    if self.unknown_handler == "ack":
+                        self._log.warning(
+                            "no handler for event type=%s ev_id=%s; acking",
+                            msg.type,
+                            msg.msg_id,
+                        )
+                        continue
+                    # Default: nack so the message is retried / DLQ'd
+                    # rather than silently dropped.
                     self._log.warning(
-                        "no handler for event type=%s ev_id=%s; acking",
+                        "no handler for event type=%s ev_id=%s; nacking",
                         msg.type,
                         msg.msg_id,
+                    )
+                    client.nack(
+                        batch_id,
+                        msg,
+                        retry_after=self.retry_after,
+                        reason=f"no handler for type={msg.type}",
                     )
                     continue
 

--- a/clients/python/tests/test_consumer.py
+++ b/clients/python/tests/test_consumer.py
@@ -1,6 +1,7 @@
 # Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 
-"""``Consumer`` end-to-end: dispatch, warn+ack on missing handler, error -> nack."""
+"""``Consumer`` end-to-end: dispatch, nack-by-default on missing handler,
+opt-in ack-on-unknown, error -> nack."""
 
 import threading
 import time
@@ -112,25 +113,84 @@ def test_consumer_nacks_on_handler_error(dsn, conn, setup_queue):
     assert cnt >= 1
 
 
-def test_consumer_warns_and_acks_unhandled_event_type(dsn, conn, setup_queue, caplog):
-    """Unhandled event type must emit a WARNING and be acked, not nacked.
+def test_consumer_nacks_unhandled_event_type(dsn, conn, setup_queue):
+    """Default policy: unhandled event types are nacked (data-safe).
 
-    The message must not appear in retry_queue; the WARNING log line must
-    contain the event type and message id.
+    The message must land in the retry queue (or, at the queue's retry
+    limit, the dead-letter queue) and a subsequent ``receive`` must NOT
+    return the same msg_id immediately -- proving the consumer advanced
+    past the bad batch instead of looping on it.
+    """
+    queue, consumer_name = setup_queue
+    client = pgque.PgqueClient(conn)
+    msg_id = client.send(queue, {"x": 1}, type="totally.unregistered.type")
+    conn.commit()
+    conn.execute("select pgque.force_tick(%s)", (queue,))
+    conn.execute("select pgque.ticker()")
+    conn.commit()
+
+    # Consumer with NO handler for the type and NO default handler.
+    # Default unknown_handler="nack" applies.
+    cons = pgque.Consumer(
+        dsn=dsn,
+        queue=queue,
+        name=consumer_name,
+        poll_interval=1,
+        retry_after=0,
+    )
+
+    t = _run_consumer_for(cons, 3.0)
+    t.join(timeout=5.0)
+
+    # The message must have been routed to retry_queue OR dead_letter
+    # (the latter only if the queue's retry limit is 0).
+    retry_cnt = conn.execute(
+        "select count(*) from pgque.retry_queue rq "
+        "join pgque.queue q on q.queue_id = rq.ev_queue "
+        "where q.queue_name = %s",
+        (queue,),
+    ).fetchone()[0]
+    dlq_cnt = conn.execute(
+        "select count(*) from pgque.dead_letter dl "
+        "join pgque.queue q on q.queue_id = dl.dl_queue_id "
+        "where q.queue_name = %s",
+        (queue,),
+    ).fetchone()[0]
+    assert (retry_cnt + dlq_cnt) >= 1, (
+        "unhandled event type with default policy must be nacked "
+        "(routed to retry_queue or dead_letter)"
+    )
+
+    # A subsequent receive must not immediately return the same message
+    # -- the consumer must have advanced past the batch.
+    next_msgs = client.receive(queue, consumer_name, max_messages=10)
+    assert not any(m.msg_id == msg_id for m in next_msgs), (
+        "consumer did not advance past the nacked batch"
+    )
+
+
+def test_consumer_acks_unhandled_event_type_when_opt_in(dsn, conn, setup_queue, caplog):
+    """Opt-in ``unknown_handler="ack"``: unhandled types are warned + acked.
+
+    Must NOT appear in retry_queue, and a subsequent ``receive`` must
+    not return the same msg_id (proves the batch advanced).
     """
     import logging
 
     queue, consumer_name = setup_queue
     client = pgque.PgqueClient(conn)
     msg_id = client.send(queue, {"x": 1}, type="totally.unregistered.type")
+    conn.commit()
     conn.execute("select pgque.force_tick(%s)", (queue,))
     conn.execute("select pgque.ticker()")
     conn.commit()
 
-    # Consumer with NO handler for "totally.unregistered.type"
-    # and NO default handler either.
     cons = pgque.Consumer(
-        dsn=dsn, queue=queue, name=consumer_name, poll_interval=1
+        dsn=dsn,
+        queue=queue,
+        name=consumer_name,
+        poll_interval=1,
+        unknown_handler="ack",
     )
 
     with caplog.at_level(logging.WARNING, logger="pgque"):
@@ -138,25 +198,28 @@ def test_consumer_warns_and_acks_unhandled_event_type(dsn, conn, setup_queue, ca
         t.join(timeout=5.0)
 
     # Must NOT be in retry_queue -- it was acked, not nacked.
-    cnt = conn.execute(
+    retry_cnt = conn.execute(
         "select count(*) from pgque.retry_queue rq "
         "join pgque.queue q on q.queue_id = rq.ev_queue "
         "where q.queue_name = %s",
         (queue,),
     ).fetchone()[0]
-    assert cnt == 0, (
-        "unhandled event type was nacked (found in retry_queue); expected ack"
+    assert retry_cnt == 0, (
+        "with unknown_handler='ack', unhandled types must not appear in retry_queue"
     )
 
-    # A WARNING must have been logged containing the type and event id.
+    # A subsequent receive must not return the same message: it was acked.
+    next_msgs = client.receive(queue, consumer_name, max_messages=10)
+    assert not any(m.msg_id == msg_id for m in next_msgs), (
+        "consumer did not advance past the acked batch"
+    )
+
+    # A WARNING must have been logged.
     warning_lines = [
         r.message for r in caplog.records if r.levelno == logging.WARNING
     ]
     assert any("totally.unregistered.type" in m for m in warning_lines), (
         "expected a WARNING mentioning the unhandled event type"
-    )
-    assert any(str(msg_id) in m for m in warning_lines), (
-        "expected a WARNING mentioning the event id"
     )
 
 

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -33,7 +33,11 @@ try {
 
   // High-level consumer with per-event-type dispatch.
   // msg.payload is raw JSON text — call JSON.parse() to get the object back.
-  const consumer = client.newConsumer('orders', 'order_worker');
+  const consumer = client.newConsumer('orders', 'order_worker', {
+    // pollInterval: 30_000,                    // default
+    // maxMessages: 500,                        // default; keep >= ticker_max_count
+    // unknownHandlerPolicy: 'nack',            // default; 'ack' for filter semantics
+  });
   consumer.handle('order.created', async (msg) => {
     const data = JSON.parse(msg.payload) as { id: number };
     console.log('got', msg.type, data);
@@ -62,6 +66,22 @@ try {
 | `consumer.handle(eventType, fn)` | Register a handler. |
 | `consumer.start(signal?)` | Run; resolves when `AbortSignal` aborts. |
 | `client.close()` | Drain the pool. |
+
+### Consumer options
+
+| Option | Default | Notes |
+|---|---|---|
+| `pollInterval` | `30_000` ms | Time between polls when no messages are available. |
+| `maxMessages` | `500` | Max messages per `pgque.receive`. **Keep `>= ticker_max_count`** (default 500) so a single Receive drains the batch. |
+| `unknownHandlerPolicy` | `'nack'` | `'nack'` (data-safe default) routes unhandled types to retry/DLQ. `'ack'` logs + acks instead. |
+| `logger` | `console` | Pass a `{ warn, error }` shim to silence in tests. |
+
+### Payload encoding
+
+`event.payload` is JSON-stringified before being passed to `pgque.send`.
+A top-level `undefined` is coerced to JSON `null` (matches the Python
+driver's handling of `None`). Other JSON-compatible values
+(`null`, primitives, objects, arrays) round-trip unchanged.
 
 `Message.msgId`, `Message.batchId`, and the return value of `send()` are
 JS `bigint` to match PostgreSQL `bigint` losslessly.

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -84,7 +84,7 @@ export class Client {
       throw new PgqueSqlError('send', { cause: new Error('queue must be a non-empty string') });
     }
     const type = event.type && event.type.length > 0 ? event.type : 'default';
-    const payload = JSON.stringify(event.payload);
+    const payload = encodeJsonbPayload(event.payload);
     try {
       const result = await this.pool.query<{ send: bigint }>(
         'select pgque.send($1, $2, $3::jsonb) as send',
@@ -281,6 +281,18 @@ export async function connect(
   }
   probe.release();
   return new Client(pool);
+}
+
+/**
+ * Encode a JS value for the pgque `jsonb` payload column. Mirrors the
+ * Python driver: top-level `undefined` becomes JSON `'null'` (matches
+ * `None` in Python) instead of the SQL string "undefined" or a thrown
+ * error from `JSON.stringify`. Any other value goes through
+ * `JSON.stringify` unchanged.
+ */
+function encodeJsonbPayload(value: unknown): string {
+  if (value === undefined) return 'null';
+  return JSON.stringify(value);
 }
 
 function rowToMessage(row: RawMessageRow): Message {

--- a/clients/typescript/src/consumer.ts
+++ b/clients/typescript/src/consumer.ts
@@ -23,6 +23,7 @@ export class Consumer {
   private readonly pollIntervalMs: number;
   private readonly maxMessages: number;
   private readonly logger: Pick<Console, 'warn' | 'error'>;
+  private readonly unknownHandlerPolicy: 'ack' | 'nack';
 
   /** @internal — use {@link Client.newConsumer}. */
   constructor(
@@ -32,8 +33,15 @@ export class Consumer {
     opts: ConsumerOptions = {},
   ) {
     this.pollIntervalMs = opts.pollInterval ?? 30_000;
-    this.maxMessages = opts.maxMessages ?? 100;
+    this.maxMessages = opts.maxMessages ?? 500;
     this.logger = opts.logger ?? console;
+    const policy = opts.unknownHandlerPolicy ?? 'nack';
+    if (policy !== 'ack' && policy !== 'nack') {
+      throw new Error(
+        `pgque: unknownHandlerPolicy must be 'ack' or 'nack', got ${String(policy)}`,
+      );
+    }
+    this.unknownHandlerPolicy = policy;
   }
 
   /** Register a handler for `eventType`. Replaces any previous handler. */
@@ -69,25 +77,42 @@ export class Consumer {
       }
 
       let batchId: bigint | null = null;
+      let nackFailed = false;
       for (const msg of msgs) {
         batchId = msg.batchId;
         const handler = this.handlers.get(msg.type);
         if (!handler) {
+          if (this.unknownHandlerPolicy === 'ack') {
+            this.logger.warn(
+              `pgque: no handler registered for event type "${msg.type}", acking msg ${msg.msgId} (ack policy)`,
+            );
+            continue;
+          }
           this.logger.warn(
             `pgque: no handler registered for event type "${msg.type}", nacking msg ${msg.msgId}`,
           );
-          await this.tryNack(batchId, msg);
+          if (!(await this.tryNack(batchId, msg, `no handler for type=${msg.type}`))) {
+            nackFailed = true;
+          }
           continue;
         }
         try {
           await handler(msg);
         } catch (err) {
           this.logger.error(`pgque: handler error for "${msg.type}": ${formatErr(err)}`);
-          await this.tryNack(batchId, msg);
+          if (!(await this.tryNack(batchId, msg))) {
+            nackFailed = true;
+          }
         }
       }
 
       if (batchId !== null) {
+        if (nackFailed) {
+          this.logger.error(
+            `pgque: skipping batch ${batchId.toString()} ack: one or more nacks failed; PgQ will redeliver`,
+          );
+          continue;
+        }
         try {
           await this.client.ack(batchId);
         } catch (err) {
@@ -97,11 +122,14 @@ export class Consumer {
     }
   }
 
-  private async tryNack(batchId: bigint, msg: Message): Promise<void> {
+  /** Returns true on success, false on error (logged). */
+  private async tryNack(batchId: bigint, msg: Message, reason?: string): Promise<boolean> {
     try {
-      await this.client.nack(batchId, msg);
+      await this.client.nack(batchId, msg, reason !== undefined ? { reason } : undefined);
+      return true;
     } catch (err) {
       this.logger.error(`pgque: nack error for "${msg.type}": ${formatErr(err)}`);
+      return false;
     }
   }
 }

--- a/clients/typescript/src/types.ts
+++ b/clients/typescript/src/types.ts
@@ -44,10 +44,24 @@ export interface NackOptions {
 export interface ConsumerOptions {
   /** Interval between poll cycles when no messages are available. Default `30s`. */
   pollInterval?: number;
-  /** Max messages requested per `pgque.receive` call. Default `100`. */
+  /**
+   * Max messages requested per `pgque.receive` call. Default `500`,
+   * which matches the default `queue_ticker_max_count`. Keep
+   * `maxMessages >= ticker_max_count` so a single Receive can drain a
+   * full batch.
+   */
   maxMessages?: number;
   /** Optional logger. Defaults to `console`. */
   logger?: Pick<Console, 'warn' | 'error'>;
+  /**
+   * Policy applied when a message has no registered handler:
+   *  - `'nack'` (default) — nack the message with reason
+   *    `"no handler for type=X"` (data-safe: routes to retry/DLQ).
+   *  - `'ack'` — log a warning and let the batch ack consume the
+   *    message. Use when handler registration is intentionally an
+   *    allow-list filter.
+   */
+  unknownHandlerPolicy?: 'ack' | 'nack';
 }
 
 /**

--- a/clients/typescript/test/client.test.ts
+++ b/clients/typescript/test/client.test.ts
@@ -148,6 +148,19 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
     await env.client.ack(msgs[0]!.batchId);
   });
 
+  skipIfNoDb('coerces top-level undefined payload to JSON null', async () => {
+    // JSON.stringify(undefined) returns the string "undefined" (which is
+    // not valid JSON) — must be coerced to "null" so the jsonb cast
+    // stores the JSON null literal, matching the Python driver's
+    // handling of None.
+    await env.client.send(env.queue, { type: 'undef', payload: undefined });
+    await advanceQueue(env.client, env.queue);
+    const msgs = await env.client.receive(env.queue, env.consumer, 10);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]!.payload).toBe('null');
+    await env.client.ack(msgs[0]!.batchId);
+  });
+
   skipIfNoDb('preserves bigint batchId across the API surface', async () => {
     await env.client.send(env.queue, { payload: { x: 1 } });
     await advanceQueue(env.client, env.queue);

--- a/clients/typescript/test/consumer.test.ts
+++ b/clients/typescript/test/consumer.test.ts
@@ -131,6 +131,40 @@ describe('Consumer (env-gated)', () => {
     );
     expect(retry.rows[0]!.count).toBe('1');
   });
+
+  skipIfNoDb('unknownHandlerPolicy="ack" warns and lets the batch ack', async () => {
+    await env.client.send(env.queue, { type: 'unknown', payload: { v: 1 } });
+    await advanceQueue(env.client, env.queue);
+
+    let warnCount = 0;
+    const consumer = env.client.newConsumer(env.queue, env.consumer, {
+      pollInterval: 50,
+      unknownHandlerPolicy: 'ack',
+      logger: {
+        warn: () => {
+          warnCount += 1;
+        },
+        error: () => undefined,
+      },
+    });
+
+    const ac = new AbortController();
+    const start = consumer.start(ac.signal);
+    await sleep(400);
+    ac.abort();
+    await start;
+
+    // No retry row: the batch was acked.
+    const retry = await env.client.rawPool.query<{ count: string }>(
+      `select count(*)::text as count
+         from pgque.retry_queue rq
+         join pgque.queue q on q.queue_id = rq.ev_queue
+        where q.queue_name = $1`,
+      [env.queue],
+    );
+    expect(retry.rows[0]!.count).toBe('0');
+    expect(warnCount).toBeGreaterThanOrEqual(1);
+  });
 });
 
 function sleep(ms: number): Promise<void> {


### PR DESCRIPTION
## Summary

Cross-driver fix to lock the v0.2.0 consumer contract on data-safety:
no driver may silently drop a message because of a missing handler or a
Nack failure, and the default `max_messages` matches the default
`queue_ticker_max_count` so a single `Receive` can drain a batch.

- **Unknown event types are nacked by default** in all three drivers,
  with an explicit opt-in to restore the previous warn+ack behaviour
  for allow-list filter patterns. **This intentionally reverses
  PR #121's Python `warn+ack` default** per the maintainer audit on
  #136 — see the rationale in #136.
- **Per-batch nack-failure tracking** in Go and TS: if any nack errors,
  the final batch ack is skipped so PgQ redelivers via the existing
  batch lifecycle. Python was already correct via psycopg's
  `with conn.transaction()` rollback.
- **Default `max_messages` raised to 500** in all drivers (matches
  default `pgque.queue.queue_ticker_max_count`).
- **TypeScript:** top-level `undefined` payload is coerced to JSON
  `'null'` (matches Python's `None` handling).
- **Docs:** new `clients/README.md` parity matrix; per-driver READMEs
  updated to describe the new defaults and options.

## Per-driver changes

### Python (`clients/python/`)
- `consumer.py`: new `unknown_handler: Literal["ack", "nack"] = "nack"`
  param. Default nacks unhandled types with reason
  `"no handler for type=X"`. `"ack"` restores the previous WARNING +
  ack behaviour.
- `consumer.py`: default `max_messages` 100 → 500.
- `tests/test_consumer.py`: replace the warn+ack test with two new
  tests — `test_consumer_nacks_unhandled_event_type` (default; asserts
  retry-or-DLQ row appears AND next `receive` does not return the same
  msg_id) and `test_consumer_acks_unhandled_event_type_when_opt_in`
  (asserts no retry row, batch advances, warning emitted).
- `README.md`: documents the new default + the `>= ticker_max_count`
  recommendation.

### Go (`clients/go/`)
- `consumer.go`: per-batch `nackFailed` tracking; ack skipped if any
  nack errored. Doc comments on `HandlerFunc`, `Handle`, `Start`
  updated to match runtime behaviour (#142).
- `options.go`: new `WithMaxMessages(n)`,
  `WithUnknownHandlerPolicy(p)` with `UnknownHandlerPolicy` enum
  (`NackUnknown` default, `AckUnknown` opt-in).
- `pgque.go`: default `maxMessages = 500`. `Client.Nack` now accepts
  variadic `NackOption`s (`WithRetryAfter`, `WithReason`); existing
  callers compile unchanged. New `Client.SendBatch` 1:1 wrapper for
  `pgque.send_batch(text, text, jsonb[])`.
- `README.md`: examples for the new options and `SendBatch`.

### TypeScript (`clients/typescript/`)
- `consumer.ts`: per-poll `nackFailed` tracking; new
  `unknownHandlerPolicy?: 'ack' | 'nack'` (default `'nack'`).
- `client.ts`: shared `encodeJsonbPayload` coerces top-level
  `undefined` to JSON `'null'` for `send` (and any future
  `sendBatch`).
- `types.ts`: extends `ConsumerOptions` with `unknownHandlerPolicy`,
  bumps default `maxMessages` to 500.
- `test/`: new tests for the ack-policy opt-in and undefined coercion.
- `README.md`: documents the new options and `undefined` semantics.

### Cross-driver parity (`clients/README.md`, new)
- Capability matrix per driver
- Locked-in nack-default contract
- List of v0.2.1+ deferred items

## Issues

Closes #134, #135, #136, #137, #142, #149.
References #138 (partial: variadic `NackOption`s land here, the
`Subscribe`/`Unsubscribe`/`Ticker`/`ForceTick` Go wrappers stay
deferred per maintainer), #144 (docs portion: parity matrix).

Out of scope (deferred to v0.2.1+): #140, #141, #143, #145, #147,
#148, #150, #151.

## Test plan

- [x] **Python:** `PGQUE_TEST_DSN=... python3 -m pytest
      clients/python/tests/` → 41 pass, 1 pre-existing baseline
      failure (`test_send_batch_none_payload_produces_json_null` —
      missing `conn.commit()` between `send_batch` and `force_tick`,
      out of scope here).
- [x] **Go:** `PGQUE_TEST_DSN=... go test -race -count=1
      ./clients/go/...` → all pass (12.5s).
- [x] **TypeScript:** `PGQUE_TEST_DSN=... npm test` in
      `clients/typescript/` → 24/24 pass; `npm run check` (tsc
      --noEmit on src + tests) is clean.
- [x] `go vet ./clients/go/...` clean.

## Notes

- Reverses #121 (the warn+ack default that just merged) as
  pre-arranged by the maintainer / #136 audit. The opt-in
  `unknown_handler="ack"` keeps that behaviour available for the
  filter-style consumers that motivated #121.
- No SQL files touched.
- Existing Go `Nack(ctx, batchID, msg)` callers continue to compile
  (variadic options are appended, not required).


---
_Generated by [Claude Code](https://claude.ai/code/session_01BRMoDzqHTTTq3T8dg8U4vx)_