### PR TITLE
fix(roles): restore PgQ producer/consumer split (#102, #106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,13 @@ Treat installation as one-way for now — upgrade and reinstall paths are still 
 
 The install creates three roles. Application users do not need superuser — grant them whichever role matches their access pattern.
 
+PgQue mirrors upstream PgQ's split: `pgque_reader` (consume) and `pgque_writer` (produce) are **siblings**, not parent/child. `pgque_admin` is a member of both. Apps that produce **and** consume must be granted both roles explicitly.
+
 | Role | Purpose | Granted access |
 |---|---|---|
-| `pgque_reader` | Dashboards, metrics, debugging | `get_queue_info`, `get_consumer_info`, `get_batch_info`, `version`, plus `select` on all tables |
-| `pgque_writer` | Producers and consumers (most apps) | inherits `pgque_reader` + the modern API (`send`, `send_batch`, `subscribe`, `unsubscribe`, `receive`, `ack`, `nack`) and the underlying PgQ primitives (`insert_event`, `next_batch`, `get_batch_events`, `finish_batch`, `event_retry`, `register_consumer`, `unregister_consumer`) |
-| `pgque_admin`  | Operators, migrations | inherits `pgque_writer` + full schema/table/sequence access. `uninstall()` is revoked from both `pgque_admin` and PUBLIC (superuser-only — it drops the schema). |
+| `pgque_reader` | Consumers, dashboards, metrics, debugging | Read-only info (`get_queue_info`, `get_consumer_info`, `get_batch_info`, `version`, `select` on all tables) **and** the consume API (`subscribe`, `unsubscribe`, `receive`, `ack`, `nack`) plus the underlying PgQ primitives (`next_batch*`, `get_batch_events`, `finish_batch`, `event_retry`, `register_consumer*`, `unregister_consumer`). |
+| `pgque_writer` | Producers | The produce API (`send`, `send_batch`) and the underlying primitive (`insert_event`). Does **not** inherit `pgque_reader` — a producer-only role cannot ack/finish/inspect consumer batches (closes #102, #106). |
+| `pgque_admin`  | Operators, migrations | Member of both `pgque_reader` and `pgque_writer`, plus full schema/table/sequence access. `uninstall()` is revoked from both `pgque_admin` and PUBLIC (superuser-only — it drops the schema). |
 
 Typical app setup:
 
@@ -178,16 +180,23 @@ Typical app setup:
 \i sql/pgque.sql
 select pgque.start();                     -- optional pg_cron ticker + maint
 
+-- Produce + consume in the same app: grant BOTH roles.
 create user app_orders with password '...';          -- replace with a real password
+grant pgque_reader to app_orders;
 grant pgque_writer to app_orders;
 
+-- Pure producer (e.g. a webhook ingester that only sends).
+create user app_webhook with password '...';
+grant pgque_writer to app_webhook;
+
+-- Pure consumer / dashboard / metrics.
 create user metrics with password '...';              -- replace with a real password
 grant pgque_reader to metrics;
 ```
 
-DDL-class operations (`create_queue`, `drop_queue`, `start`, `stop`, `maint`, `maint_retry_events`, `ticker`, `force_tick`, `set_queue_config`) are not granted to `pgque_writer`. The schema-wide blanket `revoke execute … from public` strips PUBLIC, and `pgque_admin` is the only role that retains `execute` on these helpers — perform them as an admin / migration role.
+DDL-class operations (`create_queue`, `drop_queue`, `start`, `stop`, `maint`, `maint_retry_events`, `ticker`, `force_tick`, `set_queue_config`) are not granted to either `pgque_reader` or `pgque_writer`. The schema-wide blanket `revoke execute … from public` strips PUBLIC, and `pgque_admin` is the only role that retains `execute` on these helpers — perform them as an admin / migration role.
 
-**Roles are global, not per-queue.** `pgque_writer` can produce and consume on any queue and ack any consumer's batch. Do not grant `pgque_writer` to mutually untrusted applications sharing one database unless you add your own schema-level or database-level isolation. See [docs/reference.md — Roles scope](docs/reference.md#roles-are-global-not-per-queue) for details and recommended isolation patterns.
+**Roles are global, not per-queue.** A `pgque_reader` granted to an app can ack any consumer's batch and read any other consumer's active batch payloads. Do not grant `pgque_reader` to mutually untrusted applications sharing one database unless you add your own schema-level or database-level isolation. See [docs/reference.md — Roles scope](docs/reference.md#roles-are-global-not-per-queue) for details and recommended isolation patterns.
 
 ## Project status
 

--- a/README.md
+++ b/README.md
@@ -194,9 +194,7 @@ create user metrics with password '...';              -- replace with a real pas
 grant pgque_reader to metrics;
 ```
 
-### Upgrading from a pre-#163 install
-
-Pre-#163 PgQue granted `pgque_reader` to `pgque_writer` (writer inherited reader). #163 reverses that: the two are now siblings. **Existing deployments must take two manual steps after re-running `\i sql/pgque.sql`:**
+**Upgrading from a pre-#163 install.** Pre-#163 PgQue granted `pgque_reader` to `pgque_writer` (writer inherited reader). #163 reverses that: the two are now siblings. **Existing deployments must take two manual steps after re-running `\i sql/pgque.sql`:**
 
 1. The re-install **does** revoke the old `pgque_reader → pgque_writer` membership for you (idempotent `revoke` in `roles.sql`). No action needed for that part.
 2. Any application role that previously held `pgque_writer` and called `receive`/`ack`/`nack`/`subscribe`/`unsubscribe` will start failing with `permission denied`. Grant `pgque_reader` to those roles:
@@ -211,10 +209,13 @@ If you previously assumed a single role for both, audit which apps still need it
 
 ```sql
 -- Find roles holding pgque_writer that are missing pgque_reader.
-select rolname from pg_roles r
+-- (pgque_writer/postgres are excluded as obvious self-matches; pgque_admin
+-- is filtered transitively by the second predicate since it is a member of
+-- pgque_reader.)
+select rolname from pg_roles
  where pg_has_role(rolname, 'pgque_writer', 'MEMBER')
    and not pg_has_role(rolname, 'pgque_reader', 'MEMBER')
-   and rolname not in ('pgque_writer','pgque_admin','postgres');
+   and rolname not in ('pgque_writer','postgres');
 ```
 
 Then `grant pgque_reader to <each_role>;` per the audit. Pure producers (e.g. webhook ingesters that only `send()`) need no change.

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ PgQue mirrors upstream PgQ's split: `pgque_reader` (consume) and `pgque_writer` 
 | Role | Purpose | Granted access |
 |---|---|---|
 | `pgque_reader` | Consumers, dashboards, metrics, debugging | Read-only info (`get_queue_info`, `get_consumer_info`, `get_batch_info`, `version`, `select` on all tables) **and** the consume API (`subscribe`, `unsubscribe`, `receive`, `ack`, `nack`) plus the underlying PgQ primitives (`next_batch*`, `get_batch_events`, `finish_batch`, `event_retry`, `register_consumer*`, `unregister_consumer`). |
-| `pgque_writer` | Producers | The produce API (`send`, `send_batch`) and the underlying primitive (`insert_event`). Does **not** inherit `pgque_reader` — a producer-only role cannot ack/finish/inspect consumer batches (closes #102, #106). |
+| `pgque_writer` | Producers | The produce API (`send`, `send_batch`) and the underlying primitive (`insert_event`). Does **not** inherit `pgque_reader` — a producer-only role cannot ack/finish/inspect consumer batches (refs #102, #106). |
 | `pgque_admin`  | Operators, migrations | Member of both `pgque_reader` and `pgque_writer`, plus full schema/table/sequence access. `uninstall()` is revoked from both `pgque_admin` and PUBLIC (superuser-only — it drops the schema). |
 
 Typical app setup:
@@ -193,6 +193,31 @@ grant pgque_writer to app_webhook;
 create user metrics with password '...';              -- replace with a real password
 grant pgque_reader to metrics;
 ```
+
+### Upgrading from a pre-#163 install
+
+Pre-#163 PgQue granted `pgque_reader` to `pgque_writer` (writer inherited reader). #163 reverses that: the two are now siblings. **Existing deployments must take two manual steps after re-running `\i sql/pgque.sql`:**
+
+1. The re-install **does** revoke the old `pgque_reader → pgque_writer` membership for you (idempotent `revoke` in `roles.sql`). No action needed for that part.
+2. Any application role that previously held `pgque_writer` and called `receive`/`ack`/`nack`/`subscribe`/`unsubscribe` will start failing with `permission denied`. Grant `pgque_reader` to those roles:
+
+```sql
+-- Apps that produce AND consume:
+grant pgque_reader to app_orders;
+-- (pgque_writer is already granted; nothing to revoke from it.)
+```
+
+If you previously assumed a single role for both, audit which apps still need it:
+
+```sql
+-- Find roles holding pgque_writer that are missing pgque_reader.
+select rolname from pg_roles r
+ where pg_has_role(rolname, 'pgque_writer', 'MEMBER')
+   and not pg_has_role(rolname, 'pgque_reader', 'MEMBER')
+   and rolname not in ('pgque_writer','pgque_admin','postgres');
+```
+
+Then `grant pgque_reader to <each_role>;` per the audit. Pure producers (e.g. webhook ingesters that only `send()`) need no change.
 
 DDL-class operations (`create_queue`, `drop_queue`, `start`, `stop`, `maint`, `maint_retry_events`, `ticker`, `force_tick`, `set_queue_config`) are not granted to either `pgque_reader` or `pgque_writer`. The schema-wide blanket `revoke execute … from public` strips PUBLIC, and `pgque_admin` is the only role that retains `execute` on these helpers — perform them as an admin / migration role.
 

--- a/blueprints/PHASES.md
+++ b/blueprints/PHASES.md
@@ -60,8 +60,10 @@ Available but most users should prefer the modern API above. See
 - `pgque.jsontriga()`, `pgque.logutriga()`, `pgque.sqltriga()`
 
 ### Roles
-- `pgque_reader`, `pgque_writer`, `pgque_admin` (with inheritance
-  `admin > writer > reader`)
+- `pgque_reader` (consume) and `pgque_writer` (produce) are siblings —
+  neither inherits the other, mirroring upstream PgQ.
+- `pgque_admin` is a member of both `pgque_reader` and `pgque_writer`.
+- Apps that produce **and** consume must be granted both roles explicitly.
 
 ## Experimental SQL (`sql/experimental/`)
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -67,10 +67,12 @@ Grant: `pgque_writer`. Source: `sql/pgque-api/send.sql`.
 
 The consume API wraps `pgque.next_batch`, `pgque.get_batch_events`, `pgque.finish_batch`, and `pgque.event_retry`. Typical loop: `receive` → process → `ack` (or `nack` on failure).
 
+All consume-side functions (`receive`, `ack`, `nack`, `subscribe`, `unsubscribe`) are granted to `pgque_reader`, mirroring upstream PgQ's producer/consumer role split. Apps that both produce and consume must hold both `pgque_reader` and `pgque_writer` — `pgque_writer` does not inherit `pgque_reader` (see issues #102, #106).
+
 #### `pgque.receive(queue text, consumer text, max_return int default 100) → setof pgque.message`
 
 Pulls the next batch for `consumer` on `queue` and streams up to `max_return` messages. `max_return` must be >= 1; passing 0 or a negative value raises an error. Returns an empty set if no batch is available. Each row is a `pgque.message` composite (see [§Message type](#message-type)).
-Grant: `pgque_writer`. Source: `sql/pgque-api/receive.sql`.
+Grant: `pgque_reader`. Source: `sql/pgque-api/receive.sql`.
 
 ```sql
 select * from pgque.receive('orders', 'processor', 100);
@@ -81,7 +83,7 @@ select * from pgque.receive('orders', 'processor', 100);
 #### `pgque.ack(batch_id bigint) → integer`
 
 Closes the batch and advances the consumer position. Modern alias for `pgque.finish_batch`. Returns `1` on success, `0` if the batch was not found.
-Grant: `pgque_writer`. Source: `sql/pgque-api/receive.sql`.
+Grant: `pgque_reader`. Source: `sql/pgque-api/receive.sql`.
 
 #### `pgque.nack(batch_id bigint, msg pgque.message, retry_after interval default '60 seconds', reason text default null) → integer`
 
@@ -90,7 +92,7 @@ Negative-acknowledges one message. Only `msg.msg_id` (and the `batch_id` argumen
 - If the canonical `ev_retry` is below the queue's `max_retries`, re-queues after `retry_after` (via `pgque.event_retry`).
 - If `ev_retry >= max_retries`, routes the canonical event to `pgque.dead_letter` (via `pgque.event_dead`). This is idempotent: repeated calls for the same terminal message produce exactly one DLQ row (the second call does nothing).
 - If `msg.msg_id` is not present in the active batch — including a `NULL` msg_id or a msg_id from a different batch — raises `msg_id % not found in batch %`.
-Grant: `pgque_writer`. Source: `sql/pgque-api/receive.sql`.
+Grant: `pgque_reader`. Source: `sql/pgque-api/receive.sql`.
 
 ```sql
 perform pgque.nack(msg.batch_id, msg, interval '5 minutes', 'validation failed');
@@ -99,12 +101,12 @@ perform pgque.nack(msg.batch_id, msg, interval '5 minutes', 'validation failed')
 #### `pgque.subscribe(queue text, consumer text) → integer`
 
 Registers `consumer` on `queue`. Modern alias for `pgque.register_consumer`. Returns `1` on new registration, `0` if already registered.
-Grant: `pgque_writer`. Source: `sql/pgque-api/send.sql`.
+Grant: `pgque_reader`. Source: `sql/pgque-api/send.sql`.
 
 #### `pgque.unsubscribe(queue text, consumer text) → integer`
 
 Removes the consumer (and its retry-queue entries) from `queue`. Modern alias for `pgque.unregister_consumer`.
-Grant: `pgque_writer`. Source: `sql/pgque-api/send.sql`.
+Grant: `pgque_reader`. Source: `sql/pgque-api/send.sql`.
 
 ## Queue management
 
@@ -200,7 +202,7 @@ Grant: superuser / schema owner only (revoked from both `pgque_admin` and PUBLIC
 
 ## Observability
 
-All observability functions here are granted to `pgque_reader` and flow up to `pgque_writer` and `pgque_admin` via role inheritance.
+All observability functions here are granted to `pgque_reader`. They flow up to `pgque_admin` (which is a member of both `pgque_reader` and `pgque_writer`) but do **not** flow to `pgque_writer` — that role is producer-only and does not inherit reader privileges. Apps that produce + consume must hold both roles.
 
 #### `pgque.get_queue_info() → setof record`
 
@@ -437,7 +439,9 @@ Returned by `pgque.receive()` and consumed by `pgque.nack()`.
 
 ## Roles and grants
 
-Three roles, with inheritance `pgque_admin > pgque_writer > pgque_reader`. Source: `sql/pgque-additions/roles.sql` (plus colocated grants in `sql/pgque-api/*.sql` and `sql/pgque-additions/dlq.sql`).
+Three roles. `pgque_reader` (consume) and `pgque_writer` (produce) are **siblings**, not parent/child — this mirrors upstream PgQ's role model and prevents a producer-only role from acking another consumer's batch (#102, #106). `pgque_admin` is a member of both. Source: `sql/pgque-additions/roles.sql` (plus colocated grants in `sql/pgque-api/*.sql` and `sql/pgque-additions/dlq.sql`).
+
+Apps that produce **and** consume must be granted both `pgque_reader` and `pgque_writer` explicitly.
 
 ### Roles are global, not per-queue
 
@@ -445,11 +449,11 @@ PgQue roles are coarse **database-level** roles. They are intended for trusted a
 
 **What this means in practice:**
 
-- `pgque_reader` gets `select` on **all** tables in the `pgque` schema — it can read events from any queue.
-- `pgque_writer` can call `receive`, `ack`, and `nack` on **any** queue with **any** consumer name. A writer granted for queue A can call `pgque.ack(batch_id)` on a batch opened by a consumer on queue B.
-- There is **no per-queue ACL** and no per-tenant isolation built into PgQue. Queue names and consumer names are plain strings — any writer who knows them can interact with them.
+- `pgque_reader` gets `select` on **all** tables in the `pgque` schema — it can read events from any queue. It can also call `receive`, `ack`, and `nack` on **any** queue with **any** consumer name. A reader granted for queue A can call `pgque.ack(batch_id)` on a batch opened by a consumer on queue B.
+- `pgque_writer` can produce to **any** queue (`pgque.send`, `pgque.send_batch`, `pgque.insert_event`).
+- There is **no per-queue ACL** and no per-tenant isolation built into PgQue. Queue names and consumer names are plain strings — any role with the matching grant can interact with them.
 
-This is an intentional design decision for the current release. The batch-ID-based primitives (`ack`, `nack`, `event_retry`) operate on IDs and do not enforce ownership.
+This is an intentional design decision for the current release. The batch-ID-based primitives (`ack`, `nack`, `event_retry`) operate on IDs and do not enforce ownership; the producer/consumer split closes only the producer-vs-consumer boundary, not the consumer-vs-consumer one.
 
 **Recommended isolation patterns** if you need mutually untrusted tenants in one database:
 
@@ -459,9 +463,9 @@ This is an intentional design decision for the current release. The batch-ID-bas
 
 | Role           | Functions granted (direct)                                                                                                                                                                                                                                              |
 |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `pgque_reader` | `get_queue_info()`, `get_queue_info(text)`, `get_consumer_info()`, `get_consumer_info(text)`, `get_consumer_info(text, text)`, `get_batch_info(bigint)`, `version()`, `dlq_inspect(text, int)`; `select` on all tables incl. `pgque.dead_letter`                        |
-| `pgque_writer` | everything `pgque_reader` has, plus `insert_event` (3, 7), `register_consumer`, `register_consumer_at`, `unregister_consumer`, `next_batch`, `next_batch_info`, `next_batch_custom`, `get_batch_events`, `finish_batch`, `event_retry` (int, timestamptz), all `send*`, `send_batch*`, `subscribe`, `unsubscribe`, `receive`, `ack`, `nack`, `dlq_replay`, `dlq_replay_all` |
-| `pgque_admin`  | everything `pgque_writer` has, plus `event_dead`, `dlq_purge`, `all` on `pgque` schema, `all` on all tables and sequences, `execute` on all functions — **except** `uninstall()` which is explicitly revoked                                                            |
+| `pgque_reader` | `get_queue_info()`, `get_queue_info(text)`, `get_consumer_info()`, `get_consumer_info(text)`, `get_consumer_info(text, text)`, `get_batch_info(bigint)`, `version()`, `dlq_inspect(text, int)`; `select` on all tables incl. `pgque.dead_letter`; consumer primitives (`register_consumer`, `register_consumer_at`, `unregister_consumer`, `next_batch`, `next_batch_info`, `next_batch_custom`, `get_batch_events`, `finish_batch`, `event_retry` int + timestamptz); modern consume API (`subscribe`, `unsubscribe`, `receive`, `ack`, `nack`)                        |
+| `pgque_writer` | `insert_event` (3, 7), all `send*`, `send_batch*`, `dlq_replay`, `dlq_replay_all`. **Does not inherit `pgque_reader`** — a producer-only role cannot ack/finish/inspect consumer batches. |
+| `pgque_admin`  | Member of both `pgque_reader` and `pgque_writer`, plus `event_dead`, `dlq_purge`, `all` on `pgque` schema, `all` on all tables and sequences, `execute` on all functions — **except** `uninstall()` which is explicitly revoked                                                            |
 
 `pgque.uninstall()` is revoked from both `pgque_admin` (explicitly) and PUBLIC (via the schema-wide blanket revoke). Only the schema/install owner (typically a superuser) can run it. All other functions not listed in the table above retain `execute` only for `pgque_admin` (the schema-wide blanket revoke from PUBLIC applies, and `pgque_admin` is granted `execute on all functions`) — notably the lifecycle helpers `start`, `stop`, `status`, `maint`, `maint_retry_events`, `ticker`, `force_tick`, and the queue-management helpers `create_queue`, `drop_queue`, `set_queue_config`. Grant these explicitly to additional roles if your policy demands it.
 

--- a/sql/pgque-additions/roles.sql
+++ b/sql/pgque-additions/roles.sql
@@ -18,6 +18,15 @@ do $$ begin create role pgque_admin;  exception when duplicate_object then null;
 -- (issue #106). Apps that both produce and consume must be granted BOTH
 -- pgque_reader and pgque_writer explicitly.
 --
+-- Upgrade path (CRITICAL): pre-#163 installs granted pgque_reader to
+-- pgque_writer. Postgres does NOT revoke prior role grants on re-install,
+-- so we must do it explicitly. Without this, in-place upgrades silently
+-- retain the vulnerable inheritance and the security fix is a no-op.
+do $$ begin
+    revoke pgque_reader from pgque_writer;
+exception when undefined_object then null;
+end $$;
+
 -- Wrapped in exception handlers for PG14/15 compatibility (no IF NOT EXISTS
 -- for role grants until PG16).
 do $$ begin
@@ -51,6 +60,23 @@ grant execute on function pgque.get_batch_info(bigint) to pgque_reader;
 
 -- version
 grant execute on function pgque.version() to pgque_reader;
+
+-- Upgrade path (CRITICAL): the consumer-side primitives below moved from
+-- pgque_writer to pgque_reader in #163. Postgres preserves function-level
+-- grants across `create or replace function`, so a re-install on a pre-#163
+-- database silently keeps the old pgque_writer grants. Explicitly revoke
+-- before re-granting. Each revoke is idempotent (no-op if the grant doesn't
+-- exist).
+revoke execute on function pgque.register_consumer(text, text) from pgque_writer;
+revoke execute on function pgque.register_consumer_at(text, text, bigint) from pgque_writer;
+revoke execute on function pgque.unregister_consumer(text, text) from pgque_writer;
+revoke execute on function pgque.next_batch(text, text) from pgque_writer;
+revoke execute on function pgque.next_batch_info(text, text) from pgque_writer;
+revoke execute on function pgque.next_batch_custom(text, text, interval, int4, interval) from pgque_writer;
+revoke execute on function pgque.get_batch_events(bigint) from pgque_writer;
+revoke execute on function pgque.finish_batch(bigint) from pgque_writer;
+revoke execute on function pgque.event_retry(bigint, bigint, timestamptz) from pgque_writer;
+revoke execute on function pgque.event_retry(bigint, bigint, integer) from pgque_writer;
 
 -- consumer registration (consumer side: create/move/drop a subscription cursor)
 grant execute on function pgque.register_consumer(text, text) to pgque_reader;

--- a/sql/pgque-additions/roles.sql
+++ b/sql/pgque-additions/roles.sql
@@ -6,11 +6,22 @@ do $$ begin create role pgque_reader; exception when duplicate_object then null;
 do $$ begin create role pgque_writer; exception when duplicate_object then null; end $$;
 do $$ begin create role pgque_admin;  exception when duplicate_object then null; end $$;
 
--- Inheritance: admin > writer > reader
+-- Role hierarchy: pgque_admin inherits both pgque_reader and pgque_writer.
+-- pgque_reader and pgque_writer are SIBLINGS, not parent/child — this matches
+-- upstream PgQ's `create role pgq_admin in role pgq_reader, pgq_writer;`
+-- model.
+--
+-- Why siblings, not writer-inherits-reader: a producer-only role MUST NOT be
+-- able to call consumer-side primitives like finish_batch / ack / next_batch.
+-- Otherwise any role that can pgque.send() can also ack any consumer's batch
+-- by id (issue #102) and read/mutate other consumers' active batches
+-- (issue #106). Apps that both produce and consume must be granted BOTH
+-- pgque_reader and pgque_writer explicitly.
+--
 -- Wrapped in exception handlers for PG14/15 compatibility (no IF NOT EXISTS
 -- for role grants until PG16).
 do $$ begin
-    grant pgque_reader to pgque_writer;
+    grant pgque_reader to pgque_admin;
 exception when duplicate_object then null;
 end $$;
 do $$ begin
@@ -19,7 +30,9 @@ exception when duplicate_object then null;
 end $$;
 
 -- ---------------------------------------------------------------------------
--- Reader: read-only access to schema and information functions
+-- Reader: consume events. Includes batch processing primitives — registering
+-- consumers, opening/closing batches, retrying events. Mirrors PgQ's
+-- pgq_reader role.
 -- ---------------------------------------------------------------------------
 grant usage on schema pgque to pgque_reader;
 grant select on all tables in schema pgque to pgque_reader;
@@ -39,35 +52,36 @@ grant execute on function pgque.get_batch_info(bigint) to pgque_reader;
 -- version
 grant execute on function pgque.version() to pgque_reader;
 
+-- consumer registration (consumer side: create/move/drop a subscription cursor)
+grant execute on function pgque.register_consumer(text, text) to pgque_reader;
+grant execute on function pgque.register_consumer_at(text, text, bigint) to pgque_reader;
+grant execute on function pgque.unregister_consumer(text, text) to pgque_reader;
+
+-- batch processing
+grant execute on function pgque.next_batch(text, text) to pgque_reader;
+grant execute on function pgque.next_batch_info(text, text) to pgque_reader;
+grant execute on function pgque.next_batch_custom(text, text, interval, int4, interval) to pgque_reader;
+grant execute on function pgque.get_batch_events(bigint) to pgque_reader;
+grant execute on function pgque.finish_batch(bigint) to pgque_reader;
+
+-- event retry — timestamptz and integer overloads
+grant execute on function pgque.event_retry(bigint, bigint, timestamptz) to pgque_reader;
+grant execute on function pgque.event_retry(bigint, bigint, integer) to pgque_reader;
+
 -- ---------------------------------------------------------------------------
--- Writer: can produce events and manage consumer lifecycle
+-- Writer: produce events. Strictly producer-side primitives.
 -- ---------------------------------------------------------------------------
 
 -- insert_event — 3-arg and 7-arg overloads
 grant execute on function pgque.insert_event(text, text, text) to pgque_writer;
 grant execute on function pgque.insert_event(text, text, text, text, text, text, text) to pgque_writer;
 
--- consumer registration
-grant execute on function pgque.register_consumer(text, text) to pgque_writer;
-grant execute on function pgque.register_consumer_at(text, text, bigint) to pgque_writer;
-grant execute on function pgque.unregister_consumer(text, text) to pgque_writer;
-
--- batch processing
-grant execute on function pgque.next_batch(text, text) to pgque_writer;
-grant execute on function pgque.next_batch_info(text, text) to pgque_writer;
-grant execute on function pgque.next_batch_custom(text, text, interval, int4, interval) to pgque_writer;
-grant execute on function pgque.get_batch_events(bigint) to pgque_writer;
-grant execute on function pgque.finish_batch(bigint) to pgque_writer;
-
--- event retry — timestamptz and integer overloads
-grant execute on function pgque.event_retry(bigint, bigint, timestamptz) to pgque_writer;
-grant execute on function pgque.event_retry(bigint, bigint, integer) to pgque_writer;
-
 -- Note: grants for the modern API wrappers (send*, subscribe, unsubscribe,
 -- receive, ack, nack) live colocated with their definitions in
 -- sql/pgque-api/*.sql. transform.sh appends pgque-additions/ before
 -- pgque-api/, so API-layer grants cannot reference their functions from
--- this file.
+-- this file. send* go to pgque_writer; subscribe/unsubscribe/receive/ack/nack
+-- go to pgque_reader.
 
 -- Deny-by-default: revoke PUBLIC EXECUTE so role grants below are authoritative.
 revoke execute on all functions in schema pgque from public;

--- a/sql/pgque-api/receive.sql
+++ b/sql/pgque-api/receive.sql
@@ -139,6 +139,11 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 -- ---------------------------------------------------------------------------
 -- Grants
 -- ---------------------------------------------------------------------------
-grant execute on function pgque.receive(text, text, int)                      to pgque_writer;
-grant execute on function pgque.ack(bigint)                                   to pgque_writer;
-grant execute on function pgque.nack(bigint, pgque.message, interval, text)   to pgque_writer;
+-- receive/ack/nack are consumer-side: they open/close batches and route
+-- failed events to retry/DLQ. They go to pgque_reader, not pgque_writer.
+-- Apps that both produce and consume must hold both roles. See
+-- sql/pgque-additions/roles.sql for the producer/consumer split rationale
+-- (closes #102, #106).
+grant execute on function pgque.receive(text, text, int)                      to pgque_reader;
+grant execute on function pgque.ack(bigint)                                   to pgque_reader;
+grant execute on function pgque.nack(bigint, pgque.message, interval, text)   to pgque_reader;

--- a/sql/pgque-api/receive.sql
+++ b/sql/pgque-api/receive.sql
@@ -143,7 +143,15 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 -- failed events to retry/DLQ. They go to pgque_reader, not pgque_writer.
 -- Apps that both produce and consume must hold both roles. See
 -- sql/pgque-additions/roles.sql for the producer/consumer split rationale
--- (closes #102, #106).
+-- (refs #102, #106; producer→consumer half. Consumer→consumer ownership
+-- is tracked separately in #164.)
+--
+-- Upgrade path: pre-#163 installs granted these to pgque_writer. Postgres
+-- preserves function-level grants across `create or replace function`, so
+-- explicitly revoke before re-granting on the new role.
+revoke execute on function pgque.receive(text, text, int)                    from pgque_writer;
+revoke execute on function pgque.ack(bigint)                                 from pgque_writer;
+revoke execute on function pgque.nack(bigint, pgque.message, interval, text) from pgque_writer;
 grant execute on function pgque.receive(text, text, int)                      to pgque_reader;
 grant execute on function pgque.ack(bigint)                                   to pgque_reader;
 grant execute on function pgque.nack(bigint, pgque.message, interval, text)   to pgque_reader;

--- a/sql/pgque-api/send.sql
+++ b/sql/pgque-api/send.sql
@@ -141,6 +141,12 @@ grant execute on function pgque.send(text, text, jsonb)         to pgque_writer;
 grant execute on function pgque.send(text, text, text)          to pgque_writer;
 grant execute on function pgque.send_batch(text, text, jsonb[]) to pgque_writer;
 grant execute on function pgque.send_batch(text, text, text[])  to pgque_writer;
+-- Upgrade path: pre-#163 installs granted subscribe/unsubscribe to
+-- pgque_writer. Revoke explicitly before re-granting on pgque_reader so
+-- in-place upgrades clear the old grants (create or replace function
+-- preserves function-level grants).
+revoke execute on function pgque.subscribe(text, text)         from pgque_writer;
+revoke execute on function pgque.unsubscribe(text, text)       from pgque_writer;
 grant execute on function pgque.subscribe(text, text)           to pgque_reader;
 grant execute on function pgque.unsubscribe(text, text)         to pgque_reader;
 

--- a/sql/pgque-api/send.sql
+++ b/sql/pgque-api/send.sql
@@ -131,14 +131,18 @@ end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
 -- Grants for the send* + subscribe/unsubscribe family.
+-- send* are producer-side (insert events) -> pgque_writer.
+-- subscribe/unsubscribe are consumer-side (manage subscription cursor) ->
+-- pgque_reader. See sql/pgque-additions/roles.sql for the producer/consumer
+-- split rationale.
 grant execute on function pgque.send(text, jsonb)               to pgque_writer;
 grant execute on function pgque.send(text, text)                to pgque_writer;
 grant execute on function pgque.send(text, text, jsonb)         to pgque_writer;
 grant execute on function pgque.send(text, text, text)          to pgque_writer;
 grant execute on function pgque.send_batch(text, text, jsonb[]) to pgque_writer;
 grant execute on function pgque.send_batch(text, text, text[])  to pgque_writer;
-grant execute on function pgque.subscribe(text, text)           to pgque_writer;
-grant execute on function pgque.unsubscribe(text, text)         to pgque_writer;
+grant execute on function pgque.subscribe(text, text)           to pgque_reader;
+grant execute on function pgque.unsubscribe(text, text)         to pgque_reader;
 
 -- Re-apply deny-by-default after all API functions are defined.
 -- roles.sql's blanket revoke runs before pgque-api/ files are loaded, so

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -4218,6 +4218,15 @@ do $$ begin create role pgque_admin;  exception when duplicate_object then null;
 -- (issue #106). Apps that both produce and consume must be granted BOTH
 -- pgque_reader and pgque_writer explicitly.
 --
+-- Upgrade path (CRITICAL): pre-#163 installs granted pgque_reader to
+-- pgque_writer. Postgres does NOT revoke prior role grants on re-install,
+-- so we must do it explicitly. Without this, in-place upgrades silently
+-- retain the vulnerable inheritance and the security fix is a no-op.
+do $$ begin
+    revoke pgque_reader from pgque_writer;
+exception when undefined_object then null;
+end $$;
+
 -- Wrapped in exception handlers for PG14/15 compatibility (no IF NOT EXISTS
 -- for role grants until PG16).
 do $$ begin
@@ -4251,6 +4260,23 @@ grant execute on function pgque.get_batch_info(bigint) to pgque_reader;
 
 -- version
 grant execute on function pgque.version() to pgque_reader;
+
+-- Upgrade path (CRITICAL): the consumer-side primitives below moved from
+-- pgque_writer to pgque_reader in #163. Postgres preserves function-level
+-- grants across `create or replace function`, so a re-install on a pre-#163
+-- database silently keeps the old pgque_writer grants. Explicitly revoke
+-- before re-granting. Each revoke is idempotent (no-op if the grant doesn't
+-- exist).
+revoke execute on function pgque.register_consumer(text, text) from pgque_writer;
+revoke execute on function pgque.register_consumer_at(text, text, bigint) from pgque_writer;
+revoke execute on function pgque.unregister_consumer(text, text) from pgque_writer;
+revoke execute on function pgque.next_batch(text, text) from pgque_writer;
+revoke execute on function pgque.next_batch_info(text, text) from pgque_writer;
+revoke execute on function pgque.next_batch_custom(text, text, interval, int4, interval) from pgque_writer;
+revoke execute on function pgque.get_batch_events(bigint) from pgque_writer;
+revoke execute on function pgque.finish_batch(bigint) from pgque_writer;
+revoke execute on function pgque.event_retry(bigint, bigint, timestamptz) from pgque_writer;
+revoke execute on function pgque.event_retry(bigint, bigint, integer) from pgque_writer;
 
 -- consumer registration (consumer side: create/move/drop a subscription cursor)
 grant execute on function pgque.register_consumer(text, text) to pgque_reader;
@@ -4747,7 +4773,15 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 -- failed events to retry/DLQ. They go to pgque_reader, not pgque_writer.
 -- Apps that both produce and consume must hold both roles. See
 -- sql/pgque-additions/roles.sql for the producer/consumer split rationale
--- (closes #102, #106).
+-- (refs #102, #106; producer→consumer half. Consumer→consumer ownership
+-- is tracked separately in #164.)
+--
+-- Upgrade path: pre-#163 installs granted these to pgque_writer. Postgres
+-- preserves function-level grants across `create or replace function`, so
+-- explicitly revoke before re-granting on the new role.
+revoke execute on function pgque.receive(text, text, int)                    from pgque_writer;
+revoke execute on function pgque.ack(bigint)                                 from pgque_writer;
+revoke execute on function pgque.nack(bigint, pgque.message, interval, text) from pgque_writer;
 grant execute on function pgque.receive(text, text, int)                      to pgque_reader;
 grant execute on function pgque.ack(bigint)                                   to pgque_reader;
 grant execute on function pgque.nack(bigint, pgque.message, interval, text)   to pgque_reader;
@@ -4896,6 +4930,12 @@ grant execute on function pgque.send(text, text, jsonb)         to pgque_writer;
 grant execute on function pgque.send(text, text, text)          to pgque_writer;
 grant execute on function pgque.send_batch(text, text, jsonb[]) to pgque_writer;
 grant execute on function pgque.send_batch(text, text, text[])  to pgque_writer;
+-- Upgrade path: pre-#163 installs granted subscribe/unsubscribe to
+-- pgque_writer. Revoke explicitly before re-granting on pgque_reader so
+-- in-place upgrades clear the old grants (create or replace function
+-- preserves function-level grants).
+revoke execute on function pgque.subscribe(text, text)         from pgque_writer;
+revoke execute on function pgque.unsubscribe(text, text)       from pgque_writer;
 grant execute on function pgque.subscribe(text, text)           to pgque_reader;
 grant execute on function pgque.unsubscribe(text, text)         to pgque_reader;
 

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -4206,11 +4206,22 @@ do $$ begin create role pgque_reader; exception when duplicate_object then null;
 do $$ begin create role pgque_writer; exception when duplicate_object then null; end $$;
 do $$ begin create role pgque_admin;  exception when duplicate_object then null; end $$;
 
--- Inheritance: admin > writer > reader
+-- Role hierarchy: pgque_admin inherits both pgque_reader and pgque_writer.
+-- pgque_reader and pgque_writer are SIBLINGS, not parent/child — this matches
+-- upstream PgQ's `create role pgq_admin in role pgq_reader, pgq_writer;`
+-- model.
+--
+-- Why siblings, not writer-inherits-reader: a producer-only role MUST NOT be
+-- able to call consumer-side primitives like finish_batch / ack / next_batch.
+-- Otherwise any role that can pgque.send() can also ack any consumer's batch
+-- by id (issue #102) and read/mutate other consumers' active batches
+-- (issue #106). Apps that both produce and consume must be granted BOTH
+-- pgque_reader and pgque_writer explicitly.
+--
 -- Wrapped in exception handlers for PG14/15 compatibility (no IF NOT EXISTS
 -- for role grants until PG16).
 do $$ begin
-    grant pgque_reader to pgque_writer;
+    grant pgque_reader to pgque_admin;
 exception when duplicate_object then null;
 end $$;
 do $$ begin
@@ -4219,7 +4230,9 @@ exception when duplicate_object then null;
 end $$;
 
 -- ---------------------------------------------------------------------------
--- Reader: read-only access to schema and information functions
+-- Reader: consume events. Includes batch processing primitives — registering
+-- consumers, opening/closing batches, retrying events. Mirrors PgQ's
+-- pgq_reader role.
 -- ---------------------------------------------------------------------------
 grant usage on schema pgque to pgque_reader;
 grant select on all tables in schema pgque to pgque_reader;
@@ -4239,35 +4252,36 @@ grant execute on function pgque.get_batch_info(bigint) to pgque_reader;
 -- version
 grant execute on function pgque.version() to pgque_reader;
 
+-- consumer registration (consumer side: create/move/drop a subscription cursor)
+grant execute on function pgque.register_consumer(text, text) to pgque_reader;
+grant execute on function pgque.register_consumer_at(text, text, bigint) to pgque_reader;
+grant execute on function pgque.unregister_consumer(text, text) to pgque_reader;
+
+-- batch processing
+grant execute on function pgque.next_batch(text, text) to pgque_reader;
+grant execute on function pgque.next_batch_info(text, text) to pgque_reader;
+grant execute on function pgque.next_batch_custom(text, text, interval, int4, interval) to pgque_reader;
+grant execute on function pgque.get_batch_events(bigint) to pgque_reader;
+grant execute on function pgque.finish_batch(bigint) to pgque_reader;
+
+-- event retry — timestamptz and integer overloads
+grant execute on function pgque.event_retry(bigint, bigint, timestamptz) to pgque_reader;
+grant execute on function pgque.event_retry(bigint, bigint, integer) to pgque_reader;
+
 -- ---------------------------------------------------------------------------
--- Writer: can produce events and manage consumer lifecycle
+-- Writer: produce events. Strictly producer-side primitives.
 -- ---------------------------------------------------------------------------
 
 -- insert_event — 3-arg and 7-arg overloads
 grant execute on function pgque.insert_event(text, text, text) to pgque_writer;
 grant execute on function pgque.insert_event(text, text, text, text, text, text, text) to pgque_writer;
 
--- consumer registration
-grant execute on function pgque.register_consumer(text, text) to pgque_writer;
-grant execute on function pgque.register_consumer_at(text, text, bigint) to pgque_writer;
-grant execute on function pgque.unregister_consumer(text, text) to pgque_writer;
-
--- batch processing
-grant execute on function pgque.next_batch(text, text) to pgque_writer;
-grant execute on function pgque.next_batch_info(text, text) to pgque_writer;
-grant execute on function pgque.next_batch_custom(text, text, interval, int4, interval) to pgque_writer;
-grant execute on function pgque.get_batch_events(bigint) to pgque_writer;
-grant execute on function pgque.finish_batch(bigint) to pgque_writer;
-
--- event retry — timestamptz and integer overloads
-grant execute on function pgque.event_retry(bigint, bigint, timestamptz) to pgque_writer;
-grant execute on function pgque.event_retry(bigint, bigint, integer) to pgque_writer;
-
 -- Note: grants for the modern API wrappers (send*, subscribe, unsubscribe,
 -- receive, ack, nack) live colocated with their definitions in
 -- sql/pgque-api/*.sql. transform.sh appends pgque-additions/ before
 -- pgque-api/, so API-layer grants cannot reference their functions from
--- this file.
+-- this file. send* go to pgque_writer; subscribe/unsubscribe/receive/ack/nack
+-- go to pgque_reader.
 
 -- Deny-by-default: revoke PUBLIC EXECUTE so role grants below are authoritative.
 revoke execute on all functions in schema pgque from public;
@@ -4729,9 +4743,14 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 -- ---------------------------------------------------------------------------
 -- Grants
 -- ---------------------------------------------------------------------------
-grant execute on function pgque.receive(text, text, int)                      to pgque_writer;
-grant execute on function pgque.ack(bigint)                                   to pgque_writer;
-grant execute on function pgque.nack(bigint, pgque.message, interval, text)   to pgque_writer;
+-- receive/ack/nack are consumer-side: they open/close batches and route
+-- failed events to retry/DLQ. They go to pgque_reader, not pgque_writer.
+-- Apps that both produce and consume must hold both roles. See
+-- sql/pgque-additions/roles.sql for the producer/consumer split rationale
+-- (closes #102, #106).
+grant execute on function pgque.receive(text, text, int)                      to pgque_reader;
+grant execute on function pgque.ack(bigint)                                   to pgque_reader;
+grant execute on function pgque.nack(bigint, pgque.message, interval, text)   to pgque_reader;
 
 -- pgque-api/send.sql
 -- pgque-api/send.sql -- Modern send/subscribe API layer
@@ -4867,18 +4886,23 @@ end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
 -- Grants for the send* + subscribe/unsubscribe family.
+-- send* are producer-side (insert events) -> pgque_writer.
+-- subscribe/unsubscribe are consumer-side (manage subscription cursor) ->
+-- pgque_reader. See sql/pgque-additions/roles.sql for the producer/consumer
+-- split rationale.
 grant execute on function pgque.send(text, jsonb)               to pgque_writer;
 grant execute on function pgque.send(text, text)                to pgque_writer;
 grant execute on function pgque.send(text, text, jsonb)         to pgque_writer;
 grant execute on function pgque.send(text, text, text)          to pgque_writer;
 grant execute on function pgque.send_batch(text, text, jsonb[]) to pgque_writer;
 grant execute on function pgque.send_batch(text, text, text[])  to pgque_writer;
-grant execute on function pgque.subscribe(text, text)           to pgque_writer;
-grant execute on function pgque.unsubscribe(text, text)         to pgque_writer;
+grant execute on function pgque.subscribe(text, text)           to pgque_reader;
+grant execute on function pgque.unsubscribe(text, text)         to pgque_reader;
 
 -- Re-apply deny-by-default after all API functions are defined.
 -- roles.sql's blanket revoke runs before pgque-api/ files are loaded, so
 -- functions created here would otherwise inherit PostgreSQL's default
 -- PUBLIC EXECUTE. This second pass covers everything.
 revoke execute on all functions in schema pgque from public;
+
 

--- a/tests/run_all.sql
+++ b/tests/run_all.sql
@@ -28,6 +28,9 @@
 \echo 'Running: test_security_extra_maint'
 \i tests/test_security_extra_maint.sql
 
+\echo 'Running: test_security_producer_isolation'
+\i tests/test_security_producer_isolation.sql
+
 \echo 'Running: test_core_lifecycle'
 \i tests/test_core_lifecycle.sql
 

--- a/tests/test_pgque_roles.sql
+++ b/tests/test_pgque_roles.sql
@@ -59,7 +59,17 @@ begin
   assert not has_function_privilege('pgque_writer', 'pgque.register_consumer_at(text, text, bigint)', 'EXECUTE'),
     'pgque_writer must NOT have execute on register_consumer_at(...) (#106)';
   assert not has_function_privilege('pgque_writer', 'pgque.event_retry(bigint, bigint, integer)', 'EXECUTE'),
-    'pgque_writer must NOT have execute on event_retry(...) (#106)';
+    'pgque_writer must NOT have execute on event_retry(int) (#106)';
+  assert not has_function_privilege('pgque_writer', 'pgque.event_retry(bigint, bigint, timestamptz)', 'EXECUTE'),
+    'pgque_writer must NOT have execute on event_retry(timestamptz) (#106)';
+  assert not has_function_privilege('pgque_writer', 'pgque.next_batch_info(text, text)', 'EXECUTE'),
+    'pgque_writer must NOT have execute on next_batch_info(text, text) (#106)';
+  assert not has_function_privilege('pgque_writer', 'pgque.next_batch_custom(text, text, interval, int4, interval)', 'EXECUTE'),
+    'pgque_writer must NOT have execute on next_batch_custom(...) (#106)';
+  assert not has_function_privilege('pgque_writer', 'pgque.register_consumer(text, text)', 'EXECUTE'),
+    'pgque_writer must NOT have execute on register_consumer(text, text) (#106)';
+  assert not has_function_privilege('pgque_writer', 'pgque.unregister_consumer(text, text)', 'EXECUTE'),
+    'pgque_writer must NOT have execute on unregister_consumer(text, text) (#106)';
   assert not has_function_privilege('pgque_writer', 'pgque.subscribe(text, text)', 'EXECUTE'),
     'pgque_writer must NOT have execute on subscribe(text, text) (#106)';
 

--- a/tests/test_pgque_roles.sql
+++ b/tests/test_pgque_roles.sql
@@ -26,20 +26,49 @@ begin
   assert has_function_privilege('pgque_writer', 'pgque.send_batch(text, text, text[])', 'EXECUTE'),
     'pgque_writer should have execute on send_batch(text, text, text[])';
 
-  -- subscribe/unsubscribe wrappers
-  assert has_function_privilege('pgque_writer', 'pgque.subscribe(text, text)', 'EXECUTE'),
-    'pgque_writer should have execute on subscribe(text, text)';
-  assert has_function_privilege('pgque_writer', 'pgque.unsubscribe(text, text)', 'EXECUTE'),
-    'pgque_writer should have execute on unsubscribe(text, text)';
+  -- subscribe/unsubscribe are consumer-side -> pgque_reader.
+  assert has_function_privilege('pgque_reader', 'pgque.subscribe(text, text)', 'EXECUTE'),
+    'pgque_reader should have execute on subscribe(text, text)';
+  assert has_function_privilege('pgque_reader', 'pgque.unsubscribe(text, text)', 'EXECUTE'),
+    'pgque_reader should have execute on unsubscribe(text, text)';
 
-  -- receive/ack/nack — explicit grants colocated with the function
-  -- definitions in sql/pgque-api/receive.sql (same convention as send.sql).
-  assert has_function_privilege('pgque_writer', 'pgque.receive(text, text, integer)', 'EXECUTE'),
-    'pgque_writer should have execute on receive(text, text, integer)';
-  assert has_function_privilege('pgque_writer', 'pgque.ack(bigint)', 'EXECUTE'),
-    'pgque_writer should have execute on ack(bigint)';
-  assert has_function_privilege('pgque_writer', 'pgque.nack(bigint, pgque.message, interval, text)', 'EXECUTE'),
-    'pgque_writer should have execute on nack(bigint, pgque.message, interval, text)';
+  -- receive/ack/nack are consumer-side -> pgque_reader (mirrors PgQ's split).
+  assert has_function_privilege('pgque_reader', 'pgque.receive(text, text, integer)', 'EXECUTE'),
+    'pgque_reader should have execute on receive(text, text, integer)';
+  assert has_function_privilege('pgque_reader', 'pgque.ack(bigint)', 'EXECUTE'),
+    'pgque_reader should have execute on ack(bigint)';
+  assert has_function_privilege('pgque_reader', 'pgque.nack(bigint, pgque.message, interval, text)', 'EXECUTE'),
+    'pgque_reader should have execute on nack(bigint, pgque.message, interval, text)';
+
+  -- Producer/consumer split (#102, #106): pgque_writer must NOT inherit
+  -- consumer-side primitives. Apps that both produce and consume hold both
+  -- roles; pure producers cannot ack/finish/inspect another consumer's
+  -- batch by id.
+  assert not has_function_privilege('pgque_writer', 'pgque.ack(bigint)', 'EXECUTE'),
+    'pgque_writer must NOT have execute on ack(bigint) (#102)';
+  assert not has_function_privilege('pgque_writer', 'pgque.nack(bigint, pgque.message, interval, text)', 'EXECUTE'),
+    'pgque_writer must NOT have execute on nack(...) (#102)';
+  assert not has_function_privilege('pgque_writer', 'pgque.receive(text, text, integer)', 'EXECUTE'),
+    'pgque_writer must NOT have execute on receive(...) (#106)';
+  assert not has_function_privilege('pgque_writer', 'pgque.finish_batch(bigint)', 'EXECUTE'),
+    'pgque_writer must NOT have execute on finish_batch(bigint) (#102)';
+  assert not has_function_privilege('pgque_writer', 'pgque.next_batch(text, text)', 'EXECUTE'),
+    'pgque_writer must NOT have execute on next_batch(text, text) (#106)';
+  assert not has_function_privilege('pgque_writer', 'pgque.get_batch_events(bigint)', 'EXECUTE'),
+    'pgque_writer must NOT have execute on get_batch_events(bigint) (#106)';
+  assert not has_function_privilege('pgque_writer', 'pgque.register_consumer_at(text, text, bigint)', 'EXECUTE'),
+    'pgque_writer must NOT have execute on register_consumer_at(...) (#106)';
+  assert not has_function_privilege('pgque_writer', 'pgque.event_retry(bigint, bigint, integer)', 'EXECUTE'),
+    'pgque_writer must NOT have execute on event_retry(...) (#106)';
+  assert not has_function_privilege('pgque_writer', 'pgque.subscribe(text, text)', 'EXECUTE'),
+    'pgque_writer must NOT have execute on subscribe(text, text) (#106)';
+
+  -- pgque_admin still inherits both: should retain access to consumer-side
+  -- functions via membership in pgque_reader.
+  assert has_function_privilege('pgque_admin', 'pgque.ack(bigint)', 'EXECUTE'),
+    'pgque_admin should have execute on ack(bigint) via pgque_reader';
+  assert has_function_privilege('pgque_admin', 'pgque.send(text, jsonb)', 'EXECUTE'),
+    'pgque_admin should have execute on send(text, jsonb) via pgque_writer';
 
   -- uninstall() must be superuser-only: execute is revoked from both
   -- pgque_admin and PUBLIC. Any non-superuser role (including pgque_admin,

--- a/tests/test_security_producer_isolation.sql
+++ b/tests/test_security_producer_isolation.sql
@@ -8,27 +8,45 @@
 -- must be granted both roles explicitly. See sql/pgque-additions/roles.sql.
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 
+-- Idempotent preamble: clean up any leftovers from a prior aborted run so
+-- a re-run on a shared dev DB does not error on duplicate objects. This must
+-- come before any setup so create_queue / create role can run unconditionally.
+do $$
+begin
+    if exists (select 1 from pg_roles where rolname = 'producer_only') then
+        revoke all privileges on schema pgque from producer_only;
+        revoke pgque_writer from producer_only;
+        drop role producer_only;
+    end if;
+    if exists (select 1 from pg_roles where rolname = 'consumer_only') then
+        revoke all privileges on schema pgque from consumer_only;
+        revoke pgque_reader from consumer_only;
+        drop role consumer_only;
+    end if;
+exception when others then
+    raise notice 'preamble cleanup: % / %', sqlstate, sqlerrm;
+end $$;
+
+do $$
+begin
+    if exists (select 1 from pgque.queue where queue_name = 'q_iso') then
+        perform pgque.drop_queue('q_iso', true);
+    end if;
+exception when others then
+    raise notice 'preamble queue cleanup: % / %', sqlstate, sqlerrm;
+end $$;
+
 -- Setup -----------------------------------------------------------------------
 
--- Pure producer (only pgque_writer).
-do $$ begin
-    create role producer_only login;
-exception when duplicate_object then null;
-end $$;
-do $$ begin
-    grant pgque_writer to producer_only;
-exception when duplicate_object then null;
-end $$;
+-- Pure producer (only pgque_writer). NOLOGIN — `set role` does not require
+-- LOGIN, and a NOLOGIN role can't be authenticated against directly even if
+-- this test aborts before cleanup.
+create role producer_only nologin;
+grant pgque_writer to producer_only;
 
 -- Pure consumer (only pgque_reader).
-do $$ begin
-    create role consumer_only login;
-exception when duplicate_object then null;
-end $$;
-do $$ begin
-    grant pgque_reader to consumer_only;
-exception when duplicate_object then null;
-end $$;
+create role consumer_only nologin;
+grant pgque_reader to consumer_only;
 
 -- Need a queue + subscription so we have a real batch_id to attempt against.
 select pgque.create_queue('q_iso');
@@ -118,32 +136,44 @@ declare
 begin
     begin
         perform pgque.get_batch_events(v_bid);
-        raise exception 'FAIL #106-C: producer_only read victim batch payloads';
+        raise exception 'FAIL #106-B: producer_only read victim batch payloads';
     exception
         when insufficient_privilege then
-            raise notice 'PASS #106-C (get_batch_events): denied';
+            raise notice 'PASS #106-B (get_batch_events): denied';
         when others then
-            raise exception 'FAIL #106-C: unexpected error: % / %', sqlstate, sqlerrm;
+            raise exception 'FAIL #106-B: unexpected error: % / %', sqlstate, sqlerrm;
     end;
 end $$;
 
 -- #106-C: producer_only must not be able to event_retry victim's events.
+-- Cover both overloads (integer and timestamptz) — they are separate function
+-- privilege rows.
 do $$
 declare
     v_bid bigint := current_setting('pgque_test.victim_batch_id')::bigint;
 begin
     begin
         perform pgque.event_retry(v_bid, 0::bigint, 0);
-        raise exception 'FAIL #106-B: producer_only retried victim event';
+        raise exception 'FAIL #106-C: producer_only retried victim event (int overload)';
     exception
         when insufficient_privilege then
-            raise notice 'PASS #106-B (event_retry): denied';
+            raise notice 'PASS #106-C (event_retry int): denied';
         when others then
-            raise exception 'FAIL #106-B: unexpected error: % / %', sqlstate, sqlerrm;
+            raise exception 'FAIL #106-C: unexpected error: % / %', sqlstate, sqlerrm;
+    end;
+
+    begin
+        perform pgque.event_retry(v_bid, 0::bigint, now());
+        raise exception 'FAIL #106-C: producer_only retried victim event (timestamptz overload)';
+    exception
+        when insufficient_privilege then
+            raise notice 'PASS #106-C (event_retry timestamptz): denied';
+        when others then
+            raise exception 'FAIL #106-C: unexpected error: % / %', sqlstate, sqlerrm;
     end;
 end $$;
 
--- And receive() / next_batch() must be denied too.
+-- next_batch must be denied.
 do $$
 begin
     begin
@@ -152,6 +182,21 @@ begin
     exception
         when insufficient_privilege then
             raise notice 'PASS: producer_only denied execute on pgque.next_batch';
+        when others then
+            raise exception 'FAIL: unexpected error: % / %', sqlstate, sqlerrm;
+    end;
+end $$;
+
+-- receive() (the modern wrapper) must be denied. Distinct from next_batch:
+-- receive is the high-level consume API and has its own grant.
+do $$
+begin
+    begin
+        perform * from pgque.receive('q_iso', 'victim', 10);
+        raise exception 'FAIL: producer_only received messages via pgque.receive';
+    exception
+        when insufficient_privilege then
+            raise notice 'PASS: producer_only denied execute on pgque.receive';
         when others then
             raise exception 'FAIL: unexpected error: % / %', sqlstate, sqlerrm;
     end;

--- a/tests/test_security_producer_isolation.sql
+++ b/tests/test_security_producer_isolation.sql
@@ -1,0 +1,191 @@
+-- test_security_producer_isolation.sql
+-- Regression test for #102 / #106: a producer-only role (pgque_writer
+-- without pgque_reader membership) must not be able to ack/finish/inspect
+-- another consumer's batch by id.
+--
+-- This locks in PgQ's original producer/consumer split: pgque_reader and
+-- pgque_writer are siblings, not parent/child. Apps that produce and consume
+-- must be granted both roles explicitly. See sql/pgque-additions/roles.sql.
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+-- Setup -----------------------------------------------------------------------
+
+-- Pure producer (only pgque_writer).
+do $$ begin
+    create role producer_only login;
+exception when duplicate_object then null;
+end $$;
+do $$ begin
+    grant pgque_writer to producer_only;
+exception when duplicate_object then null;
+end $$;
+
+-- Pure consumer (only pgque_reader).
+do $$ begin
+    create role consumer_only login;
+exception when duplicate_object then null;
+end $$;
+do $$ begin
+    grant pgque_reader to consumer_only;
+exception when duplicate_object then null;
+end $$;
+
+-- Need a queue + subscription so we have a real batch_id to attempt against.
+select pgque.create_queue('q_iso');
+select pgque.subscribe('q_iso', 'victim');
+
+-- Producer publishes one event and ticks the queue so a batch is available.
+select pgque.send('q_iso', 'evt', '{"k":1}'::jsonb);
+select pgque.force_tick('q_iso');
+select pgque.ticker('q_iso');
+
+-- Victim opens a batch (under pgque_reader privileges).
+set role consumer_only;
+do $$
+declare
+    v_count int;
+begin
+    select count(*) into v_count
+    from pgque.receive('q_iso', 'victim', 10);
+    assert v_count = 1, format('victim should have received 1 message, got %s', v_count);
+
+    -- Stash the active batch_id for the attacker test below.
+    perform set_config(
+        'pgque_test.victim_batch_id',
+        (select sub_batch::text
+           from pgque.subscription s
+           join pgque.queue q on q.queue_id = s.sub_queue
+           join pgque.consumer c on c.co_id = s.sub_consumer
+          where q.queue_name = 'q_iso' and c.co_name = 'victim'),
+        false);
+end $$;
+reset role;
+
+-- Attacker tests (#102, #106) -------------------------------------------------
+
+set role producer_only;
+
+-- #102: producer_only must not be able to ack the victim's batch.
+do $$
+declare
+    v_bid bigint := current_setting('pgque_test.victim_batch_id')::bigint;
+begin
+    begin
+        perform pgque.ack(v_bid);
+        raise exception 'FAIL #102: producer_only acked victim batch %', v_bid;
+    exception
+        when insufficient_privilege then
+            raise notice 'PASS #102 (ack): producer_only denied execute on pgque.ack(bigint)';
+        when others then
+            raise exception 'FAIL #102: unexpected error: % / %', sqlstate, sqlerrm;
+    end;
+end $$;
+
+-- #102 (low-level): same on pgque.finish_batch().
+do $$
+declare
+    v_bid bigint := current_setting('pgque_test.victim_batch_id')::bigint;
+begin
+    begin
+        perform pgque.finish_batch(v_bid);
+        raise exception 'FAIL #102: producer_only finished victim batch %', v_bid;
+    exception
+        when insufficient_privilege then
+            raise notice 'PASS #102 (finish_batch): producer_only denied execute on pgque.finish_batch';
+        when others then
+            raise exception 'FAIL #102: unexpected error: % / %', sqlstate, sqlerrm;
+    end;
+end $$;
+
+-- #106-A: producer_only must not be able to reposition victim's cursor.
+do $$
+begin
+    begin
+        perform pgque.register_consumer_at('q_iso', 'victim', 0);
+        raise exception 'FAIL #106-A: producer_only repositioned victim cursor';
+    exception
+        when insufficient_privilege then
+            raise notice 'PASS #106-A (register_consumer_at): denied';
+        when others then
+            raise exception 'FAIL #106-A: unexpected error: % / %', sqlstate, sqlerrm;
+    end;
+end $$;
+
+-- #106-B: producer_only must not be able to read victim's active batch payloads.
+do $$
+declare
+    v_bid bigint := current_setting('pgque_test.victim_batch_id')::bigint;
+begin
+    begin
+        perform pgque.get_batch_events(v_bid);
+        raise exception 'FAIL #106-C: producer_only read victim batch payloads';
+    exception
+        when insufficient_privilege then
+            raise notice 'PASS #106-C (get_batch_events): denied';
+        when others then
+            raise exception 'FAIL #106-C: unexpected error: % / %', sqlstate, sqlerrm;
+    end;
+end $$;
+
+-- #106-C: producer_only must not be able to event_retry victim's events.
+do $$
+declare
+    v_bid bigint := current_setting('pgque_test.victim_batch_id')::bigint;
+begin
+    begin
+        perform pgque.event_retry(v_bid, 0::bigint, 0);
+        raise exception 'FAIL #106-B: producer_only retried victim event';
+    exception
+        when insufficient_privilege then
+            raise notice 'PASS #106-B (event_retry): denied';
+        when others then
+            raise exception 'FAIL #106-B: unexpected error: % / %', sqlstate, sqlerrm;
+    end;
+end $$;
+
+-- And receive() / next_batch() must be denied too.
+do $$
+begin
+    begin
+        perform pgque.next_batch('q_iso', 'victim');
+        raise exception 'FAIL: producer_only opened a batch via next_batch';
+    exception
+        when insufficient_privilege then
+            raise notice 'PASS: producer_only denied execute on pgque.next_batch';
+        when others then
+            raise exception 'FAIL: unexpected error: % / %', sqlstate, sqlerrm;
+    end;
+end $$;
+
+reset role;
+
+-- Sanity: pgque_admin still has both via membership. ---------------------------
+do $$
+begin
+    assert has_function_privilege('pgque_admin', 'pgque.ack(bigint)', 'EXECUTE'),
+        'pgque_admin should retain ack via pgque_reader membership';
+    assert has_function_privilege('pgque_admin', 'pgque.send(text, jsonb)', 'EXECUTE'),
+        'pgque_admin should retain send via pgque_writer membership';
+end $$;
+
+-- Cleanup ---------------------------------------------------------------------
+
+-- Let the victim ack its batch so drop_queue does not fail on a held batch.
+set role consumer_only;
+do $$
+declare
+    v_bid bigint := current_setting('pgque_test.victim_batch_id')::bigint;
+begin
+    perform pgque.ack(v_bid);
+end $$;
+reset role;
+
+select pgque.unsubscribe('q_iso', 'victim');
+select pgque.drop_queue('q_iso', true);
+
+revoke pgque_writer from producer_only;
+revoke pgque_reader from consumer_only;
+drop role producer_only;
+drop role consumer_only;
+
+\echo 'PASS: producer/consumer role isolation (#102, #106)'


### PR DESCRIPTION
## Summary

PgQue had collapsed PgQ's two-role model. Upstream PgQ (`pgq/structure/grants.ini`) puts consumer primitives (`finish_batch`, `next_batch*`, `get_batch_events`, `register_consumer*`, `event_retry`) on **`pgq_reader`**, with `pgq_writer` granted only producer primitives (`insert_event`, triggers). `pgq_admin` is a sibling member of both.

In PgQue:

- Every consumer primitive — including the modern `receive`, `ack`, `nack`, `subscribe`, `unsubscribe` — was granted directly to `pgque_writer`.
- `pgque_writer` was *also* a member of `pgque_reader`.

Effect: any role that could call `pgque.send()` could also ack any consumer's batch by id (#102), reposition another consumer's cursor, replay another consumer's events, or read another consumer's active batch payloads (#106). PgQ's role separation, designed exactly to prevent this, had been undone.

## Fix — restore PgQ's sibling split

- `pgque_reader` is no longer inherited by `pgque_writer`. Both are now members of `pgque_admin` (sibling model, matches PgQ's `create role pgq_admin in role pgq_reader, pgq_writer;`).
- Consumer primitives move from `pgque_writer` to `pgque_reader`:
  - `register_consumer`, `register_consumer_at`, `unregister_consumer`
  - `next_batch`, `next_batch_info`, `next_batch_custom`
  - `get_batch_events`, `finish_batch`
  - `event_retry` (both overloads)
- Modern consume API (`receive`, `ack`, `nack`, `subscribe`, `unsubscribe`) moves to `pgque_reader`. `send`/`send_batch` stay on `pgque_writer`.

Apps that **produce and consume** must now hold **both** `pgque_reader` and `pgque_writer` explicitly.

## Tests

- `tests/test_pgque_roles.sql`: positive assertions migrated to `pgque_reader`; new negative assertions that `pgque_writer` does **not** have `execute` on `ack`, `nack`, `receive`, `finish_batch`, `next_batch`, `get_batch_events`, `register_consumer_at`, `event_retry`, `subscribe`; `pgque_admin` keeps both via membership.
- New `tests/test_security_producer_isolation.sql`: end-to-end #102/#106 repro. A producer-only role (only `pgque_writer`) tries to `ack`/`finish_batch`/`register_consumer_at`/`get_batch_events`/`event_retry`/`next_batch` against a victim consumer's batch and is denied with `insufficient_privilege` at every step.

Local run on a fresh PG16 install: **70/70 PASS, 0 FAIL.**

## Docs

- `README.md` and `docs/reference.md` rewritten to describe the sibling split, dual-grant pattern for produce+consume apps, and the remaining (unsolved) consumer-vs-consumer interference.

## Breaking change

Existing deployments that grant `pgque_writer` for ack/receive must add `grant pgque_reader to <role>;` after upgrade. Documented in the commit message and README.

## Out of scope — deferred to a later release (#164)

The role split closes the **producer → consumer** boundary, not the **consumer → consumer** one. Any `pgque_reader` can still ack another consumer's batch by id. Closing that requires ownership checks inside `ack`/`nack` (e.g. `ack(queue, consumer, batch_id)`) — the second half of #102's "Suggested fix options".

**Decision:** not in this release. Tracked in **#164**. The producer/consumer split lands now and is the higher-leverage half (it closes the most common misconfiguration — apps using `pgque_writer` for everything). Consumer-vs-consumer ownership is a meaningful API change (new arities, breaking signature change) and needs its own PR + client-driver coordination.

## Test plan

- [x] `bash build/transform.sh` — clean
- [x] Fresh install + `tests/run_all.sql` on PG16 — 70 PASS, 0 FAIL
- [x] New `test_security_producer_isolation.sql` exercises 6 attacker paths under a pure producer role; all denied
- [x] CI matrix (PG 14-18) — all green; `verify` and `client-smoke` green

Closes #102 (producer side) and #106 (producer side). Consumer-side ownership tracked in #164.