### PR TITLE
docs: add roadmap and contributing guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ snapshot isolation, batch_event_sql algorithm, dual-filter optimization).
 
 ## Style Rules
 
-Follow the shared rules at https://gitlab.com/postgres-ai/rules/-/tree/main/rules
+These rules are the source of truth for agentic engineering in this repo. Agents and AI coding tools must read this file before making changes.
 
 ### SQL Style
 
@@ -100,6 +100,15 @@ pgque/
     typescript/        -- pgque-ts
   cli/                 -- pgque CLI (Go)
 ```
+
+## Agentic Engineering Rules
+
+- Use red/green TDD for new code: write the failing test first, then the implementation.
+- Keep changes surgical: one logical fix or feature per PR.
+- Preserve PgQ core behavior unless the change is intentional, documented, and tested.
+- Keep the default install managed-Postgres-compatible: no C extension, no `shared_preload_libraries`, no restart requirement.
+- Keep generated files and source changes consistent when both are affected.
+- Include the relevant test or manual verification command in PR descriptions.
 
 ## Key Design Rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to PgQue
+
+Thanks for helping improve PgQue.
+
+PgQue is a pure SQL / PL/pgSQL repackaging of PgQ for managed Postgres environments. Keep changes small, testable, and compatible with managed Postgres unless a document explicitly says otherwise.
+
+## Start here
+
+- Read [README.md](README.md) for project positioning and user-facing behavior.
+- Read [blueprints/SPECx.md](blueprints/SPECx.md) for the current specification and implementation plan.
+- Read [CLAUDE.md](CLAUDE.md). It is the source of truth for agentic engineering rules, style, design constraints, and project conventions.
+
+## Development rules
+
+Use [CLAUDE.md](CLAUDE.md) for the detailed rules. In short:
+
+- Use red/green TDD for new code: failing test first, implementation second.
+- Keep PRs focused: one logical change per PR.
+- Preserve PgQ core behavior unless the change is intentional, documented, and tested.
+- Keep the default install managed-Postgres-compatible.
+- Keep generated files and source changes consistent when both are affected.
+
+## Tests
+
+Run the relevant SQL regression tests before opening a PR. For changes touching supported-version behavior, test against the supported Postgres matrix when possible.
+
+At minimum, include the test or manual verification command in the PR description.
+
+## Pull requests
+
+- Use a descriptive branch name.
+- Explain the motivation and the user-visible change.
+- Link related issues or design docs.
+- Keep PRs focused and easy to review.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Discussion on [Hacker News](https://news.ycombinator.com/item?id=47817349).
 - [Client libraries](#client-libraries)
 - [Benchmarks](#benchmarks)
 - [Architecture](#architecture)
+- [Roadmap](#roadmap)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -344,9 +345,41 @@ methodology continues to evolve.
 
 PgQue keeps PgQ's proven core architecture — snapshot-based batch isolation, three-table TRUNCATE rotation on the hot path, separate retry / delayed / dead-letter tables, and independent per-consumer cursors — and adds a modern API layer on top. See [blueprints/SPECx.md](blueprints/SPECx.md) for the full specification and [docs/pgq-concepts.md](docs/pgq-concepts.md) for the batch/tick/rotation glossary.
 
+## Roadmap
+
+| Feature | Done |
+|---|---|
+| PgQ core engine | ✅ |
+| Modern Postgres support (14-18, 19devel) | ✅ |
+| Pure SQL / PL/pgSQL install | ✅ |
+| Managed Postgres support | ✅ |
+| No daemon / no C extension | ✅ |
+| `pg_cron` or external ticking | ✅ |
+| Sub-second ticking with `pg_cron` |  |
+| System-table rotation / bloat mitigation |  |
+| Subconsumers / coop consumers |  |
+| Queue splitter |  |
+| Queue mover |  |
+| Modern `send`, `receive`, `ack`, `nack` API | ✅ |
+| `send_batch` API | ✅ |
+| Improved `send_batch` performance |  |
+| Dead-letter queue after retry limit | ✅ |
+| Go library | ✅ |
+| TypeScript library | ✅ |
+| Python library | ✅ |
+| Rust library |  |
+| Java library |  |
+| Ruby library |  |
+| Basic observability views | ✅ |
+| Prometheus exporter |  |
+| `pg_tle` extension package |  |
+| Migration guides |  |
+
 ## Contributing
 
-See [blueprints/SPECx.md](blueprints/SPECx.md) for the specification and implementation plan. New code should follow red/green TDD: write the failing test first, then fix it.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
+
+See [blueprints/SPECx.md](blueprints/SPECx.md) for the specification and implementation plan. New code should follow red/green TDD: write the failing test first, then fix it. Agents and AI coding tools should also read [CLAUDE.md](CLAUDE.md).
 
 ## License
 


### PR DESCRIPTION
Adds README roadmap and contribution guidance.

Changes:
- add a single `Feature | Done` roadmap table near the end of README
- mark shipped items with ✅ and leave planned items empty
- include planned items such as sub-second `pg_cron` ticking, coop consumers, system-table bloat mitigation, `pg_tle` packaging, Prometheus exporter, and more client libraries
- add `CONTRIBUTING.md`
- update README Contributing section to link `CONTRIBUTING.md` and `CLAUDE.md`
- make `CLAUDE.md` the source of truth for agentic engineering rules, including red/green TDD

Verification:
- all local Markdown links resolve