### PR TITLE
feat(clients): expose atomic batch send

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,10 +117,19 @@ jobs:
           python3 -m pip install -e clients/python[dev]
           pytest -q clients/python/tests/test_smoke.py
 
+      - name: Python producer benchmark
+        run: |
+          python3 clients/python/bench_producer.py
+
       - name: Go smoke
         run: |
           cd clients/go
           go test -run TestSmoke ./...
+
+      - name: Go producer benchmark
+        run: |
+          cd clients/go
+          PGQUE_RUN_PRODUCER_BENCH=1 go test -run TestProducerBenchmarks -v ./...
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -134,6 +143,11 @@ jobs:
           bun run check
           bun run test
           bun src/smoke.ts
+
+      - name: TypeScript producer benchmark
+        run: |
+          cd clients/typescript
+          bun run bench:producer
 
       - name: Cleanup client smoke DB
         if: always()

--- a/benchmark/charts/client_producer_batch_api.svg
+++ b/benchmark/charts/client_producer_batch_api.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="628" viewBox="0 0 1120 628">
+<rect width="100%" height="100%" fill="#ffffff"/>
+<text x="560.0" y="30" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="22" font-weight="700" fill="#111827">PgQue client producer throughput: send loop vs batch API</text>
+<text x="560.0" y="55" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="13" fill="#6b7280">events/sec, median of 3 repeats, GitHub Actions PostgreSQL 18 runner</text>
+<rect x="190" y="64" width="14" height="10" fill="#64748b" rx="2"/><text x="210" y="74" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">send loop</text>
+<rect x="295" y="64" width="14" height="10" fill="#16a34a" rx="2"/><text x="315" y="74" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">batch API</text>
+<line x1="190.0" y1="74" x2="190.0" y2="574" stroke="#e5e7eb" stroke-width="1"/>
+<text x="190.0" y="598" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">0</text>
+<line x1="375.0" y1="74" x2="375.0" y2="574" stroke="#e5e7eb" stroke-width="1"/>
+<text x="375.0" y="598" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">5,058</text>
+<line x1="560.0" y1="74" x2="560.0" y2="574" stroke="#e5e7eb" stroke-width="1"/>
+<text x="560.0" y="598" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">10,116</text>
+<line x1="745.0" y1="74" x2="745.0" y2="574" stroke="#e5e7eb" stroke-width="1"/>
+<text x="745.0" y="598" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">15,174</text>
+<line x1="930.0" y1="74" x2="930.0" y2="574" stroke="#e5e7eb" stroke-width="1"/>
+<text x="930.0" y="598" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">20,233</text>
+<text x="174" y="101" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="600" fill="#111827">Python · n=1</text>
+<rect x="190" y="85" width="22.7" height="14" fill="#64748b" rx="3"/>
+<rect x="190" y="105" width="28.9" height="14" fill="#16a34a" rx="3"/>
+<text x="220.7" y="97" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">622</text>
+<text x="226.9" y="117" font-family="Inter,Arial,sans-serif" font-size="12" fill="#111827" font-weight="600">790</text>
+<text x="958" y="110" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#16a34a">1.27×</text>
+<text x="174" y="155" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="600" fill="#111827">Python · n=100</text>
+<rect x="190" y="139" width="114.9" height="14" fill="#64748b" rx="3"/>
+<rect x="190" y="159" width="543.0" height="14" fill="#16a34a" rx="3"/>
+<text x="312.9" y="151" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">3,142</text>
+<text x="741.0" y="171" font-family="Inter,Arial,sans-serif" font-size="12" fill="#111827" font-weight="600">14,847</text>
+<text x="958" y="164" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#16a34a">4.7×</text>
+<text x="174" y="209" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="600" fill="#111827">Python · n=1000</text>
+<rect x="190" y="193" width="121.6" height="14" fill="#64748b" rx="3"/>
+<rect x="190" y="213" width="656.8" height="14" fill="#16a34a" rx="3"/>
+<text x="319.6" y="205" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">3,324</text>
+<text x="854.8" y="225" font-family="Inter,Arial,sans-serif" font-size="12" fill="#111827" font-weight="600">17,959</text>
+<text x="958" y="218" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#16a34a">5.4×</text>
+<text x="174" y="263" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="600" fill="#111827">Go · n=1</text>
+<rect x="190" y="247" width="41.2" height="14" fill="#64748b" rx="3"/>
+<rect x="190" y="267" width="40.7" height="14" fill="#16a34a" rx="3"/>
+<text x="239.2" y="259" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">1,127</text>
+<text x="238.7" y="279" font-family="Inter,Arial,sans-serif" font-size="12" fill="#111827" font-weight="600">1,112</text>
+<text x="958" y="272" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#dc2626">0.99×</text>
+<text x="174" y="317" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="600" fill="#111827">Go · n=100</text>
+<rect x="190" y="301" width="83.8" height="14" fill="#64748b" rx="3"/>
+<rect x="190" y="321" width="640.8" height="14" fill="#16a34a" rx="3"/>
+<text x="281.8" y="313" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">2,290</text>
+<text x="838.8" y="333" font-family="Inter,Arial,sans-serif" font-size="12" fill="#111827" font-weight="600">17,522</text>
+<text x="958" y="326" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#16a34a">7.7×</text>
+<text x="174" y="371" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="600" fill="#111827">Go · n=1000</text>
+<rect x="190" y="355" width="86.4" height="14" fill="#64748b" rx="3"/>
+<rect x="190" y="375" width="740.0" height="14" fill="#16a34a" rx="3"/>
+<text x="284.4" y="367" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">2,363</text>
+<text x="938.0" y="387" font-family="Inter,Arial,sans-serif" font-size="12" fill="#111827" font-weight="600">20,233</text>
+<text x="958" y="380" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#16a34a">8.6×</text>
+<text x="174" y="425" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="600" fill="#111827">TypeScript · n=1</text>
+<rect x="190" y="409" width="17.9" height="14" fill="#64748b" rx="3"/>
+<rect x="190" y="429" width="25.3" height="14" fill="#16a34a" rx="3"/>
+<text x="215.9" y="421" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">490</text>
+<text x="223.3" y="441" font-family="Inter,Arial,sans-serif" font-size="12" fill="#111827" font-weight="600">691</text>
+<text x="958" y="434" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#16a34a">1.41×</text>
+<text x="174" y="479" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="600" fill="#111827">TypeScript · n=100</text>
+<rect x="190" y="463" width="59.8" height="14" fill="#64748b" rx="3"/>
+<rect x="190" y="483" width="584.5" height="14" fill="#16a34a" rx="3"/>
+<text x="257.8" y="475" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">1,635</text>
+<text x="782.5" y="495" font-family="Inter,Arial,sans-serif" font-size="12" fill="#111827" font-weight="600">15,980</text>
+<text x="958" y="488" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#16a34a">9.8×</text>
+<text x="174" y="533" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="600" fill="#111827">TypeScript · n=1000</text>
+<rect x="190" y="517" width="69.9" height="14" fill="#64748b" rx="3"/>
+<rect x="190" y="537" width="703.0" height="14" fill="#16a34a" rx="3"/>
+<text x="267.9" y="529" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">1,912</text>
+<text x="901.0" y="549" font-family="Inter,Arial,sans-serif" font-size="12" fill="#111827" font-weight="600">19,222</text>
+<text x="958" y="542" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#16a34a">10.1×</text>
+<text x="190" y="612" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">Source: PR #161 client-smoke logs. Higher is better. Speedup = batch API throughput / send-loop throughput.</text>
+</svg>

--- a/benchmark/charts/client_producer_batch_api.svg
+++ b/benchmark/charts/client_producer_batch_api.svg
@@ -1,72 +1,113 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="628" viewBox="0 0 1120 628">
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="860" viewBox="0 0 1280 860">
 <rect width="100%" height="100%" fill="#ffffff"/>
