### PR TITLE
fix(security): restrict get_batch_cursor(extra_where) to pgque_admin (#108)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -421,12 +421,12 @@ Grant: `pgque_writer`. Source: `sql/pgque.sql`.
 #### `pgque.get_batch_cursor(batch_id bigint, cursor_name text, quick_limit int4) → setof record`
 
 Declares a server-side cursor over the batch and returns the first `quick_limit` events. Remaining events can be fetched with `fetch … from <cursor_name>`.
-Grant: `pgque_admin`. Source: `sql/pgque.sql`.
+Grant: `pgque_admin` only. Source: `sql/pgque.sql`.
 
 #### `pgque.get_batch_cursor(batch_id bigint, cursor_name text, quick_limit int4, extra_where text) → setof record`
 
 Same as above with an additional `where` filter applied inside the cursor.
-Grant: `pgque_admin`. Source: `sql/pgque.sql`.
+Grant: `pgque_admin` only. Source: `sql/pgque.sql`.
 
 #### `pgque.finish_batch(batch_id bigint) → integer`
 

--- a/sql/pgque-additions/roles.sql
+++ b/sql/pgque-additions/roles.sql
@@ -148,12 +148,7 @@ begin
 end $$;
 
 
--- get_batch_cursor: the 4-arg overload (i_extra_where) concatenates raw SQL
--- into the dynamic cursor body and is therefore a trusted-SQL primitive
--- (issue #108: a UNION ALL fragment can forge rows returned to callers).
--- The 3-arg overload routes through the 4-arg variant, so it is treated the
--- same way. Defense-in-depth: explicitly revoke from pgque_reader,
--- pgque_writer, and PUBLIC. Access remains via "grant execute on all
--- functions ... to pgque_admin" above. Do NOT grant these to reader/writer.
+-- get_batch_cursor is an advanced PgQ-compatible primitive.
+-- Keep both overloads admin-only; application roles should use pgque.receive().
 revoke execute on function pgque.get_batch_cursor(bigint, text, int4)        from public, pgque_reader, pgque_writer;
 revoke execute on function pgque.get_batch_cursor(bigint, text, int4, text)  from public, pgque_reader, pgque_writer;

--- a/sql/pgque-additions/roles.sql
+++ b/sql/pgque-additions/roles.sql
@@ -146,3 +146,14 @@ begin
             from public, pgque_reader, pgque_writer, pgque_admin;
     end if;
 end $$;
+
+
+-- get_batch_cursor: the 4-arg overload (i_extra_where) concatenates raw SQL
+-- into the dynamic cursor body and is therefore a trusted-SQL primitive
+-- (issue #108: a UNION ALL fragment can forge rows returned to callers).
+-- The 3-arg overload routes through the 4-arg variant, so it is treated the
+-- same way. Defense-in-depth: explicitly revoke from pgque_reader,
+-- pgque_writer, and PUBLIC. Access remains via "grant execute on all
+-- functions ... to pgque_admin" above. Do NOT grant these to reader/writer.
+revoke execute on function pgque.get_batch_cursor(bigint, text, int4)        from public, pgque_reader, pgque_writer;
+revoke execute on function pgque.get_batch_cursor(bigint, text, int4, text)  from public, pgque_reader, pgque_writer;

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -2214,6 +2214,28 @@ end;
 $$ language plpgsql; -- no perms needed
 
 
+-- ----------------------------------------------------------------------
+-- SECURITY (issue #108): get_batch_cursor / 4-arg overload
+--
+-- i_extra_where is concatenated VERBATIM into the dynamic cursor body:
+--     'select * from (' || _sql || ') _evs where ' || i_extra_where || ' order by 1'
+-- This is a trusted-SQL primitive. A caller that controls i_extra_where
+-- can:
+--   - Inject arbitrary predicate SQL.
+--   - Use "false UNION ALL SELECT ..." to forge event rows returned to
+--     application code.
+--   - Exfiltrate data visible to the function invoker via subqueries.
+--
+-- The PgQ engine body is sacred (SPECx Key Design Rule #2), so the chosen
+-- fix is a boundary lockdown rather than predicate sanitization:
+--   - EXECUTE is revoked from pgque_reader, pgque_writer, and PUBLIC
+--     (see the grants block in this file).
+--   - Only pgque_admin may invoke this function.
+--   - Callers MUST NEVER pass user-controlled text in i_extra_where.
+--
+-- The 3-arg overload below routes through the 4-arg variant (with NULL
+-- extra_where). Both are treated as admin-only.
+-- ----------------------------------------------------------------------
 create or replace function pgque.get_batch_cursor(
     in i_batch_id       bigint,
     in i_cursor_name    text,
@@ -4346,6 +4368,16 @@ begin
             from public, pgque_reader, pgque_writer, pgque_admin;
     end if;
 end $$;
+
+-- get_batch_cursor: the 4-arg overload (i_extra_where) concatenates raw SQL
+-- into the dynamic cursor body and is therefore a trusted-SQL primitive
+-- (issue #108: a UNION ALL fragment can forge rows returned to callers).
+-- The 3-arg overload routes through the 4-arg variant, so it is treated the
+-- same way. Defense-in-depth: explicitly revoke from pgque_reader,
+-- pgque_writer, and PUBLIC. Access remains via "grant execute on all
+-- functions ... to pgque_admin" above. Do NOT grant these to reader/writer.
+revoke execute on function pgque.get_batch_cursor(bigint, text, int4)        from public, pgque_reader, pgque_writer;
+revoke execute on function pgque.get_batch_cursor(bigint, text, int4, text)  from public, pgque_reader, pgque_writer;
 
 -- pgque-additions/dlq.sql
 -- pgque dead letter queue (DLQ) -- table + helper functions

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -2215,26 +2215,8 @@ $$ language plpgsql; -- no perms needed
 
 
 -- ----------------------------------------------------------------------
--- SECURITY (issue #108): get_batch_cursor / 4-arg overload
---
--- i_extra_where is concatenated VERBATIM into the dynamic cursor body:
---     'select * from (' || _sql || ') _evs where ' || i_extra_where || ' order by 1'
--- This is a trusted-SQL primitive. A caller that controls i_extra_where
--- can:
---   - Inject arbitrary predicate SQL.
---   - Use "false UNION ALL SELECT ..." to forge event rows returned to
---     application code.
---   - Exfiltrate data visible to the function invoker via subqueries.
---
--- The PgQ engine body is sacred (SPECx Key Design Rule #2), so the chosen
--- fix is a boundary lockdown rather than predicate sanitization:
---   - EXECUTE is revoked from pgque_reader, pgque_writer, and PUBLIC
---     (see the grants block in this file).
---   - Only pgque_admin may invoke this function.
---   - Callers MUST NEVER pass user-controlled text in i_extra_where.
---
--- The 3-arg overload below routes through the 4-arg variant (with NULL
--- extra_where). Both are treated as admin-only.
+-- Advanced PgQ-compatible primitive. Application roles should use
+-- pgque.receive(); get_batch_cursor is kept admin-only in the grants block.
 -- ----------------------------------------------------------------------
 create or replace function pgque.get_batch_cursor(
     in i_batch_id       bigint,
@@ -4369,13 +4351,8 @@ begin
     end if;
 end $$;
 
--- get_batch_cursor: the 4-arg overload (i_extra_where) concatenates raw SQL
--- into the dynamic cursor body and is therefore a trusted-SQL primitive
--- (issue #108: a UNION ALL fragment can forge rows returned to callers).
--- The 3-arg overload routes through the 4-arg variant, so it is treated the
--- same way. Defense-in-depth: explicitly revoke from pgque_reader,
--- pgque_writer, and PUBLIC. Access remains via "grant execute on all
--- functions ... to pgque_admin" above. Do NOT grant these to reader/writer.
+-- get_batch_cursor is an advanced PgQ-compatible primitive.
+-- Keep both overloads admin-only; application roles should use pgque.receive().
 revoke execute on function pgque.get_batch_cursor(bigint, text, int4)        from public, pgque_reader, pgque_writer;
 revoke execute on function pgque.get_batch_cursor(bigint, text, int4, text)  from public, pgque_reader, pgque_writer;
 

--- a/tests/run_all.sql
+++ b/tests/run_all.sql
@@ -28,6 +28,9 @@
 \echo 'Running: test_security_extra_maint'
 \i tests/test_security_extra_maint.sql
 
+\echo 'Running: test_security_get_batch_cursor'
+\i tests/test_security_get_batch_cursor.sql
+
 \echo 'Running: test_security_producer_isolation'
 \i tests/test_security_producer_isolation.sql
 

--- a/tests/test_security_get_batch_cursor.sql
+++ b/tests/test_security_get_batch_cursor.sql
@@ -1,22 +1,11 @@
 -- test_security_get_batch_cursor.sql -- Regression: get_batch_cursor restricted to pgque_admin
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 --
--- Issue #108: pgque.get_batch_cursor(batch_id, cursor_name, quick_limit, extra_where)
--- concatenates `i_extra_where` directly into dynamic SQL. A caller can inject
--- predicate fragments (e.g. `false UNION ALL SELECT ...`) and forge rows
--- returned to the application.
---
--- The PgQ engine body is sacred (SPECx Key Design Rule #2). The chosen fix is
--- a boundary-level lockdown: keep the function pgque_admin-only (trusted SQL)
--- rather than parsing/sanitizing the predicate. This test asserts the grant
--- posture and documents the threat model.
---
 -- Posture asserted:
---   1. pgque_reader cannot call either get_batch_cursor overload.
---   2. pgque_writer cannot call either get_batch_cursor overload.
---   3. pgque_admin (or members) can call both overloads.
---   4. UNION-ALL forgery still works *inside* admin context — we are not
---      sanitizing extra_where; we are restricting *who* can pass it.
+--   1. PUBLIC cannot call either get_batch_cursor overload.
+--   2. pgque_reader cannot call either get_batch_cursor overload.
+--   3. pgque_writer cannot call either get_batch_cursor overload.
+--   4. pgque_admin (or members) can call both overloads.
 
 -- =========================================================================
 -- Setup: probe roles
@@ -24,6 +13,9 @@
 
 do $$
 begin
+  if not exists (select 1 from pg_roles where rolname = 'pgque_test_public') then
+    execute 'create role pgque_test_public login';
+  end if;
   if not exists (select 1 from pg_roles where rolname = 'pgque_test_reader') then
     execute 'create role pgque_test_reader login';
     execute 'grant pgque_reader to pgque_test_reader';
@@ -36,6 +28,50 @@ begin
     execute 'create role pgque_test_admin login';
     execute 'grant pgque_admin to pgque_test_admin';
   end if;
+end $$;
+
+-- =========================================================================
+-- Test A0: PUBLIC is blocked from get_batch_cursor (both overloads)
+-- =========================================================================
+
+do $$
+declare
+  v_sqlstate text;
+begin
+  set role pgque_test_public;
+  begin
+    perform pgque.get_batch_cursor(1::bigint, 'probe_cursor_public3', 0);
+    raise exception 'expected insufficient_privilege calling get_batch_cursor/3 as PUBLIC, got success';
+  exception
+    when insufficient_privilege then
+      v_sqlstate := sqlstate;
+  end;
+  reset role;
+
+  assert v_sqlstate = '42501',
+    'expected sqlstate 42501 (insufficient_privilege) for public/3, got ' || coalesce(v_sqlstate, 'NULL');
+
+  raise notice 'PASS: security_get_batch_cursor/A0.1 - PUBLIC blocked from get_batch_cursor/3';
+end $$;
+
+do $$
+declare
+  v_sqlstate text;
+begin
+  set role pgque_test_public;
+  begin
+    perform pgque.get_batch_cursor(1::bigint, 'probe_cursor_public4', 0, 'true');
+    raise exception 'expected insufficient_privilege calling get_batch_cursor/4 as PUBLIC, got success';
+  exception
+    when insufficient_privilege then
+      v_sqlstate := sqlstate;
+  end;
+  reset role;
+
+  assert v_sqlstate = '42501',
+    'expected sqlstate 42501 (insufficient_privilege) for public/4, got ' || coalesce(v_sqlstate, 'NULL');
+
+  raise notice 'PASS: security_get_batch_cursor/A0.2 - PUBLIC blocked from get_batch_cursor/4';
 end $$;
 
 -- =========================================================================
@@ -132,21 +168,20 @@ end $$;
 -- Build a queue + consumer + batch so we have a real batch id to point at.
 -- This must run as superuser/owner so we have permission to set it up.
 
-select pgque.create_queue('issue108_q');
-select pgque.register_consumer('issue108_q', 'issue108_c');
-select pgque.insert_event('issue108_q', 'real', 'real-data');
-select pgque.ticker('issue108_q');
+select pgque.create_queue('security_cursor_q');
+select pgque.register_consumer('security_cursor_q', 'security_cursor_c');
+select pgque.insert_event('security_cursor_q', 'real', 'real-data');
+select pgque.ticker('security_cursor_q');
 
 do $$
 declare
   v_batch_id bigint;
   v_count_admin int := 0;
-  v_forged_seen int := 0;
 begin
   -- Switch to admin member to claim the batch.
   set role pgque_test_admin;
 
-  v_batch_id := pgque.next_batch('issue108_q', 'issue108_c');
+  v_batch_id := pgque.next_batch('security_cursor_q', 'security_cursor_c');
 
   if v_batch_id is null then
     reset role;
@@ -156,59 +191,41 @@ begin
   -- 3-arg overload should work for admin. The function returns the first
   -- quick_limit rows directly as setof record, so we can just count.
   select count(*) into v_count_admin
-    from pgque.get_batch_cursor(v_batch_id, 'issue108_admin_c3', 100);
+    from pgque.get_batch_cursor(v_batch_id, 'security_cursor_admin_c3', 100);
 
   -- Close the cursor we just opened so the name is reusable in this xact.
-  execute 'close issue108_admin_c3';
+  execute 'close security_cursor_admin_c3';
 
   assert v_count_admin >= 1,
     'pgque_admin/3 returned no rows from batch ' || v_batch_id::text;
 
   raise notice 'PASS: security_get_batch_cursor/C1 - pgque_admin can call get_batch_cursor/3 (rows=%)', v_count_admin;
 
-  -- 4-arg overload (the dangerous one): admin can call it.
-  -- Demonstrate the threat model: UNION ALL forgery still produces forged
-  -- rows *under admin* — we are NOT sanitizing predicates; we are revoking
-  -- access so untrusted callers cannot reach this entry point at all.
-  begin
-    select count(*) filter (where ev_type = 'forged-by-admin')
-      into v_forged_seen
-      from pgque.get_batch_cursor(
-        v_batch_id,
-        'issue108_admin_c4',
-        100,
-        $extra$false UNION ALL
-          SELECT 999999::bigint, now(), '0'::xid8, 0::int4,
-                 'forged-by-admin'::text, current_database()::text,
-                 NULL::text, NULL::text, NULL::text, NULL::text$extra$);
-    execute 'close issue108_admin_c4';
-  exception when others then
-    -- Probe is informational; only the reader/writer revoke is the hard fix.
-    raise notice 'NOTICE: union-all probe failed under admin (column shape may have changed): %', sqlerrm;
-    v_forged_seen := -1;
-  end;
+  -- 4-arg overload should also remain callable by admin.
+  perform 1
+    from pgque.get_batch_cursor(
+      v_batch_id,
+      'security_cursor_admin_c4',
+      100,
+      'true');
+  execute 'close security_cursor_admin_c4';
 
   reset role;
 
-  if v_forged_seen > 0 then
-    raise notice 'THREAT-MODEL: union-all forgery is reachable inside pgque_admin (forged_rows=%) — extra_where is RAW SQL; admin must treat this entry point as trusted-SQL only', v_forged_seen;
-  elsif v_forged_seen = 0 then
-    raise notice 'THREAT-MODEL: union-all probe under admin returned 0 forged rows — fix relies on grant revoke, not predicate sanitization';
-  else
-    raise notice 'THREAT-MODEL: union-all probe under admin did not execute (column shape mismatch). Fix relies on grant revoke at the boundary.';
-  end if;
+  raise notice 'PASS: security_get_batch_cursor/C2 - pgque_admin can call get_batch_cursor/4';
 end $$;
 
 -- =========================================================================
 -- Cleanup
 -- =========================================================================
 
-select pgque.unregister_consumer('issue108_q', 'issue108_c');
-select pgque.drop_queue('issue108_q');
+select pgque.unregister_consumer('security_cursor_q', 'security_cursor_c');
+select pgque.drop_queue('security_cursor_q');
 
 revoke pgque_reader from pgque_test_reader;
 revoke pgque_writer from pgque_test_writer;
 revoke pgque_admin  from pgque_test_admin;
+drop role if exists pgque_test_public;
 drop role if exists pgque_test_reader;
 drop role if exists pgque_test_writer;
 drop role if exists pgque_test_admin;

--- a/tests/test_security_get_batch_cursor.sql
+++ b/tests/test_security_get_batch_cursor.sql
@@ -1,0 +1,216 @@
+-- test_security_get_batch_cursor.sql -- Regression: get_batch_cursor restricted to pgque_admin
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- Issue #108: pgque.get_batch_cursor(batch_id, cursor_name, quick_limit, extra_where)
+-- concatenates `i_extra_where` directly into dynamic SQL. A caller can inject
+-- predicate fragments (e.g. `false UNION ALL SELECT ...`) and forge rows
+-- returned to the application.
+--
+-- The PgQ engine body is sacred (SPECx Key Design Rule #2). The chosen fix is
+-- a boundary-level lockdown: keep the function pgque_admin-only (trusted SQL)
+-- rather than parsing/sanitizing the predicate. This test asserts the grant
+-- posture and documents the threat model.
+--
+-- Posture asserted:
+--   1. pgque_reader cannot call either get_batch_cursor overload.
+--   2. pgque_writer cannot call either get_batch_cursor overload.
+--   3. pgque_admin (or members) can call both overloads.
+--   4. UNION-ALL forgery still works *inside* admin context — we are not
+--      sanitizing extra_where; we are restricting *who* can pass it.
+
+-- =========================================================================
+-- Setup: probe roles
+-- =========================================================================
+
+do $$
+begin
+  if not exists (select 1 from pg_roles where rolname = 'pgque_test_reader') then
+    execute 'create role pgque_test_reader login';
+    execute 'grant pgque_reader to pgque_test_reader';
+  end if;
+  if not exists (select 1 from pg_roles where rolname = 'pgque_test_writer') then
+    execute 'create role pgque_test_writer login';
+    execute 'grant pgque_writer to pgque_test_writer';
+  end if;
+  if not exists (select 1 from pg_roles where rolname = 'pgque_test_admin') then
+    execute 'create role pgque_test_admin login';
+    execute 'grant pgque_admin to pgque_test_admin';
+  end if;
+end $$;
+
+-- =========================================================================
+-- Test A: pgque_reader is blocked from get_batch_cursor (both overloads)
+-- =========================================================================
+
+do $$
+declare
+  v_sqlstate text;
+begin
+  set role pgque_test_reader;
+  begin
+    perform pgque.get_batch_cursor(1::bigint, 'probe_cursor_r3', 0);
+    raise exception 'expected insufficient_privilege calling get_batch_cursor/3 as pgque_reader, got success';
+  exception
+    when insufficient_privilege then
+      v_sqlstate := sqlstate;
+  end;
+  reset role;
+
+  assert v_sqlstate = '42501',
+    'expected sqlstate 42501 (insufficient_privilege) for reader/3, got ' || coalesce(v_sqlstate, 'NULL');
+
+  raise notice 'PASS: security_get_batch_cursor/A1 - pgque_reader blocked from get_batch_cursor/3';
+end $$;
+
+do $$
+declare
+  v_sqlstate text;
+begin
+  set role pgque_test_reader;
+  begin
+    perform pgque.get_batch_cursor(1::bigint, 'probe_cursor_r4', 0, 'true');
+    raise exception 'expected insufficient_privilege calling get_batch_cursor/4 as pgque_reader, got success';
+  exception
+    when insufficient_privilege then
+      v_sqlstate := sqlstate;
+  end;
+  reset role;
+
+  assert v_sqlstate = '42501',
+    'expected sqlstate 42501 (insufficient_privilege) for reader/4, got ' || coalesce(v_sqlstate, 'NULL');
+
+  raise notice 'PASS: security_get_batch_cursor/A2 - pgque_reader blocked from get_batch_cursor/4 (extra_where overload)';
+end $$;
+
+-- =========================================================================
+-- Test B: pgque_writer is blocked from get_batch_cursor (both overloads)
+-- =========================================================================
+
+do $$
+declare
+  v_sqlstate text;
+begin
+  set role pgque_test_writer;
+  begin
+    perform pgque.get_batch_cursor(1::bigint, 'probe_cursor_w3', 0);
+    raise exception 'expected insufficient_privilege calling get_batch_cursor/3 as pgque_writer, got success';
+  exception
+    when insufficient_privilege then
+      v_sqlstate := sqlstate;
+  end;
+  reset role;
+
+  assert v_sqlstate = '42501',
+    'expected sqlstate 42501 (insufficient_privilege) for writer/3, got ' || coalesce(v_sqlstate, 'NULL');
+
+  raise notice 'PASS: security_get_batch_cursor/B1 - pgque_writer blocked from get_batch_cursor/3';
+end $$;
+
+do $$
+declare
+  v_sqlstate text;
+begin
+  set role pgque_test_writer;
+  begin
+    perform pgque.get_batch_cursor(1::bigint, 'probe_cursor_w4', 0, 'true');
+    raise exception 'expected insufficient_privilege calling get_batch_cursor/4 as pgque_writer, got success';
+  exception
+    when insufficient_privilege then
+      v_sqlstate := sqlstate;
+  end;
+  reset role;
+
+  assert v_sqlstate = '42501',
+    'expected sqlstate 42501 (insufficient_privilege) for writer/4, got ' || coalesce(v_sqlstate, 'NULL');
+
+  raise notice 'PASS: security_get_batch_cursor/B2 - pgque_writer blocked from get_batch_cursor/4 (extra_where overload)';
+end $$;
+
+-- =========================================================================
+-- Test C: pgque_admin can still call get_batch_cursor (positive path)
+-- =========================================================================
+-- Build a queue + consumer + batch so we have a real batch id to point at.
+-- This must run as superuser/owner so we have permission to set it up.
+
+select pgque.create_queue('issue108_q');
+select pgque.register_consumer('issue108_q', 'issue108_c');
+select pgque.insert_event('issue108_q', 'real', 'real-data');
+select pgque.ticker('issue108_q');
+
+do $$
+declare
+  v_batch_id bigint;
+  v_count_admin int := 0;
+  v_forged_seen int := 0;
+begin
+  -- Switch to admin member to claim the batch.
+  set role pgque_test_admin;
+
+  v_batch_id := pgque.next_batch('issue108_q', 'issue108_c');
+
+  if v_batch_id is null then
+    reset role;
+    raise exception 'next_batch returned NULL; cannot continue test C';
+  end if;
+
+  -- 3-arg overload should work for admin. The function returns the first
+  -- quick_limit rows directly as setof record, so we can just count.
+  select count(*) into v_count_admin
+    from pgque.get_batch_cursor(v_batch_id, 'issue108_admin_c3', 100);
+
+  -- Close the cursor we just opened so the name is reusable in this xact.
+  execute 'close issue108_admin_c3';
+
+  assert v_count_admin >= 1,
+    'pgque_admin/3 returned no rows from batch ' || v_batch_id::text;
+
+  raise notice 'PASS: security_get_batch_cursor/C1 - pgque_admin can call get_batch_cursor/3 (rows=%)', v_count_admin;
+
+  -- 4-arg overload (the dangerous one): admin can call it.
+  -- Demonstrate the threat model: UNION ALL forgery still produces forged
+  -- rows *under admin* — we are NOT sanitizing predicates; we are revoking
+  -- access so untrusted callers cannot reach this entry point at all.
+  begin
+    select count(*) filter (where ev_type = 'forged-by-admin')
+      into v_forged_seen
+      from pgque.get_batch_cursor(
+        v_batch_id,
+        'issue108_admin_c4',
+        100,
+        $extra$false UNION ALL
+          SELECT 999999::bigint, now(), '0'::xid8, 0::int4,
+                 'forged-by-admin'::text, current_database()::text,
+                 NULL::text, NULL::text, NULL::text, NULL::text$extra$);
+    execute 'close issue108_admin_c4';
+  exception when others then
+    -- Probe is informational; only the reader/writer revoke is the hard fix.
+    raise notice 'NOTICE: union-all probe failed under admin (column shape may have changed): %', sqlerrm;
+    v_forged_seen := -1;
+  end;
+
+  reset role;
+
+  if v_forged_seen > 0 then
+    raise notice 'THREAT-MODEL: union-all forgery is reachable inside pgque_admin (forged_rows=%) — extra_where is RAW SQL; admin must treat this entry point as trusted-SQL only', v_forged_seen;
+  elsif v_forged_seen = 0 then
+    raise notice 'THREAT-MODEL: union-all probe under admin returned 0 forged rows — fix relies on grant revoke, not predicate sanitization';
+  else
+    raise notice 'THREAT-MODEL: union-all probe under admin did not execute (column shape mismatch). Fix relies on grant revoke at the boundary.';
+  end if;
+end $$;
+
+-- =========================================================================
+-- Cleanup
+-- =========================================================================
+
+select pgque.unregister_consumer('issue108_q', 'issue108_c');
+select pgque.drop_queue('issue108_q');
+
+revoke pgque_reader from pgque_test_reader;
+revoke pgque_writer from pgque_test_writer;
+revoke pgque_admin  from pgque_test_admin;
+drop role if exists pgque_test_reader;
+drop role if exists pgque_test_writer;
+drop role if exists pgque_test_admin;
+
+\echo 'PASS: test_security_get_batch_cursor'


### PR DESCRIPTION
## Summary

Closes the surface area of issue #108 by restricting `pgque.get_batch_cursor` (both 3-arg and 4-arg overloads) to `pgque_admin` only.

Changes:
- add `tests/test_security_get_batch_cursor.sql` covering PUBLIC blocked, reader/writer blocked, and admin allowed
- explicitly revoke both `get_batch_cursor` overloads from PUBLIC, `pgque_reader`, and `pgque_writer` in `sql/pgque-additions/roles.sql` and generated `sql/pgque.sql`
- keep documentation minimal: `docs/reference.md` only says both overloads are admin-only

Rebase notes:
- rebased on current `main`
- resolved grant-block conflict with the newer `insert_event_bulk` revokes by keeping both protections

Verification:
- local install of `sql/pgque.sql` into fresh database
- `tests/test_security_get_batch_cursor.sql` passed
- `tests/test_pgque_roles.sql` passed
- checks re-running after PUBLIC coverage update