### PR TITLE
ci: split client library checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,8 @@ jobs:
         if: always()
         run: docker rm -f pgque-test
 
-  client-smoke:
+  python-client-tests:
+    name: Python client tests
     runs-on: ubuntu-latest
     env:
       PGQUE_TEST_DSN: postgresql://postgres:pgque_test@localhost/pgque_test
@@ -88,14 +89,15 @@ jobs:
 
       - name: Start PostgreSQL 18
         run: |
-          docker run -d --name pgque-client-test \
+          set -Eeuo pipefail
+          docker run -d --name pgque-python-test \
             -e POSTGRES_PASSWORD=pgque_test \
             -e POSTGRES_DB=pgque_test \
             -p 5432:5432 \
             postgres:18
 
           for i in $(seq 1 30); do
-            docker exec pgque-client-test pg_isready -U postgres && break
+            docker exec pgque-python-test pg_isready -U postgres && break
             sleep 1
           done || { echo "PG not ready after 30 seconds"; exit 1; }
 
@@ -104,54 +106,115 @@ jobs:
 
       - name: Install pgque
         run: |
+          set -Eeuo pipefail
           PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
             -v ON_ERROR_STOP=1 -f sql/pgque.sql
+
+      - name: Python client test suite
+        run: |
+          set -Eeuo pipefail
+          python3 -m venv /tmp/pgque-python-venv
+          . /tmp/pgque-python-venv/bin/activate
+          python -m pip install -U pip
+          python -m pip install -e 'clients/python[dev]'
+          pytest -v clients/python/tests/
+
+      - name: Cleanup Python test DB
+        if: always()
+        run: docker rm -f pgque-python-test
+
+  go-client-tests:
+    name: Go client tests
+    runs-on: ubuntu-latest
+    env:
+      PGQUE_TEST_DSN: postgresql://postgres:pgque_test@localhost/pgque_test
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Start PostgreSQL 18
+        run: |
+          set -Eeuo pipefail
+          docker run -d --name pgque-go-test \
+            -e POSTGRES_PASSWORD=pgque_test \
+            -e POSTGRES_DB=pgque_test \
+            -p 5432:5432 \
+            postgres:18
+
+          for i in $(seq 1 30); do
+            docker exec pgque-go-test pg_isready -U postgres && break
+            sleep 1
+          done || { echo "PG not ready after 30 seconds"; exit 1; }
+
+      - name: Build pgque
+        run: bash build/transform.sh
+
+      - name: Install pgque
+        run: |
+          set -Eeuo pipefail
           PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
-            -v ON_ERROR_STOP=1 -c "select pgque.create_queue('smoke_py'); select pgque.create_queue('smoke_go'); select pgque.create_queue('smoke_ts');"
+            -v ON_ERROR_STOP=1 -f sql/pgque.sql
+
+      - name: Go client test suite
+        run: |
+          set -Eeuo pipefail
+          cd clients/go
+          go test -race -v ./...
+
+      - name: Cleanup Go test DB
+        if: always()
+        run: docker rm -f pgque-go-test
+
+  typescript-client-tests:
+    name: TypeScript client tests
+    runs-on: ubuntu-latest
+    env:
+      PGQUE_TEST_DSN: postgresql://postgres:pgque_test@localhost/pgque_test
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Start PostgreSQL 18
+        run: |
+          set -Eeuo pipefail
+          docker run -d --name pgque-ts-test \
+            -e POSTGRES_PASSWORD=pgque_test \
+            -e POSTGRES_DB=pgque_test \
+            -p 5432:5432 \
+            postgres:18
+
+          for i in $(seq 1 30); do
+            docker exec pgque-ts-test pg_isready -U postgres && break
+            sleep 1
+          done || { echo "PG not ready after 30 seconds"; exit 1; }
+
+      - name: Build pgque
+        run: bash build/transform.sh
+
+      - name: Install pgque
+        run: |
+          set -Eeuo pipefail
           PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
-            -v ON_ERROR_STOP=1 -c "select pgque.force_tick('smoke_py'); select pgque.force_tick('smoke_go'); select pgque.force_tick('smoke_ts'); select pgque.ticker();"
-
-      - name: Python smoke
-        run: |
-          python3 -m pip install -U pip
-          python3 -m pip install -e clients/python[dev]
-          pytest -q clients/python/tests/test_smoke.py
-
-      - name: Python producer benchmark
-        run: |
-          python3 clients/python/bench_producer.py
-
-      - name: Go smoke
-        run: |
-          cd clients/go
-          go test -run TestSmoke ./...
-
-      - name: Go producer benchmark
-        run: |
-          cd clients/go
-          PGQUE_RUN_PRODUCER_BENCH=1 go test -run TestProducerBenchmarks -v ./...
+            -v ON_ERROR_STOP=1 -f sql/pgque.sql
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.8
 
-      - name: TypeScript smoke
+      - name: TypeScript client test suite
         run: |
+          set -Eeuo pipefail
           cd clients/typescript
           bun install --frozen-lockfile
           bun run check
           bun run test
-          bun src/smoke.ts
 
-      - name: TypeScript producer benchmark
-        run: |
-          cd clients/typescript
-          bun run bench:producer
-
-      - name: Cleanup client smoke DB
+      - name: Cleanup TypeScript test DB
         if: always()
-        run: docker rm -f pgque-client-test
+        run: docker rm -f pgque-ts-test
 
   verify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

We support three client libraries, but CI currently reports them under one combined `client-smoke` job. That makes failures harder to triage and hides per-client status.

PR #84 had the right direction, but it is stale/conflicting. This is a clean current-main replacement with intentionally small scope.

## What changes

Replaces `client-smoke` with separate jobs:

- `Python client tests`
- `Go client tests`
- `TypeScript client tests`

Each job gets its own fresh PostgreSQL 18 container, installs `sql/pgque.sql`, and sets `PGQUE_TEST_DSN`.

Suites run:

- Go: `go test -race -v ./...`
- Python: `pytest -v clients/python/tests/`
- TypeScript: Bun install/check + full vitest suite via `bun run test`

Also uses `set -Eeuo pipefail` in the new shell blocks and a Python venv to avoid PEP 668/system-pip issues.

## Local validation

- YAML parses and has jobs: `test`, `python-client-tests`, `go-client-tests`, `typescript-client-tests`, `verify`
- Python job body passed locally against fresh PG18 before the final verbosity-only command tweak.
- TypeScript job body passed locally against fresh PG18 before removing smoke/benchmark extras.
- Go is not installed on this host, so exact `go test -race` is left to CI. Separate post-159 validation did run full Go tests against fresh PG18 successfully.