-<text x="560.0" y="30" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="22" font-weight="700" fill="#111827">PgQue client producer throughput: send loop vs batch API</text>
-<text x="560.0" y="55" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="13" fill="#6b7280">events/sec, median of 3 repeats, GitHub Actions PostgreSQL 18 runner</text>
-<rect x="190" y="64" width="14" height="10" fill="#64748b" rx="2"/><text x="210" y="74" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">send loop</text>
-<rect x="295" y="64" width="14" height="10" fill="#16a34a" rx="2"/><text x="315" y="74" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">batch API</text>
-<line x1="190.0" y1="74" x2="190.0" y2="574" stroke="#e5e7eb" stroke-width="1"/>
-<text x="190.0" y="598" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">0</text>
-<line x1="375.0" y1="74" x2="375.0" y2="574" stroke="#e5e7eb" stroke-width="1"/>
-<text x="375.0" y="598" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">5,058</text>
-<line x1="560.0" y1="74" x2="560.0" y2="574" stroke="#e5e7eb" stroke-width="1"/>
-<text x="560.0" y="598" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">10,116</text>
-<line x1="745.0" y1="74" x2="745.0" y2="574" stroke="#e5e7eb" stroke-width="1"/>
-<text x="745.0" y="598" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">15,174</text>
-<line x1="930.0" y1="74" x2="930.0" y2="574" stroke="#e5e7eb" stroke-width="1"/>
-<text x="930.0" y="598" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">20,233</text>
-<text x="174" y="101" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="600" fill="#111827">Python · n=1</text>
-<rect x="190" y="85" width="22.7" height="14" fill="#64748b" rx="3"/>
-<rect x="190" y="105" width="28.9" height="14" fill="#16a34a" rx="3"/>
-<text x="220.7" y="97" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">622</text>
-<text x="226.9" y="117" font-family="Inter,Arial,sans-serif" font-size="12" fill="#111827" font-weight="600">790</text>
-<text x="958" y="110" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#16a34a">1.27×</text>
-<text x="174" y="155" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="600" fill="#111827">Python · n=100</text>
-<rect x="190" y="139" width="114.9" height="14" fill="#64748b" rx="3"/>
-<rect x="190" y="159" width="543.0" height="14" fill="#16a34a" rx="3"/>
-<text x="312.9" y="151" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">3,142</text>
-<text x="741.0" y="171" font-family="Inter,Arial,sans-serif" font-size="12" fill="#111827" font-weight="600">14,847</text>
-<text x="958" y="164" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#16a34a">4.7×</text>
-<text x="174" y="209" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="600" fill="#111827">Python · n=1000</text>
-<rect x="190" y="193" width="121.6" height="14" fill="#64748b" rx="3"/>
-<rect x="190" y="213" width="656.8" height="14" fill="#16a34a" rx="3"/>
-<text x="319.6" y="205" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">3,324</text>
-<text x="854.8" y="225" font-family="Inter,Arial,sans-serif" font-size="12" fill="#111827" font-weight="600">17,959</text>
-<text x="958" y="218" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#16a34a">5.4×</text>
-<text x="174" y="263" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="600" fill="#111827">Go · n=1</text>
-<rect x="190" y="247" width="41.2" height="14" fill="#64748b" rx="3"/>
-<rect x="190" y="267" width="40.7" height="14" fill="#16a34a" rx="3"/>
-<text x="239.2" y="259" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">1,127</text>
-<text x="238.7" y="279" font-family="Inter,Arial,sans-serif" font-size="12" fill="#111827" font-weight="600">1,112</text>
-<text x="958" y="272" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#dc2626">0.99×</text>
-<text x="174" y="317" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="600" fill="#111827">Go · n=100</text>
-<rect x="190" y="301" width="83.8" height="14" fill="#64748b" rx="3"/>
-<rect x="190" y="321" width="640.8" height="14" fill="#16a34a" rx="3"/>
-<text x="281.8" y="313" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">2,290</text>
-<text x="838.8" y="333" font-family="Inter,Arial,sans-serif" font-size="12" fill="#111827" font-weight="600">17,522</text>
-<text x="958" y="326" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#16a34a">7.7×</text>
-<text x="174" y="371" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="600" fill="#111827">Go · n=1000</text>
-<rect x="190" y="355" width="86.4" height="14" fill="#64748b" rx="3"/>
-<rect x="190" y="375" width="740.0" height="14" fill="#16a34a" rx="3"/>
-<text x="284.4" y="367" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">2,363</text>
-<text x="938.0" y="387" font-family="Inter,Arial,sans-serif" font-size="12" fill="#111827" font-weight="600">20,233</text>
-<text x="958" y="380" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#16a34a">8.6×</text>
-<text x="174" y="425" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="600" fill="#111827">TypeScript · n=1</text>
-<rect x="190" y="409" width="17.9" height="14" fill="#64748b" rx="3"/>
-<rect x="190" y="429" width="25.3" height="14" fill="#16a34a" rx="3"/>
-<text x="215.9" y="421" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">490</text>
-<text x="223.3" y="441" font-family="Inter,Arial,sans-serif" font-size="12" fill="#111827" font-weight="600">691</text>
-<text x="958" y="434" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#16a34a">1.41×</text>
-<text x="174" y="479" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="600" fill="#111827">TypeScript · n=100</text>
-<rect x="190" y="463" width="59.8" height="14" fill="#64748b" rx="3"/>
-<rect x="190" y="483" width="584.5" height="14" fill="#16a34a" rx="3"/>
-<text x="257.8" y="475" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">1,635</text>
-<text x="782.5" y="495" font-family="Inter,Arial,sans-serif" font-size="12" fill="#111827" font-weight="600">15,980</text>
-<text x="958" y="488" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#16a34a">9.8×</text>
-<text x="174" y="533" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="600" fill="#111827">TypeScript · n=1000</text>
-<rect x="190" y="517" width="69.9" height="14" fill="#64748b" rx="3"/>
-<rect x="190" y="537" width="703.0" height="14" fill="#16a34a" rx="3"/>
-<text x="267.9" y="529" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">1,912</text>
-<text x="901.0" y="549" font-family="Inter,Arial,sans-serif" font-size="12" fill="#111827" font-weight="600">19,222</text>
-<text x="958" y="542" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#16a34a">10.1×</text>
-<text x="190" y="612" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">Source: PR #161 client-smoke logs. Higher is better. Speedup = batch API throughput / send-loop throughput.</text>
+<text x="640.0" y="34" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="24" font-weight="800" fill="#111827">PgQue clients: batching vs loop over send()</text>
+<text x="640.0" y="60" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="13" fill="#6b7280">Single sequential producer, one DB connection/client, median of 3 repeats on GitHub Actions PostgreSQL 18 runner</text>
+<text x="92" y="82" font-family="Inter,Arial,sans-serif" font-size="17" font-weight="700" fill="#111827">A. Throughput speedup from batch API</text>
+<text x="92" y="100" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">batch events/sec ÷ loop-over-send events/sec; higher is better</text>
+<line x1="92" y1="372.0" x2="612" y2="372.0" stroke="#e5e7eb"/>
+<text x="82" y="376.0" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">0×</text>
+<line x1="92" y1="322.9" x2="612" y2="322.9" stroke="#e5e7eb"/>
+<text x="82" y="326.9" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">2×</text>
+<line x1="92" y1="273.8" x2="612" y2="273.8" stroke="#e5e7eb"/>
+<text x="82" y="277.8" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">4×</text>
+<line x1="92" y1="224.7" x2="612" y2="224.7" stroke="#e5e7eb"/>
+<text x="82" y="228.7" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">6×</text>
+<line x1="92" y1="175.6" x2="612" y2="175.6" stroke="#e5e7eb"/>
+<text x="82" y="179.6" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">8×</text>
+<line x1="92" y1="126.5" x2="612" y2="126.5" stroke="#e5e7eb"/>
+<text x="82" y="130.5" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">10×</text>
+<text x="172" y="396" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">n=1</text>
+<rect x="112.0" y="340.8" width="34" height="31.2" fill="#2563eb" rx="4"/>
+<text x="129.0" y="334.8" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="10" font-weight="700" fill="#2563eb">1.27×</text>
+<rect x="152.0" y="347.8" width="34" height="24.2" fill="#0891b2" rx="4"/>
+<text x="169.0" y="341.8" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="10" font-weight="700" fill="#0891b2">0.99×</text>
+<rect x="192.0" y="337.4" width="34" height="34.6" fill="#7c3aed" rx="4"/>
+<text x="209.0" y="331.4" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="10" font-weight="700" fill="#7c3aed">1.41×</text>
+<text x="342" y="396" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">n=100</text>
+<rect x="282.0" y="256.0" width="34" height="116.0" fill="#2563eb" rx="4"/>
+<text x="299.0" y="250.0" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="10" font-weight="700" fill="#2563eb">4.7×</text>
+<rect x="322.0" y="184.2" width="34" height="187.8" fill="#0891b2" rx="4"/>
+<text x="339.0" y="178.2" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="10" font-weight="700" fill="#0891b2">7.7×</text>
+<rect x="362.0" y="132.1" width="34" height="239.9" fill="#7c3aed" rx="4"/>
+<text x="379.0" y="126.1" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="10" font-weight="700" fill="#7c3aed">9.8×</text>
+<text x="512" y="396" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">n=1000</text>
+<rect x="452.0" y="239.4" width="34" height="132.6" fill="#2563eb" rx="4"/>
+<text x="469.0" y="233.4" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="10" font-weight="700" fill="#2563eb">5.4×</text>
+<rect x="492.0" y="161.8" width="34" height="210.2" fill="#0891b2" rx="4"/>
+<text x="509.0" y="155.8" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="10" font-weight="700" fill="#0891b2">8.6×</text>
+<rect x="532.0" y="125.2" width="34" height="246.8" fill="#7c3aed" rx="4"/>
+<text x="549.0" y="119.2" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="10" font-weight="700" fill="#7c3aed">10.1×</text>
+<rect x="147" y="416" width="13" height="13" fill="#2563eb" rx="3"/><text x="166" y="427" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">Python</text>
+<rect x="287" y="416" width="13" height="13" fill="#0891b2" rx="3"/><text x="306" y="427" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">Go</text>
+<rect x="427" y="416" width="13" height="13" fill="#7c3aed" rx="3"/><text x="446" y="427" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">TypeScript</text>
+<text x="710" y="82" font-family="Inter,Arial,sans-serif" font-size="17" font-weight="700" fill="#111827">B. Producer latency per batch</text>
+<text x="710" y="100" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">milliseconds to publish the whole batch; log scale, lower is better</text>
+<line x1="710" y1="357.7" x2="1180" y2="357.7" stroke="#e5e7eb"/>
+<text x="700" y="361.7" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">1 ms</text>
+<line x1="710" y1="313.8" x2="1180" y2="313.8" stroke="#e5e7eb"/>
+<text x="700" y="317.8" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">3 ms</text>
+<line x1="710" y1="265.7" x2="1180" y2="265.7" stroke="#e5e7eb"/>
+<text x="700" y="269.7" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">10 ms</text>
+<line x1="710" y1="221.8" x2="1180" y2="221.8" stroke="#e5e7eb"/>
+<text x="700" y="225.8" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">30 ms</text>
+<line x1="710" y1="173.6" x2="1180" y2="173.6" stroke="#e5e7eb"/>
+<text x="700" y="177.6" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">100 ms</text>
+<line x1="710" y1="129.7" x2="1180" y2="129.7" stroke="#e5e7eb"/>
+<text x="700" y="133.7" text-anchor="end" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">300 ms</text>
+<line x1="723.0" y1="372.0" x2="723.0" y2="338.7" stroke="#94a3b8" stroke-width="7" stroke-linecap="round"/>
+<line x1="737.0" y1="372.0" x2="737.0" y2="348.3" stroke="#16a34a" stroke-width="7" stroke-linecap="round"/>
+<text x="730.0" y="390" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="9" fill="#6b7280">Py</text>
+<text x="730.0" y="403" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="9" fill="#6b7280">1</text>
+<line x1="776.8" y1="372.0" x2="776.8" y2="219.4" stroke="#94a3b8" stroke-width="7" stroke-linecap="round"/>
+<line x1="790.8" y1="372.0" x2="790.8" y2="281.5" stroke="#16a34a" stroke-width="7" stroke-linecap="round"/>
+<text x="783.75" y="390" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="9" fill="#6b7280">Py</text>
+<text x="783.75" y="403" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="9" fill="#6b7280">100</text>
+<line x1="830.5" y1="372.0" x2="830.5" y2="129.6" stroke="#94a3b8" stroke-width="7" stroke-linecap="round"/>
+<line x1="844.5" y1="372.0" x2="844.5" y2="197.0" stroke="#16a34a" stroke-width="7" stroke-linecap="round"/>
+<text x="837.5" y="390" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="9" fill="#6b7280">Py</text>
+<text x="837.5" y="403" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="9" fill="#6b7280">1000</text>
+<line x1="884.2" y1="372.0" x2="884.2" y2="362.5" stroke="#94a3b8" stroke-width="7" stroke-linecap="round"/>
+<line x1="898.2" y1="372.0" x2="898.2" y2="362.0" stroke="#16a34a" stroke-width="7" stroke-linecap="round"/>
+<text x="891.25" y="390" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="9" fill="#6b7280">Go</text>
+<text x="891.25" y="403" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="9" fill="#6b7280">1</text>
+<line x1="938.0" y1="372.0" x2="938.0" y2="206.8" stroke="#94a3b8" stroke-width="7" stroke-linecap="round"/>
+<line x1="952.0" y1="372.0" x2="952.0" y2="288.1" stroke="#16a34a" stroke-width="7" stroke-linecap="round"/>
+<text x="945.0" y="390" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="9" fill="#6b7280">Go</text>
+<text x="945.0" y="403" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="9" fill="#6b7280">100</text>
+<line x1="991.8" y1="372.0" x2="991.8" y2="116.0" stroke="#94a3b8" stroke-width="7" stroke-linecap="round"/>
+<line x1="1005.8" y1="372.0" x2="1005.8" y2="201.8" stroke="#16a34a" stroke-width="7" stroke-linecap="round"/>
+<text x="998.75" y="390" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="9" fill="#6b7280">Go</text>
+<text x="998.75" y="403" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="9" fill="#6b7280">1000</text>
+<line x1="1045.5" y1="372.0" x2="1045.5" y2="329.2" stroke="#94a3b8" stroke-width="7" stroke-linecap="round"/>
+<line x1="1059.5" y1="372.0" x2="1059.5" y2="343.0" stroke="#16a34a" stroke-width="7" stroke-linecap="round"/>
+<text x="1052.5" y="390" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="9" fill="#6b7280">Ty</text>
+<text x="1052.5" y="403" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="9" fill="#6b7280">1</text>
+<line x1="1099.2" y1="372.0" x2="1099.2" y2="193.3" stroke="#94a3b8" stroke-width="7" stroke-linecap="round"/>
+<line x1="1113.2" y1="372.0" x2="1113.2" y2="284.4" stroke="#16a34a" stroke-width="7" stroke-linecap="round"/>
+<text x="1106.25" y="390" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="9" fill="#6b7280">Ty</text>
+<text x="1106.25" y="403" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="9" fill="#6b7280">100</text>
+<line x1="1153.0" y1="372.0" x2="1153.0" y2="107.5" stroke="#94a3b8" stroke-width="7" stroke-linecap="round"/>
+<line x1="1167.0" y1="372.0" x2="1167.0" y2="199.8" stroke="#16a34a" stroke-width="7" stroke-linecap="round"/>
+<text x="1160.0" y="390" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="9" fill="#6b7280">Ty</text>
+<text x="1160.0" y="403" text-anchor="middle" font-family="Inter,Arial,sans-serif" font-size="9" fill="#6b7280">1000</text>
+<rect x="810" y="422" width="14" height="10" fill="#94a3b8" rx="2"/><text x="830" y="432" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">loop over send()</text>
+<rect x="970" y="422" width="14" height="10" fill="#16a34a" rx="2"/><text x="990" y="432" font-family="Inter,Arial,sans-serif" font-size="12" fill="#6b7280">batch API</text>
+<rect x="92" y="480" width="1088" height="300" fill="#f8fafc" stroke="#e2e8f0" rx="16"/>
+<text x="116" y="516" font-family="Inter,Arial,sans-serif" font-size="18" font-weight="800" fill="#111827">What bottleneck is this exposing?</text>
+<circle cx="122" cy="547" r="5" fill="#0f766e"/>
+<text x="138" y="544" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#111827">loop over send(), n=100/1000</text>
+<text x="327" y="544" font-family="Inter,Arial,sans-serif" font-size="13" fill="#6b7280">Dominated by client↔Postgres round trips and per-call driver overhead. Each message is one SQL statement.</text>
+<circle cx="122" cy="587" r="5" fill="#0f766e"/>
+<text x="138" y="584" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#111827">batch API, n=100/1000</text>
+<text x="327" y="584" font-family="Inter,Arial,sans-serif" font-size="13" fill="#6b7280">Round trips collapse to one SQL call. Remaining cost is payload JSON serialization + server-side send_batch insert work.</text>
+<circle cx="122" cy="627" r="5" fill="#0f766e"/>
+<text x="138" y="624" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#111827">server-side note</text>
+<text x="327" y="624" font-family="Inter,Arial,sans-serif" font-size="13" fill="#6b7280">Current safe API still depends on pgque.send_batch implementation; #159/set-based rewrite should improve the green bars further.</text>
+<circle cx="122" cy="667" r="5" fill="#0f766e"/>
+<text x="138" y="664" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#111827">n=1</text>
+<text x="327" y="664" font-family="Inter,Arial,sans-serif" font-size="13" fill="#6b7280">Batch and single send are intentionally similar; batching pays off once multiple events share one logical publish operation.</text>
+<circle cx="122" cy="707" r="5" fill="#0f766e"/>
+<text x="138" y="704" font-family="Inter,Arial,sans-serif" font-size="13" font-weight="700" fill="#111827">single producer</text>
+<text x="327" y="704" font-family="Inter,Arial,sans-serif" font-size="13" fill="#6b7280">These are not max cluster throughput numbers. They isolate producer API overhead for one sequential producer/client.</text>
+<text x="92" y="832" font-family="Inter,Arial,sans-serif" font-size="11" fill="#6b7280">Source: PR #161 client-smoke logs. Metrics are medians over 3 repeats; each run creates a fresh queue and verifies inserted row count.</text>
 </svg>

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -47,6 +47,15 @@ func main() {
         log.Fatal(err)
     }
 
+    ids, err := client.SendBatch(ctx, "orders", "order.created", []any{
+        map[string]any{"order_id": 43},
+        map[string]any{"order_id": 44},
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+    _ = ids
+
     // Consumer side
     consumer := client.NewConsumer("orders", "order_worker")
     consumer.Handle("order.created", func(ctx context.Context, msg pgque.Message) error {

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -54,7 +54,7 @@ func main() {
     if err != nil {
         log.Fatal(err)
     }
-    _ = ids
+    log.Printf("published batch event IDs: %v", ids)
 
     // Consumer side
     consumer := client.NewConsumer("orders", "order_worker")

--- a/clients/go/pgque.go
+++ b/clients/go/pgque.go
@@ -82,7 +82,7 @@ func (c *Client) SendBatch(ctx context.Context, queue, typ string, payloads []an
 
 	var ids []int64
 	err := c.pool.QueryRow(ctx,
-		"SELECT pgque.send_batch($1, $2, $3::jsonb[])", queue, typ, jsonPayloads,
+		"select pgque.send_batch($1, $2, $3::jsonb[])", queue, typ, jsonPayloads,
 	).Scan(&ids)
 	if err != nil {
 		return nil, fmt.Errorf("pgque: send batch: %w", err)

--- a/clients/go/pgque.go
+++ b/clients/go/pgque.go
@@ -67,9 +67,9 @@ func (c *Client) Send(ctx context.Context, queue string, ev Event) (int64, error
 }
 
 // SendBatch publishes multiple payloads with the same event type in one SQL call.
-// It returns event IDs in input order. PostgreSQL executes the call atomically
-// inside the caller's transaction: if any payload is rejected, no message from
-// the batch is inserted. An empty typ defaults to "default".
+// It returns event IDs in input order. PostgreSQL executes the SQL function as
+// one atomic statement: if any payload is rejected, no message from the batch is
+// inserted. An empty typ defaults to "default".
 func (c *Client) SendBatch(ctx context.Context, queue, typ string, payloads []any) ([]int64, error) {
 	jsonPayloads := make([]string, len(payloads))
 	for i, payload := range payloads {

--- a/clients/go/pgque.go
+++ b/clients/go/pgque.go
@@ -66,7 +66,10 @@ func (c *Client) Send(ctx context.Context, queue string, ev Event) (int64, error
 	return eid, nil
 }
 
-// SendBatch publishes same-type payloads atomically; an empty typ defaults to "default".
+// SendBatch publishes multiple payloads with the same event type in one SQL call.
+// It returns event IDs in input order. PostgreSQL executes the call atomically
+// inside the caller's transaction: if any payload is rejected, no message from
+// the batch is inserted. An empty typ defaults to "default".
 func (c *Client) SendBatch(ctx context.Context, queue, typ string, payloads []any) ([]int64, error) {
 	jsonPayloads := make([]string, len(payloads))
 	for i, payload := range payloads {

--- a/clients/go/pgque.go
+++ b/clients/go/pgque.go
@@ -66,6 +66,33 @@ func (c *Client) Send(ctx context.Context, queue string, ev Event) (int64, error
 	return eid, nil
 }
 
+// SendBatch publishes multiple payloads with the same event type in one SQL
+// call and returns event IDs in input order. PostgreSQL executes the call
+// atomically inside the caller's transaction: if any payload is rejected, no
+// message from the batch is inserted. An empty typ defaults to "default".
+func (c *Client) SendBatch(ctx context.Context, queue, typ string, payloads []any) ([]int64, error) {
+	jsonPayloads := make([]string, len(payloads))
+	for i, payload := range payloads {
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			return nil, fmt.Errorf("pgque: marshal batch payload %d: %w", i, err)
+		}
+		jsonPayloads[i] = string(encoded)
+	}
+	if typ == "" {
+		typ = "default"
+	}
+
+	var ids []int64
+	err := c.pool.QueryRow(ctx,
+		"SELECT pgque.send_batch($1, $2, $3::jsonb[])", queue, typ, jsonPayloads,
+	).Scan(&ids)
+	if err != nil {
+		return nil, fmt.Errorf("pgque: send batch: %w", err)
+	}
+	return ids, nil
+}
+
 // Receive fetches up to maxMessages from the next batch for the named
 // consumer. Returns an empty slice when no batch is available; in that
 // case the caller should sleep before polling again. Each returned

--- a/clients/go/pgque.go
+++ b/clients/go/pgque.go
@@ -66,10 +66,7 @@ func (c *Client) Send(ctx context.Context, queue string, ev Event) (int64, error
 	return eid, nil
 }
 
-// SendBatch publishes multiple payloads with the same event type in one SQL
-// call and returns event IDs in input order. PostgreSQL executes the call
-// atomically inside the caller's transaction: if any payload is rejected, no
-// message from the batch is inserted. An empty typ defaults to "default".
+// SendBatch publishes same-type payloads atomically; an empty typ defaults to "default".
 func (c *Client) SendBatch(ctx context.Context, queue, typ string, payloads []any) ([]int64, error) {
 	jsonPayloads := make([]string, len(payloads))
 	for i, payload := range payloads {

--- a/clients/go/pgque_test.go
+++ b/clients/go/pgque_test.go
@@ -94,6 +94,47 @@ func TestSend(t *testing.T) {
 	}
 }
 
+func TestSendBatch(t *testing.T) {
+	ctx := context.Background()
+	client, err := pgque.Connect(ctx, getDSN())
+	if err != nil {
+		t.Skip("Cannot connect to PG:", err)
+	}
+	defer client.Close()
+	setupQueue(t, client)
+
+	ids, err := client.SendBatch(ctx, "gotest_queue", "batch.test", []any{
+		map[string]any{"n": 1},
+		map[string]any{"n": 2},
+		map[string]any{"n": 3},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 3 {
+		t.Fatalf("expected 3 IDs, got %d", len(ids))
+	}
+	if ids[0] >= ids[1] || ids[1] >= ids[2] {
+		t.Fatalf("expected IDs in input order, got %v", ids)
+	}
+
+	if _, err = client.Pool().Exec(ctx, "SELECT pgque.ticker('gotest_queue')"); err != nil {
+		t.Fatal(err)
+	}
+	msgs, err := client.Receive(ctx, "gotest_queue", "gotest_consumer", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(msgs))
+	}
+	for _, msg := range msgs {
+		if msg.Type != "batch.test" {
+			t.Fatalf("expected type batch.test, got %s", msg.Type)
+		}
+	}
+}
+
 func TestSendAndReceive(t *testing.T) {
 	ctx := context.Background()
 	client, err := pgque.Connect(ctx, getDSN())

--- a/clients/go/pgque_test.go
+++ b/clients/go/pgque_test.go
@@ -138,6 +138,80 @@ func TestSendBatch(t *testing.T) {
 	}
 }
 
+func TestSendBatchEmptySlice(t *testing.T) {
+	client := connectOrSkip(t)
+	defer client.Close()
+	queue, consumer := setupFreshQueue(t, client)
+	ids, err := client.SendBatch(context.Background(), queue, "batch.empty", []any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("expected no IDs, got %v", ids)
+	}
+	tick(t, client, queue)
+	msgs, err := client.Receive(context.Background(), queue, consumer, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 0 {
+		t.Fatalf("expected no messages, got %d", len(msgs))
+	}
+}
+
+func TestSendBatchEmptyTypeDefaults(t *testing.T) {
+	client := connectOrSkip(t)
+	defer client.Close()
+	queue, consumer := setupFreshQueue(t, client)
+	if _, err := client.SendBatch(context.Background(), queue, "", []any{map[string]any{"x": 1}}); err != nil {
+		t.Fatal(err)
+	}
+	tick(t, client, queue)
+	msgs, err := client.Receive(context.Background(), queue, consumer, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 1 || msgs[0].Type != "default" {
+		t.Fatalf("expected one default message, got %#v", msgs)
+	}
+}
+
+func TestSendBatchNilPayloadProducesJSONNull(t *testing.T) {
+	client := connectOrSkip(t)
+	defer client.Close()
+	queue, consumer := setupFreshQueue(t, client)
+	if _, err := client.SendBatch(context.Background(), queue, "batch.null", []any{nil}); err != nil {
+		t.Fatal(err)
+	}
+	tick(t, client, queue)
+	msgs, err := client.Receive(context.Background(), queue, consumer, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 1 || msgs[0].Payload != "null" {
+		t.Fatalf("expected JSON null payload, got %#v", msgs)
+	}
+}
+
+func TestSendBatchMissingQueue(t *testing.T) {
+	client := connectOrSkip(t)
+	defer client.Close()
+	_, err := client.SendBatch(context.Background(), "missing_"+randSuffix(t), "x", []any{map[string]any{"x": 1}})
+	if err == nil {
+		t.Fatal("expected missing queue error")
+	}
+}
+
+func TestSendBatchUnmarshalablePayload(t *testing.T) {
+	client := connectOrSkip(t)
+	defer client.Close()
+	queue, _ := setupFreshQueue(t, client)
+	_, err := client.SendBatch(context.Background(), queue, "x", []any{make(chan int)})
+	if err == nil {
+		t.Fatal("expected marshal error")
+	}
+}
+
 func TestSendAndReceive(t *testing.T) {
 	ctx := context.Background()
 	client, err := pgque.Connect(ctx, getDSN())

--- a/clients/go/pgque_test.go
+++ b/clients/go/pgque_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"sort"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -124,6 +125,7 @@ func TestSendBatch(t *testing.T) {
 	if len(msgs) != 3 {
 		t.Fatalf("expected 3 messages, got %d", len(msgs))
 	}
+	sort.Slice(msgs, func(i, j int) bool { return msgs[i].MsgID < msgs[j].MsgID })
 	for i, msg := range msgs {
 		if msg.Type != "batch.test" {
 			t.Fatalf("expected type batch.test, got %s", msg.Type)

--- a/clients/go/pgque_test.go
+++ b/clients/go/pgque_test.go
@@ -2,6 +2,7 @@ package pgque_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"sync/atomic"
@@ -96,14 +97,11 @@ func TestSend(t *testing.T) {
 
 func TestSendBatch(t *testing.T) {
 	ctx := context.Background()
-	client, err := pgque.Connect(ctx, getDSN())
-	if err != nil {
-		t.Skip("Cannot connect to PG:", err)
-	}
+	client := connectOrSkip(t)
 	defer client.Close()
-	setupQueue(t, client)
+	queue, consumer := setupFreshQueue(t, client)
 
-	ids, err := client.SendBatch(ctx, "gotest_queue", "batch.test", []any{
+	ids, err := client.SendBatch(ctx, queue, "batch.test", []any{
 		map[string]any{"n": 1},
 		map[string]any{"n": 2},
 		map[string]any{"n": 3},
@@ -118,19 +116,24 @@ func TestSendBatch(t *testing.T) {
 		t.Fatalf("expected IDs in input order, got %v", ids)
 	}
 
-	if _, err = client.Pool().Exec(ctx, "SELECT pgque.ticker('gotest_queue')"); err != nil {
-		t.Fatal(err)
-	}
-	msgs, err := client.Receive(ctx, "gotest_queue", "gotest_consumer", 10)
+	tick(t, client, queue)
+	msgs, err := client.Receive(ctx, queue, consumer, 10)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(msgs) != 3 {
 		t.Fatalf("expected 3 messages, got %d", len(msgs))
 	}
-	for _, msg := range msgs {
+	for i, msg := range msgs {
 		if msg.Type != "batch.test" {
 			t.Fatalf("expected type batch.test, got %s", msg.Type)
+		}
+		var payload map[string]int
+		if err := json.Unmarshal([]byte(msg.Payload), &payload); err != nil {
+			t.Fatal(err)
+		}
+		if payload["n"] != i+1 {
+			t.Fatalf("expected payload n=%d, got %v", i+1, payload)
 		}
 	}
 }

--- a/clients/go/producer_benchmark_test.go
+++ b/clients/go/producer_benchmark_test.go
@@ -13,14 +13,7 @@ import (
 	pgque "github.com/NikolayS/pgque/clients/go"
 )
 
-// TestProducerBenchmarks compares producer latency/throughput for the default
-// Go client API paths:
-//   - loop over Client.Send(...)
-//   - one Client.SendBatch(...) call
-//
-// It is opt-in because it is a microbenchmark-style integration test:
-//
-//	PGQUE_RUN_PRODUCER_BENCH=1 PGQUE_TEST_DSN=postgres://... go test -run TestProducerBenchmarks -v
+// TestProducerBenchmarks compares send-loop and SendBatch producer paths.
 func TestProducerBenchmarks(t *testing.T) {
 	if os.Getenv("PGQUE_RUN_PRODUCER_BENCH") != "1" {
 		t.Skip("PGQUE_RUN_PRODUCER_BENCH=1 not set")

--- a/clients/go/producer_benchmark_test.go
+++ b/clients/go/producer_benchmark_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+package pgque_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	pgque "github.com/NikolayS/pgque/clients/go"
+)
+
+// TestProducerBenchmarks compares producer latency/throughput for the default
+// Go client API paths:
+//   - loop over Client.Send(...)
+//   - one Client.SendBatch(...) call
+//
+// It is opt-in because it is a microbenchmark-style integration test:
+//
+//	PGQUE_RUN_PRODUCER_BENCH=1 PGQUE_TEST_DSN=postgres://... go test -run TestProducerBenchmarks -v
+func TestProducerBenchmarks(t *testing.T) {
+	if os.Getenv("PGQUE_RUN_PRODUCER_BENCH") != "1" {
+		t.Skip("PGQUE_RUN_PRODUCER_BENCH=1 not set")
+	}
+
+	client := connectOrSkip(t)
+	defer client.Close()
+
+	batchSizes := []int{1, 100, 1000}
+	repeats := 3
+	if raw := os.Getenv("PGQUE_BENCH_REPEATS"); raw != "" {
+		if _, err := fmt.Sscanf(raw, "%d", &repeats); err != nil || repeats < 1 {
+			t.Fatalf("invalid PGQUE_BENCH_REPEATS=%q", raw)
+		}
+	}
+
+	t.Log("# pgque Go producer benchmark")
+	t.Log("| method | batch_size | median_ms | events_per_sec | repeats |")
+	t.Log("|---|---:|---:|---:|---:|")
+	for _, n := range batchSizes {
+		measureProducer(t, client, "send_loop", n, repeats, sendLoopGo)
+		measureProducer(t, client, "send_batch", n, repeats, sendBatchGo)
+	}
+	t.Log("csv:language,method,batch_size,median_ms,events_per_sec,repeats")
+}
+
+type producerFn func(context.Context, *pgque.Client, string, []any) error
+
+func measureProducer(t *testing.T, client *pgque.Client, method string, n, repeats int, fn producerFn) {
+	t.Helper()
+	ctx := context.Background()
+	durations := make([]time.Duration, 0, repeats)
+	for r := 0; r < repeats; r++ {
+		queue := fmt.Sprintf("gobench_%s_%d_%s", method, n, randSuffix(t))
+		payloads := make([]any, n)
+		for i := range payloads {
+			payloads[i] = map[string]any{"i": i, "lang": "go", "method": method}
+		}
+		if _, err := client.Pool().Exec(ctx, "select pgque.create_queue($1)", queue); err != nil {
+			t.Fatal(err)
+		}
+		start := time.Now()
+		err := fn(ctx, client, queue, payloads)
+		elapsed := time.Since(start)
+		if err != nil {
+			client.Pool().Exec(ctx, "select pgque.drop_queue($1, true)", queue)
+			t.Fatal(err)
+		}
+		verifyProducerCount(t, ctx, client, queue, n)
+		durations = append(durations, elapsed)
+		if _, err := client.Pool().Exec(ctx, "select pgque.drop_queue($1, true)", queue); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	median := medianDuration(durations)
+	medianMs := float64(median) / float64(time.Millisecond)
+	eps := float64(n) / median.Seconds()
+	t.Logf("| %s | %d | %.3f | %.0f | %d |", method, n, medianMs, eps, repeats)
+	t.Logf("csv:go,%s,%d,%.3f,%.0f,%d", method, n, medianMs, eps, repeats)
+}
+
+func sendLoopGo(ctx context.Context, client *pgque.Client, queue string, payloads []any) error {
+	for _, payload := range payloads {
+		if _, err := client.Send(ctx, queue, pgque.Event{Type: "bench.producer", Payload: payload}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func sendBatchGo(ctx context.Context, client *pgque.Client, queue string, payloads []any) error {
+	_, err := client.SendBatch(ctx, queue, "bench.producer", payloads)
+	return err
+}
+
+func verifyProducerCount(t *testing.T, ctx context.Context, client *pgque.Client, queue string, expected int) {
+	t.Helper()
+	var table string
+	if err := client.Pool().QueryRow(ctx, "select pgque.current_event_table($1)", queue).Scan(&table); err != nil {
+		t.Fatal(err)
+	}
+	var got int
+	if err := client.Pool().QueryRow(ctx, "select count(*) from "+table).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != expected {
+		t.Fatalf("%s: expected %d events, got %d", queue, expected, got)
+	}
+}
+
+func medianDuration(values []time.Duration) time.Duration {
+	sorted := append([]time.Duration(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 1 {
+		return sorted[mid]
+	}
+	return (sorted[mid-1] + sorted[mid]) / 2
+}

--- a/clients/go/producer_benchmark_test.go
+++ b/clients/go/producer_benchmark_test.go
@@ -79,8 +79,19 @@ func measureProducer(t *testing.T, client *pgque.Client, method string, n, repea
 	median := medianDuration(durations)
 	medianMs := float64(median) / float64(time.Millisecond)
 	eps := float64(n) / median.Seconds()
-	t.Logf("| %s | %d | %.3f | %.0f | %d |", method, n, medianMs, eps, repeats)
+	t.Logf("| %s | %d | %.3f | %.0f | %d |", displayProducerMethod(method), n, medianMs, eps, repeats)
 	t.Logf("csv:go,%s,%d,%.3f,%.0f,%d", method, n, medianMs, eps, repeats)
+}
+
+func displayProducerMethod(method string) string {
+	switch method {
+	case "send_loop":
+		return "loop over Send()"
+	case "send_batch":
+		return "SendBatch()"
+	default:
+		return method
+	}
 }
 
 func sendLoopGo(ctx context.Context, client *pgque.Client, queue string, payloads []any) error {

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -45,10 +45,8 @@ def handle_order(msg: pgque.Message) -> None:
     print(f"got {msg.type}: {msg.payload}")
 
 # Optional: catch-all handler for types with no specific handler.
-# Without it, messages with unhandled types are logged at WARNING and
-# acked. Register a handler for that type or use a "*" catch-all to
-# handle them deliberately.
-# Note: Unhandled event types are acknowledged after a warning. Register a `*` handler if you want to fail/nack/route unknown types yourself.
+# Without it, messages with unhandled types are logged at WARNING and acked.
+# Register a `*` handler if you want to fail/nack/route unknown types yourself.
 @consumer.on("*")
 def handle_unknown(msg: pgque.Message) -> None:
     print(f"unhandled type {msg.type!r}: {msg.payload}")

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -26,6 +26,10 @@ with pgque.connect("postgresql://localhost/mydb") as client:
 
     # producer
     client.send("orders", {"order_id": 42}, type="order.created")
+    client.send_batch("orders", "order.created", [
+        {"order_id": 43},
+        {"order_id": 44},
+    ])
     client.conn.commit()
 
 # consumer (separate process / thread)

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -24,13 +24,14 @@ with pgque.connect("postgresql://localhost/mydb") as client:
     client.conn.execute("select pgque.subscribe('orders', 'order_worker')")
     client.conn.commit()
 
-    # producer
-    client.send("orders", {"order_id": 42}, type="order.created")
-    client.send_batch("orders", "order.created", [
+    # producer: commit once to publish both calls atomically
+    event_id = client.send("orders", {"order_id": 42}, type="order.created")
+    batch_ids = client.send_batch("orders", "order.created", [
         {"order_id": 43},
         {"order_id": 44},
     ])
     client.conn.commit()
+    print(event_id, batch_ids)
 
 # consumer (separate process / thread)
 consumer = pgque.Consumer(

--- a/clients/python/bench_producer.py
+++ b/clients/python/bench_producer.py
@@ -59,7 +59,7 @@ def main() -> int:
     print("| method | batch_size | median_ms | events_per_sec | repeats |")
     print("|---|---:|---:|---:|---:|")
     for r in results:
-        print(f"| {r.method} | {r.batch_size} | {r.median_ms:.3f} | {r.events_per_sec:.0f} | {r.repeats} |")
+        print(f"| {display_method(r.method)} | {r.batch_size} | {r.median_ms:.3f} | {r.events_per_sec:.0f} | {r.repeats} |")
 
     print()
     print("```csv")
@@ -98,6 +98,10 @@ def measure(client: pgque.PgqueClient, method: str, n: int, fn: Callable[[str, l
         events_per_sec=n / median_s if median_s > 0 else float("inf"),
         repeats=REPEATS,
     )
+
+
+def display_method(method: str) -> str:
+    return "loop over send()" if method == "send_loop" else "send_batch()"
 
 
 def send_loop(client: pgque.PgqueClient, queue: str, payloads: list[dict]) -> None:

--- a/clients/python/bench_producer.py
+++ b/clients/python/bench_producer.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+"""Producer microbenchmarks for pgque-py.
+
+Compares the default client API paths:
+
+- loop over ``client.send(queue, payload, type=...)``
+- one ``client.send_batch(queue, type, payloads)`` call
+
+Batch sizes are fixed at 1, 100, and 1000. Each measurement creates a fresh
+queue, publishes N events, commits, verifies the inserted row count, and drops
+the queue. Output is Markdown plus CSV-friendly rows.
+
+Usage:
+    PGQUE_TEST_DSN=postgresql://... python clients/python/bench_producer.py
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import statistics
+import sys
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import pgque
+
+DSN = os.environ.get("PGQUE_TEST_DSN")
+BATCH_SIZES = (1, 100, 1000)
+REPEATS = int(os.environ.get("PGQUE_BENCH_REPEATS", "3"))
+
+
+@dataclass(frozen=True)
+class Result:
+    language: str
+    method: str
+    batch_size: int
+    median_ms: float
+    events_per_sec: float
+    repeats: int
+
+
+def main() -> int:
+    if not DSN:
+        print("PGQUE_TEST_DSN not set; skipping pgque-py producer benchmarks")
+        return 0
+
+    results: list[Result] = []
+    with pgque.connect(DSN) as client:
+        for n in BATCH_SIZES:
+            results.append(measure(client, "send_loop", n, lambda q, payloads: send_loop(client, q, payloads)))
+            results.append(measure(client, "send_batch", n, lambda q, payloads: send_batch(client, q, payloads)))
+
+    print("# pgque-py producer benchmark")
+    print()
+    print("| method | batch_size | median_ms | events_per_sec | repeats |")
+    print("|---|---:|---:|---:|---:|")
+    for r in results:
+        print(f"| {r.method} | {r.batch_size} | {r.median_ms:.3f} | {r.events_per_sec:.0f} | {r.repeats} |")
+
+    print()
+    print("```csv")
+    print("language,method,batch_size,median_ms,events_per_sec,repeats")
+    for r in results:
+        print(f"{r.language},{r.method},{r.batch_size},{r.median_ms:.3f},{r.events_per_sec:.0f},{r.repeats}")
+    print("```")
+    return 0
+
+
+def measure(client: pgque.PgqueClient, method: str, n: int, fn: Callable[[str, list[dict]], None]) -> Result:
+    durations: list[float] = []
+    for _ in range(REPEATS):
+        queue = f"pybench_{method}_{n}_{secrets.token_hex(4)}"
+        payloads = [{"i": i, "lang": "python", "method": method} for i in range(n)]
+        client.conn.execute("select pgque.create_queue(%s)", (queue,))
+        client.conn.commit()
+        try:
+            start = time.perf_counter()
+            fn(queue, payloads)
+            client.conn.commit()
+            elapsed = time.perf_counter() - start
+            verify_count(client, queue, n)
+            durations.append(elapsed)
+        finally:
+            client.conn.rollback()
+            client.conn.execute("select pgque.drop_queue(%s, true)", (queue,))
+            client.conn.commit()
+
+    median_s = statistics.median(durations)
+    return Result(
+        language="python",
+        method=method,
+        batch_size=n,
+        median_ms=median_s * 1000,
+        events_per_sec=n / median_s if median_s > 0 else float("inf"),
+        repeats=REPEATS,
+    )
+
+
+def send_loop(client: pgque.PgqueClient, queue: str, payloads: list[dict]) -> None:
+    for payload in payloads:
+        client.send(queue, payload, type="bench.producer")
+
+
+def send_batch(client: pgque.PgqueClient, queue: str, payloads: list[dict]) -> None:
+    client.send_batch(queue, "bench.producer", payloads)
+
+
+def verify_count(client: pgque.PgqueClient, queue: str, expected: int) -> None:
+    table = client.conn.execute("select pgque.current_event_table(%s)", (queue,)).fetchone()[0]
+    got = client.conn.execute(f"select count(*) from {table}").fetchone()[0]
+    if got != expected:
+        raise RuntimeError(f"{queue}: expected {expected} events, got {got}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/clients/python/bench_producer.py
+++ b/clients/python/bench_producer.py
@@ -1,20 +1,7 @@
 #!/usr/bin/env python3
 # Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 
-"""Producer microbenchmarks for pgque-py.
-
-Compares the default client API paths:
-
-- loop over ``client.send(queue, payload, type=...)``
-- one ``client.send_batch(queue, type, payloads)`` call
-
-Batch sizes are fixed at 1, 100, and 1000. Each measurement creates a fresh
-queue, publishes N events, commits, verifies the inserted row count, and drops
-the queue. Output is Markdown plus CSV-friendly rows.
-
-Usage:
-    PGQUE_TEST_DSN=postgresql://... python clients/python/bench_producer.py
-"""
+"""Producer microbenchmarks for pgque-py send-loop vs send_batch."""
 
 from __future__ import annotations
 

--- a/clients/python/pgque/client.py
+++ b/clients/python/pgque/client.py
@@ -155,7 +155,7 @@ class PgqueClient:
         type: str,
         payloads: list,
     ) -> list[int]:
-        """Send same-type payloads atomically and return event IDs in input order."""
+        """Send same-type payloads atomically; str must be JSON text, None stores JSON null."""
         json_payloads = [
             json.dumps(p) if isinstance(p, (dict, list))
             else ("null" if p is None else p)

--- a/clients/python/pgque/client.py
+++ b/clients/python/pgque/client.py
@@ -155,7 +155,15 @@ class PgqueClient:
         type: str,
         payloads: list,
     ) -> list[int]:
-        """Send same-type payloads atomically; str must be JSON text, None stores JSON null."""
+        """Send multiple messages in one SQL call.
+
+        Maps to ``pgque.send_batch(queue, type, payloads[])`` and returns event
+        IDs in input order. The call is atomic inside the current transaction.
+
+        Payload encoding matches ``send``: ``dict``/``list`` values are JSON
+        encoded, ``str`` values must already be valid JSON text, and ``None`` is
+        stored as JSON ``null`` rather than SQL NULL.
+        """
         json_payloads = [
             json.dumps(p) if isinstance(p, (dict, list))
             else ("null" if p is None else p)

--- a/clients/python/pgque/client.py
+++ b/clients/python/pgque/client.py
@@ -155,21 +155,7 @@ class PgqueClient:
         type: str,
         payloads: list,
     ) -> list[int]:
-        """Send multiple messages in a single SQL call (one transaction).
-
-        Maps to ``pgque.send_batch(queue, type, payloads[])``.
-
-        Args:
-            queue: Target queue name.
-            type: Event type for all messages.
-            payloads: Each entry is JSON-encoded automatically if
-                ``dict``/``list``; ``str`` entries must be valid JSON
-                text (cast to ``jsonb`` by PostgreSQL); ``None`` is
-                stored as JSON ``null`` (same as ``send(None)``).
-
-        Returns:
-            List of event IDs in input order.
-        """
+        """Send same-type payloads atomically and return event IDs in input order."""
         json_payloads = [
             json.dumps(p) if isinstance(p, (dict, list))
             else ("null" if p is None else p)

--- a/clients/python/tests/test_send.py
+++ b/clients/python/tests/test_send.py
@@ -161,6 +161,8 @@ def test_jsonb_payload_round_trip(conn, setup_queue, payload, expected):
 
 def test_send_batch_none_payload_produces_json_null(conn, setup_queue):
     """send_batch([None]) must store JSON null, not SQL NULL."""
+    # send(None) coerces to JSON null via "null"; send_batch must match it.
+    # Passing Python None through psycopg as SQL NULL would bypass ::jsonb.
     import json
 
     queue, consumer = setup_queue

--- a/clients/python/tests/test_send.py
+++ b/clients/python/tests/test_send.py
@@ -160,12 +160,7 @@ def test_jsonb_payload_round_trip(conn, setup_queue, payload, expected):
 
 
 def test_send_batch_none_payload_produces_json_null(conn, setup_queue):
-    """send_batch([None]) must store JSON null, not SQL NULL.
-
-    Regression test for send/send_batch asymmetry: send(None) coerces to
-    JSON null via "null" string, but send_batch previously passed Python
-    None through psycopg as SQL NULL, bypassing the ::jsonb cast.
-    """
+    """send_batch([None]) must store JSON null, not SQL NULL."""
     import json
 
     queue, consumer = setup_queue

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -32,14 +32,15 @@ try {
   await client.subscribe('orders', 'order_worker');
 
   // Producer
-  await client.send('orders', {
+  const eventId = await client.send('orders', {
     type: 'order.created',
     payload: { id: 42 },
   });
-  await client.sendBatch('orders', 'order.created', [
+  const batchIds = await client.sendBatch('orders', 'order.created', [
     { id: 43 },
     { id: 44 },
   ]);
+  console.log('published', eventId, batchIds);
 
   // High-level consumer with per-event-type dispatch.
   // msg.payload is raw JSON text — call JSON.parse() to get the object back.
@@ -76,8 +77,8 @@ try {
 | `consumer.start(signal?)` | Run; resolves when `AbortSignal` aborts. |
 | `client.close()` | Drain the pool. |
 
-`Message.msgId`, `Message.batchId`, and the return value of `send()` are
-JS `bigint` to match PostgreSQL `bigint` losslessly.
+`Message.msgId`, `Message.batchId`, and the return values of `send()` /
+`sendBatch()` are JS `bigint` to match PostgreSQL `bigint` losslessly.
 
 ## Errors
 

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -36,6 +36,10 @@ try {
     type: 'order.created',
     payload: { id: 42 },
   });
+  await client.sendBatch('orders', 'order.created', [
+    { id: 43 },
+    { id: 44 },
+  ]);
 
   // High-level consumer with per-event-type dispatch.
   // msg.payload is raw JSON text — call JSON.parse() to get the object back.
@@ -59,6 +63,7 @@ try {
 |---|---|
 | `connect(dsn, poolOptions?)` | Connect via `pg.Pool`. Eagerly probes the connection. |
 | `client.send(queue, event)` | Publish; returns event id (`bigint`). |
+| `client.sendBatch(queue, type, payloads)` | Publish a same-type batch atomically; returns event ids (`bigint[]`). |
 | `client.receive(queue, consumer, max?)` | Fetch up to `max` (default 100) messages from the next batch. |
 | `client.ack(batchId)` | Finish the batch. |
 | `client.nack(batchId, msg, opts?)` | Single-message retry/DLQ. |

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -45,6 +45,7 @@
     "build": "tsc -p tsconfig.json",
     "check": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.test.json",
     "test": "vitest run",
+    "bench:producer": "bun src/producer_bench.ts",
     "test:watch": "vitest",
     "clean": "rm -rf dist"
   },

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -101,12 +101,7 @@ export class Client {
     }
   }
 
-  /**
-   * Publish multiple payloads with the same event type in one SQL call. Returns
-   * event IDs in input order. PostgreSQL executes the call atomically inside
-   * the caller's transaction: if any payload is rejected, no message from the
-   * batch is inserted.
-   */
+  /** Publish same-type payloads atomically; empty type defaults to `default`. */
   async sendBatch(queue: string, type: string, payloads: unknown[]): Promise<bigint[]> {
     if (!queue) {
       throw new PgqueSqlError('sendBatch', {

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -102,6 +102,45 @@ export class Client {
   }
 
   /**
+   * Publish multiple payloads with the same event type in one SQL call. Returns
+   * event IDs in input order. PostgreSQL executes the call atomically inside
+   * the caller's transaction: if any payload is rejected, no message from the
+   * batch is inserted.
+   */
+  async sendBatch(queue: string, type: string, payloads: unknown[]): Promise<bigint[]> {
+    if (!queue) {
+      throw new PgqueSqlError('sendBatch', {
+        cause: new Error('queue must be a non-empty string'),
+      });
+    }
+    const eventType = type && type.length > 0 ? type : 'default';
+    const encoded = payloads.map((payload, index) => {
+      try {
+        return JSON.stringify(payload) ?? 'null';
+      } catch (err) {
+        throw new PgqueSqlError('sendBatch', {
+          cause: new Error(`payload at index ${index} is not JSON-serializable`, { cause: err }),
+        });
+      }
+    });
+
+    try {
+      const result = await this.pool.query<{ send_batch: Array<bigint | string> }>(
+        'select pgque.send_batch($1, $2, $3::jsonb[]) as send_batch',
+        [queue, eventType, encoded],
+      );
+      const row = result.rows[0];
+      if (!row) {
+        throw new PgqueSqlError('sendBatch', { cause: new Error('no row returned') });
+      }
+      return row.send_batch.map((id) => (typeof id === 'bigint' ? id : BigInt(id)));
+    } catch (err) {
+      if (err instanceof PgqueError) throw err;
+      throw mapPgError('sendBatch', err, { queue });
+    }
+  }
+
+  /**
    * Fetch up to `maxMessages` from the next batch for `consumer` on `queue`.
    * Returns an empty array when no batch is currently available.
    */

--- a/clients/typescript/src/producer_bench.ts
+++ b/clients/typescript/src/producer_bench.ts
@@ -13,7 +13,7 @@
  * queue. Output is Markdown plus CSV-friendly rows.
  *
  * Usage:
- *   PGQUE_TEST_DSN=postgres://... npx tsx src/producer_bench.ts
+ *   PGQUE_TEST_DSN=postgresql://... bun src/producer_bench.ts
  */
 
 import { randomBytes } from 'node:crypto';

--- a/clients/typescript/src/producer_bench.ts
+++ b/clients/typescript/src/producer_bench.ts
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// pgque -- TypeScript client for PgQue
+// Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+/** Producer microbenchmarks for the TypeScript client.
+ *
+ * Compares the default client API paths:
+ * - loop over client.send(queue, event)
+ * - one client.sendBatch(queue, type, payloads) call
+ *
+ * Batch sizes are fixed at 1, 100, and 1000. Each measurement creates a fresh
+ * queue, publishes N events, verifies the inserted row count, and drops the
+ * queue. Output is Markdown plus CSV-friendly rows.
+ *
+ * Usage:
+ *   PGQUE_TEST_DSN=postgres://... npx tsx src/producer_bench.ts
+ */
+
+import { randomBytes } from 'node:crypto';
+import { performance } from 'node:perf_hooks';
+import { connect, type Client } from './client.js';
+
+const dsn = process.env.PGQUE_TEST_DSN;
+const batchSizes = [1, 100, 1000] as const;
+const repeats = Number.parseInt(process.env.PGQUE_BENCH_REPEATS ?? '3', 10);
+
+type Method = 'send_loop' | 'send_batch';
+type Payload = { i: number; lang: 'typescript'; method: Method };
+
+interface Result {
+  language: 'typescript';
+  method: Method;
+  batchSize: number;
+  medianMs: number;
+  eventsPerSec: number;
+  repeats: number;
+}
+
+async function main(): Promise<void> {
+  if (!dsn) {
+    console.log('PGQUE_TEST_DSN not set; skipping pgque TypeScript producer benchmarks');
+    return;
+  }
+
+  const client = await connect(dsn);
+  try {
+    const results: Result[] = [];
+    for (const n of batchSizes) {
+      results.push(await measure(client, 'send_loop', n, sendLoop));
+      results.push(await measure(client, 'send_batch', n, sendBatch));
+    }
+
+    console.log('# pgque TypeScript producer benchmark');
+    console.log();
+    console.log('| method | batch_size | median_ms | events_per_sec | repeats |');
+    console.log('|---|---:|---:|---:|---:|');
+    for (const r of results) {
+      console.log(`| ${r.method} | ${r.batchSize} | ${r.medianMs.toFixed(3)} | ${r.eventsPerSec.toFixed(0)} | ${r.repeats} |`);
+    }
+
+    console.log();
+    console.log('```csv');
+    console.log('language,method,batch_size,median_ms,events_per_sec,repeats');
+    for (const r of results) {
+      console.log(`${r.language},${r.method},${r.batchSize},${r.medianMs.toFixed(3)},${r.eventsPerSec.toFixed(0)},${r.repeats}`);
+    }
+    console.log('```');
+  } finally {
+    await client.close();
+  }
+}
+
+async function measure(
+  client: Client,
+  method: Method,
+  n: number,
+  fn: (client: Client, queue: string, payloads: Payload[]) => Promise<void>,
+): Promise<Result> {
+  const durations: number[] = [];
+  for (let r = 0; r < repeats; r++) {
+    const queue = `tsbench_${method}_${n}_${randomBytes(4).toString('hex')}`;
+    const payloads = Array.from({ length: n }, (_, i) => ({ i, lang: 'typescript' as const, method }));
+    await client.rawPool.query('select pgque.create_queue($1)', [queue]);
+    try {
+      const start = performance.now();
+      await fn(client, queue, payloads);
+      const elapsedMs = performance.now() - start;
+      await verifyCount(client, queue, n);
+      durations.push(elapsedMs);
+    } finally {
+      await client.rawPool.query('select pgque.drop_queue($1, true)', [queue]).catch(() => undefined);
+    }
+  }
+
+  const medianMs = median(durations);
+  return {
+    language: 'typescript',
+    method,
+    batchSize: n,
+    medianMs,
+    eventsPerSec: medianMs > 0 ? n / (medianMs / 1000) : Number.POSITIVE_INFINITY,
+    repeats,
+  };
+}
+
+async function sendLoop(client: Client, queue: string, payloads: Payload[]): Promise<void> {
+  for (const payload of payloads) {
+    await client.send(queue, { type: 'bench.producer', payload });
+  }
+}
+
+async function sendBatch(client: Client, queue: string, payloads: Payload[]): Promise<void> {
+  await client.sendBatch(queue, 'bench.producer', payloads);
+}
+
+async function verifyCount(client: Client, queue: string, expected: number): Promise<void> {
+  const tableResult = await client.rawPool.query<{ current_event_table: string }>(
+    'select pgque.current_event_table($1)',
+    [queue],
+  );
+  const table = tableResult.rows[0]?.current_event_table;
+  if (!table) throw new Error(`current_event_table returned no row for ${queue}`);
+  const countResult = await client.rawPool.query<{ count: string }>(`select count(*) from ${table}`);
+  const got = Number.parseInt(countResult.rows[0]?.count ?? 'NaN', 10);
+  if (got !== expected) {
+    throw new Error(`${queue}: expected ${expected} events, got ${got}`);
+  }
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) return sorted[mid]!;
+  return (sorted[mid - 1]! + sorted[mid]!) / 2;
+}
+
+main().catch((err) => {
+  console.error('pgque TypeScript producer benchmark: FAIL', err);
+  process.exit(1);
+});

--- a/clients/typescript/src/producer_bench.ts
+++ b/clients/typescript/src/producer_bench.ts
@@ -1,20 +1,8 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
 // pgque -- TypeScript client for PgQue
 // Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 
-/** Producer microbenchmarks for the TypeScript client.
- *
- * Compares the default client API paths:
- * - loop over client.send(queue, event)
- * - one client.sendBatch(queue, type, payloads) call
- *
- * Batch sizes are fixed at 1, 100, and 1000. Each measurement creates a fresh
- * queue, publishes N events, verifies the inserted row count, and drops the
- * queue. Output is Markdown plus CSV-friendly rows.
- *
- * Usage:
- *   PGQUE_TEST_DSN=postgresql://... bun src/producer_bench.ts
- */
+// Producer microbenchmarks for pgque TypeScript send-loop vs sendBatch.
 
 import { randomBytes } from 'node:crypto';
 import { performance } from 'node:perf_hooks';

--- a/clients/typescript/src/producer_bench.ts
+++ b/clients/typescript/src/producer_bench.ts
@@ -55,7 +55,7 @@ async function main(): Promise<void> {
     console.log('| method | batch_size | median_ms | events_per_sec | repeats |');
     console.log('|---|---:|---:|---:|---:|');
     for (const r of results) {
-      console.log(`| ${r.method} | ${r.batchSize} | ${r.medianMs.toFixed(3)} | ${r.eventsPerSec.toFixed(0)} | ${r.repeats} |`);
+      console.log(`| ${displayMethod(r.method)} | ${r.batchSize} | ${r.medianMs.toFixed(3)} | ${r.eventsPerSec.toFixed(0)} | ${r.repeats} |`);
     }
 
     console.log();
@@ -101,6 +101,10 @@ async function measure(
     eventsPerSec: medianMs > 0 ? n / (medianMs / 1000) : Number.POSITIVE_INFINITY,
     repeats,
   };
+}
+
+function displayMethod(method: Method): string {
+  return method === 'send_loop' ? 'loop over send()' : 'sendBatch()';
 }
 
 async function sendLoop(client: Client, queue: string, payloads: Payload[]): Promise<void> {

--- a/clients/typescript/test/client.test.ts
+++ b/clients/typescript/test/client.test.ts
@@ -85,6 +85,21 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
     await env.client.ack(msgs[0]!.batchId);
   });
 
+  skipIfNoDb('sendBatch accepts an empty array without inserting messages', async () => {
+    await expect(env.client.sendBatch(env.queue, 'batch.empty', [])).resolves.toEqual([]);
+    await advanceQueue(env.client, env.queue);
+    await expect(env.client.receive(env.queue, env.consumer, 10)).resolves.toEqual([]);
+  });
+
+  skipIfNoDb('sendBatch defaults empty event type to "default"', async () => {
+    await env.client.sendBatch(env.queue, '', [{ x: 1 }]);
+    await advanceQueue(env.client, env.queue);
+    const [msg] = await env.client.receive(env.queue, env.consumer, 10);
+    expect(msg).toBeDefined();
+    expect(msg!.type).toBe('default');
+    await env.client.ack(msg!.batchId);
+  });
+
   skipIfNoDb('defaults event type to "default" when omitted', async () => {
     await env.client.send(env.queue, { payload: { x: 1 } });
     await advanceQueue(env.client, env.queue);
@@ -105,6 +120,10 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
 
   skipIfNoDb('rejects empty queue name on send', async () => {
     await expect(env.client.send('', { payload: {} })).rejects.toBeInstanceOf(PgqueSqlError);
+  });
+
+  skipIfNoDb('rejects empty queue name on sendBatch', async () => {
+    await expect(env.client.sendBatch('', 'x', [{}])).rejects.toBeInstanceOf(PgqueSqlError);
   });
 
   skipIfNoDb('rejects empty queue name on receive', async () => {
@@ -136,6 +155,20 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
     await expect(
       env.client.send('does_not_exist_xyz', { payload: {} }),
     ).rejects.toBeInstanceOf(PgqueQueueNotFoundError);
+  });
+
+  skipIfNoDb('sendBatch to nonexistent queue raises PgqueQueueNotFoundError', async () => {
+    await expect(
+      env.client.sendBatch('does_not_exist_xyz', 'x', [{}]),
+    ).rejects.toBeInstanceOf(PgqueQueueNotFoundError);
+  });
+
+  skipIfNoDb('sendBatch rejects non-serializable payloads', async () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    await expect(env.client.sendBatch(env.queue, 'x', [circular])).rejects.toBeInstanceOf(
+      PgqueSqlError,
+    );
   });
 
   // ---------------------------------------------------------------------------

--- a/clients/typescript/test/client.test.ts
+++ b/clients/typescript/test/client.test.ts
@@ -66,6 +66,25 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
     expect(after).toEqual([]);
   });
 
+  skipIfNoDb('sendBatch publishes multiple payloads atomically', async () => {
+    const ids = await env.client.sendBatch(env.queue, 'batch.test', [
+      { n: 1 },
+      { n: 2 },
+      { n: 3 },
+    ]);
+    expect(ids).toHaveLength(3);
+    expect(ids[0]).toBeLessThan(ids[1]!);
+    expect(ids[1]).toBeLessThan(ids[2]!);
+
+    await advanceQueue(env.client, env.queue);
+
+    const msgs = await env.client.receive(env.queue, env.consumer, 10);
+    expect(msgs).toHaveLength(3);
+    expect(msgs.map((m) => m.type)).toEqual(['batch.test', 'batch.test', 'batch.test']);
+    expect(msgs.map((m) => JSON.parse(m.payload))).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
+    await env.client.ack(msgs[0]!.batchId);
+  });
+
   skipIfNoDb('defaults event type to "default" when omitted', async () => {
     await env.client.send(env.queue, { payload: { x: 1 } });
     await advanceQueue(env.client, env.queue);


### PR DESCRIPTION
## Summary

Expose **atomic batch send** as a first-class producer API in Go and TypeScript, document the existing Python batch API, and add comparable producer benchmarks for all three client libraries.

This PR is about the **final client interfaces**: application code should not need to hand-roll loops over `send()` when it wants to publish many messages as one logical batch.

## Before

Python had a batch method:

```python
client.send_batch("orders", "order.created", [
    {"order_id": 1},
    {"order_id": 2},
])
```

But Go and TypeScript users had to write loops over `send()`:

```go
for _, order := range orders {
    _, err := client.Send(ctx, "orders", pgque.Event{
        Type: "order.created",
        Payload: order,
    })
    if err != nil {
        return err
    }
}
```

```ts
for (const order of orders) {
  await client.send("orders", {
    type: "order.created",
    payload: order,
  });
}
```

Problems:

- one client/server round trip per message;
- no single logical batch boundary in the client API;
- harder retry/error handling at the app layer;
- Go/TS were less capable than Python despite the SQL API already supporting batch sends;
- users could easily miss that `pgque.send_batch(...)` exists.

## After

Go:

```go
ids, err := client.SendBatch(ctx, "orders", "order.created", []any{
    map[string]any{"order_id": 1},
    map[string]any{"order_id": 2},
})
```

TypeScript:

```ts
const ids = await client.sendBatch("orders", "order.created", [
  { order_id: 1 },
  { order_id: 2 },
]);
```

Python docs now show the already-existing equivalent:

```python
ids = client.send_batch("orders", "order.created", [
    {"order_id": 1},
    {"order_id": 2},
])
```

All three point at the same SQL-level contract:

```sql
select pgque.send_batch(queue, type, payloads[])
```

## Contract

A batch is one logical publish operation:

- one queue;
- one event type;
- many payloads;
- returned event IDs in input order;
- empty event type defaults to `default`;
- empty payload list returns an empty ID list;
- PostgreSQL executes the call atomically inside the caller's transaction.

If a payload cannot be encoded or the database rejects the call, no partial batch is reported as successful.

## Why this is better

### 1. Batch is visible in all final client interfaces

Batching becomes a normal producer operation, not something only SQL/Python users discover.

### 2. The API matches the actual product model

`sendBatch` / `send_batch` / `SendBatch` mirrors the existing safe SQL API instead of exposing table internals.

### 3. Atomicity is explicit

The client docs/comments say the important part plainly: the call is all-or-nothing inside the caller's transaction.

### 4. It removes client-side loops from the happy path

Go/TS users can make one call and let PgQue handle the batch boundary.

### 5. It composes with #159 instead of competing with it

This PR intentionally uses the existing same-type SQL shape:

```sql
pgque.send_batch(queue, type, payloads[])
```

If/when #159 (or its successor from #160) makes `send_batch()` set-based internally, these client APIs automatically benefit without changing public interfaces.

## Producer benchmarks

Added env-gated producer benchmarks for all three clients:

- Python: `clients/python/bench_producer.py`
- Go: `TestProducerBenchmarks` gated by `PGQUE_RUN_PRODUCER_BENCH=1`
- TypeScript: `bun run bench:producer`

Each benchmark compares:

1. `loop over send()`: loop over `send()` / `Send()` / `client.send()`;
2. batch API call: `send_batch()` / `SendBatch()` / `sendBatch()`;

for batch sizes **1, 100, 1000**. Each measurement creates a fresh queue, publishes N events, verifies inserted row count, drops the queue, and reports median latency + events/sec over 3 repeats.

Latest GitHub Actions `client-smoke` benchmark results (PostgreSQL 18 runner):

![PgQue client producer throughput: send loop vs batch API](https://raw.githubusercontent.com/NikolayS/pgque/feat/atomic-batch-interfaces/benchmark/charts/client_producer_batch_api.svg)

| language | method | batch_size | median_ms | events_per_sec |
|---|---|---:|---:|---:|
| python | loop over send() | 1 | 1.609 | 622 |
| python | send_batch | 1 | 1.267 | 790 |
| python | loop over send() | 100 | 31.822 | 3,142 |
| python | send_batch | 100 | 6.735 | 14,847 |
| python | loop over send() | 1000 | 300.820 | 3,324 |
| python | send_batch | 1000 | 55.683 | 17,959 |
| go | loop over Send() | 1 | 0.887 | 1,127 |
| go | send_batch | 1 | 0.899 | 1,112 |
| go | loop over Send() | 100 | 43.665 | 2,290 |
| go | send_batch | 100 | 5.707 | 17,522 |
| go | loop over Send() | 1000 | 423.223 | 2,363 |
| go | send_batch | 1000 | 49.425 | 20,233 |
| typescript | loop over send() | 1 | 2.041 | 490 |
| typescript | send_batch | 1 | 1.447 | 691 |
| typescript | loop over send() | 100 | 61.150 | 1,635 |
| typescript | send_batch | 100 | 6.258 | 15,980 |
| typescript | loop over send() | 1000 | 523.057 | 1,912 |
| typescript | send_batch | 1000 | 52.023 | 19,222 |

## Relationship to #159 and #160

This PR does **not** rewrite server-side `send_batch()`.

- #159: server-side implementation optimization — make `send_batch()` set-based.
- #160: benchmark/product analysis — `send_batch()` is the safe high-level batch API; direct `current_event_table()` / COPY remains the expert max-throughput path.
- This PR: expose and measure the safe high-level batch API consistently in client libraries.

Intended layering:

1. `send()` — simple single-message API.
2. `sendBatch` / `send_batch` / `SendBatch` — safe high-level app batching.
3. direct `current_event_table()` insert/COPY — expert throughput path.

## Changed files

- Go:
  - `Client.SendBatch(ctx, queue, type, payloads)`
  - live tests for IDs/order/payloads and edge cases
  - producer benchmark for 1/100/1000
  - README quickstart example
- TypeScript:
  - `client.sendBatch(queue, type, payloads)`
  - live tests for IDs/order/payloads and edge cases
  - producer benchmark for 1/100/1000 using Bun
  - README API + quickstart example
- Python:
  - README quickstart now shows existing `send_batch(...)`
  - producer benchmark for 1/100/1000
  - send_batch docs clarify payload encoding and transaction semantics
- CI:
  - `client-smoke` runs all three producer benchmarks and prints tables in logs.

## Tests

Latest evidence is posted in comments after the final rebase/fixes:

- CI green: `claude-review`, `client-smoke`, PG 14–18 matrix, `verify`
- REV via interactive Claude Code/tmux: no blocking issues
- Local TypeScript:
  - `bun run check`
  - `PGQUE_TEST_DSN=... bun run test` → 28 passed
  - `PGQUE_TEST_DSN=... bun src/smoke.ts`
  - `PGQUE_TEST_DSN=... bun run bench:producer`
- Local Python:
  - `PGQUE_TEST_DSN=... pytest -q clients/python/tests/test_send.py clients/python/tests/test_smoke.py` → 20 passed
  - `PGQUE_TEST_DSN=... python clients/python/bench_producer.py`
- Go local tests were not run on this host because no `go` binary is installed; GitHub `client-smoke` covers Go and passed.
