### PR TITLE
docs: focus README and docs on new users

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,11 +71,15 @@ set -Eeuo pipefail
   "previously did Y, now does Z" framing in the README or under `docs/`.
   Migration notes belong in release notes (`CHANGELOG.md` / GitHub releases),
   full stop.
-- **No PR or issue numbers in the README or `docs/`.** No `#123`, no
-  `(see PR #456)`, no `refs #102, #106`. Refer to behavior, not the change
-  history that produced it. (External citations to other projects' issue
-  trackers, used as evidence for a claim, are fine.) PR/issue numbers may
-  appear in commit messages, release notes, `blueprints/`, and `CONTRIBUTING.md`.
+- **No PR or issue numbers, and no concrete version tags, in the README or
+  `docs/` unless it really helps the reader.** No `#123`, no `(see PR #456)`,
+  no `refs #102, #106`, no `Breaking change in v0.2`, no `PgQue v0.2.0 has
+  …`. Refer to behavior, not the change history or release labels that
+  produced it. (External citations to other projects' issue trackers, used
+  as evidence for a claim, are fine. Version tags are fine in roadmap-style
+  contexts under `blueprints/` where the version IS the topic.) PR/issue
+  numbers and version tags may appear in commit messages, release notes,
+  `blueprints/`, and `CONTRIBUTING.md`.
 - **Installation docs must be self-complete but not bloated.** Every
   install/quickstart doc covers: install command, ticker setup (or how to skip
   it), and role grants (`pgque_reader` / `pgque_writer` / `pgque_admin`,
@@ -107,7 +111,7 @@ pgque/
   docs/                -- user-facing documentation (flat layout)
     README.md          -- index of the docs directory
     tutorial.md        -- hands-on walkthrough (start here for new users)
-    reference.md       -- per-function reference for the v0.1 install
+    reference.md       -- per-function reference for the default install
     examples.md        -- short patterns (fan-out, exactly-once, etc.)
     benchmarks.md      -- throughput numbers + methodology
     pgq-concepts.md    -- contributor glossary (batch, tick, rotation)
@@ -127,6 +131,30 @@ pgque/
 - Keep the default install managed-Postgres-compatible: no C extension, no `shared_preload_libraries`, no restart requirement.
 - Keep generated files and source changes consistent when both are affected.
 - Include the relevant test or manual verification command in PR descriptions.
+
+## PR Lifecycle
+
+Every PR walks through this loop. Do not skip steps; do not reorder them.
+
+1. **CI green.** All check runs on the head commit must pass before review.
+   If CI is red, fix the failure first (red/green TDD when the fix is code:
+   reproduce in a failing test, make it green, then refactor).
+2. **Review done.** Use REV (`https://gitlab.com/postgres-ai/rev/`) — it
+   targets GitLab MRs natively but works on GitHub PRs too. Ignore SOC2
+   findings; this repo does not need them. Address blocking findings;
+   reply to non-blocking with rationale or a follow-up.
+3. **Real testing, where it makes sense.** Walk the change as a new user
+   would. For docs PRs that means executing the snippets verbatim against
+   a fresh Postgres. For code PRs that means running the affected tests
+   and any manual verification command listed in the PR description. Post
+   the evidence (commands run, output, screenshots when relevant) as a
+   PR comment so a reviewer can see what was checked.
+4. **Approve and merge.** If 1–3 are clean, approve, merge, and delete
+   the branch. Otherwise return to the author with a concrete fix list
+   and LOOP from step 1 on the next push.
+
+For any code change made during the loop, follow red/green TDD: failing
+test first, then the implementation that turns it green.
 
 ## Key Design Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,24 @@ set -Eeuo pipefail
 - 2-space indent, no tabs
 - Quote all variable expansions
 
+### Documentation
+
+- **Write for new users.** README and docs target someone arriving today, not
+  someone migrating from an older state. Do not include "before X" or
+  "previously did Y, now does Z" framing in the README or under `docs/`.
+  Migration notes belong in release notes (`CHANGELOG.md` / GitHub releases),
+  full stop.
+- **No PR or issue numbers in the README or `docs/`.** No `#123`, no
+  `(see PR #456)`, no `refs #102, #106`. Refer to behavior, not the change
+  history that produced it. (External citations to other projects' issue
+  trackers, used as evidence for a claim, are fine.) PR/issue numbers may
+  appear in commit messages, release notes, `blueprints/`, and `CONTRIBUTING.md`.
+- **Installation docs must be self-complete but not bloated.** Every
+  install/quickstart doc covers: install command, ticker setup (or how to skip
+  it), and role grants (`pgque_reader` / `pgque_writer` / `pgque_admin`,
+  including the produce+consume case that needs both). One short snippet,
+  not a tour.
+
 ### Git Commits
 
 - Conventional Commits: `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`

--- a/README.md
+++ b/README.md
@@ -232,7 +232,9 @@ select pgque.subscribe('orders', 'processor');
 select pgque.send('orders', '{"order_id": 42, "total": 99.95}'::jsonb);
 
 -- tx 3: advance the queue if you are not using pg_cron
--- (force_tick bumps the event-seq threshold; ticker() then inserts the tick)
+-- force_tick bumps the event-seq threshold; ticker() then inserts the tick.
+-- Each select below is its own implicit transaction in psql autocommit —
+-- do NOT wrap these in begin/commit (the tick must see the send committed).
 select pgque.force_tick('orders');
 select pgque.ticker();
 
@@ -304,7 +306,8 @@ if (messages.length > 0) await client.ack(messages[0].batch_id);
 ```sql
 select pgque.send('orders', '{"order_id": 42}'::jsonb);
 
--- without pg_cron, advance the queue manually (omit if a ticker is running)
+-- without pg_cron, advance the queue manually (omit if a ticker is running).
+-- Run as separate transactions — do not wrap in begin/commit.
 select pgque.force_tick('orders');
 select pgque.ticker();
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ PgQue mirrors upstream PgQ's split: `pgque_reader` (consume) and `pgque_writer` 
 | Role | Purpose | Granted access |
 |---|---|---|
 | `pgque_reader` | Consumers, dashboards, metrics, debugging | Read-only info (`get_queue_info`, `get_consumer_info`, `get_batch_info`, `version`, `select` on all tables) **and** the consume API (`subscribe`, `unsubscribe`, `receive`, `ack`, `nack`) plus the underlying PgQ primitives (`next_batch*`, `get_batch_events`, `finish_batch`, `event_retry`, `register_consumer*`, `unregister_consumer`). |
-| `pgque_writer` | Producers | The produce API (`send`, `send_batch`) and the underlying primitive (`insert_event`). Does **not** inherit `pgque_reader` — a producer-only role cannot ack/finish/inspect consumer batches (refs #102, #106). |
+| `pgque_writer` | Producers | The produce API (`send`, `send_batch`) and the underlying primitive (`insert_event`). Does **not** inherit `pgque_reader` — a producer-only role cannot ack/finish/inspect consumer batches. |
 | `pgque_admin`  | Operators, migrations | Member of both `pgque_reader` and `pgque_writer`, plus full schema/table/sequence access. `uninstall()` is revoked from both `pgque_admin` and PUBLIC (superuser-only — it drops the schema). |
 
 Typical app setup:
@@ -194,32 +194,6 @@ grant pgque_writer to app_webhook;
 create user metrics with password '...';              -- replace with a real password
 grant pgque_reader to metrics;
 ```
-
-**Upgrading from a pre-#163 install.** Pre-#163 PgQue granted `pgque_reader` to `pgque_writer` (writer inherited reader). #163 reverses that: the two are now siblings. **Existing deployments must take two manual steps after re-running `\i sql/pgque.sql`:**
-
-1. The re-install **does** revoke the old `pgque_reader → pgque_writer` membership for you (idempotent `revoke` in `roles.sql`). No action needed for that part.
-2. Any application role that previously held `pgque_writer` and called `receive`/`ack`/`nack`/`subscribe`/`unsubscribe` will start failing with `permission denied`. Grant `pgque_reader` to those roles:
-
-```sql
--- Apps that produce AND consume:
-grant pgque_reader to app_orders;
--- (pgque_writer is already granted; nothing to revoke from it.)
-```
-
-If you previously assumed a single role for both, audit which apps still need it:
-
-```sql
--- Find roles holding pgque_writer that are missing pgque_reader.
--- (pgque_writer/postgres are excluded as obvious self-matches; pgque_admin
--- is filtered transitively by the second predicate since it is a member of
--- pgque_reader.)
-select rolname from pg_roles
- where pg_has_role(rolname, 'pgque_writer', 'MEMBER')
-   and not pg_has_role(rolname, 'pgque_reader', 'MEMBER')
-   and rolname not in ('pgque_writer','postgres');
-```
-
-Then `grant pgque_reader to <each_role>;` per the audit. Pure producers (e.g. webhook ingesters that only `send()`) need no change.
 
 DDL-class operations (`create_queue`, `drop_queue`, `start`, `stop`, `maint`, `maint_retry_events`, `ticker`, `force_tick`, `set_queue_config`) are not granted to either `pgque_reader` or `pgque_writer`. The schema-wide blanket `revoke execute … from public` strips PUBLIC, and `pgque_admin` is the only role that retains `execute` on these helpers — perform them as an admin / migration role.
 
@@ -255,15 +229,17 @@ select pgque.send('orders', '{"order_id": 42, "total": 99.95}'::jsonb);
 select pgque.force_tick('orders');
 select pgque.ticker();
 
--- tx 4: receive (all returned rows share the same batch_id)
-create temp table msgs as
-  select * from pgque.receive('orders', 'processor', 100);
+-- tx 4: receive — every returned row carries the same batch_id
+select * from pgque.receive('orders', 'processor', 100);
+--  msg_id | batch_id |  type   |             payload              | retry_count | ...
+-- --------+----------+---------+----------------------------------+-------------+----
+--       1 |        1 | default | {"order_id": 42, "total": 99.95} |             |
 
--- tx 5: acknowledge — pull the batch_id from any returned row
-select pgque.ack((select batch_id from msgs limit 1));
+-- tx 5: ack the batch_id from the previous result
+select pgque.ack(1);
 ```
 
-Send, tick, and receive should be separate transactions — that's PgQ's snapshot-based design working as intended. In normal operation, `pg_cron` or an external scheduler drives `pgque.ticker()`; `force_tick()` is mainly for demos, tests, and manual operation. The temp-table capture above is the safe psql pattern when `receive` returns more than one row; for application code, store the `batch_id` from any returned row.
+Send, tick, and receive should be separate transactions — that's PgQ's snapshot-based design working as intended. In normal operation, `pg_cron` or an external scheduler drives `pgque.ticker()`; `force_tick()` is mainly for demos, tests, and manual operation. In application code, capture `batch_id` from any returned row and pass it to `ack`. In psql, `... \gset` followed by `select pgque.ack(:batch_id)` is the scriptable equivalent of the manual call above.
 
 Longer walkthrough in the [tutorial](docs/tutorial.md); patterns like fan-out, exactly-once, and recurring jobs in [examples](docs/examples.md).
 
@@ -319,22 +295,22 @@ if (messages.length > 0) await client.ack(messages[0].batch_id);
 ```sql
 select pgque.send('orders', '{"order_id": 42}'::jsonb);
 
--- receive returns rows; each row carries the batch_id
-create temp table msgs as
-  select * from pgque.receive('orders', 'processor', 100);
+-- receive returns rows; every row carries the same batch_id
+select * from pgque.receive('orders', 'processor', 100);
 
--- ack uses the batch_id from any row (all rows share the same batch_id)
-select pgque.ack((select batch_id from msgs limit 1));
+-- ack the batch_id from any returned row (capture it in the driver)
+select pgque.ack(1);  -- replace with the batch_id from above
 ```
 
 ## Benchmarks
 
-Preliminary laptop numbers: ~86k ev/s PL/pgSQL insert, ~2.4M ev/s primitive
-batch read rate (`get_batch_events`), zero dead-tuple growth under a 30-minute
-sustained test. The batch read figure reflects raw PgQ primitive throughput,
-not end-to-end `receive()`/`ack()` consumer throughput. See
+Preliminary laptop numbers: ~86k ev/s batched PL/pgSQL insert, ~2.4M ev/s
+primitive batch read rate (`get_batch_events`), zero dead-tuple growth under a
+30-minute sustained test with a blocked xmin horizon (a concurrent long-running
+transaction holding an assigned XID — the worst case for SKIP LOCKED queues).
+The batch read figure reflects raw PgQ primitive throughput, not end-to-end
+`receive()`/`ack()` consumer throughput. See
 [docs/benchmarks.md](docs/benchmarks.md) for the full table and methodology.
-Server-class numbers to follow.
 
 Preliminary cross-system measurements live in [`benchmark/`](benchmark/).
 Numbers there are for reference and exploration, not a final verdict —

--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ Oban Pro shipped table partitioning to mitigate it; PGMQ ships aggressive autova
 
 **Requirements:** Postgres 14+, and something that calls `pgque.ticker()` periodically (every 1 second by default). `pg_cron` is the recommended default — pre-installed or one-command available on all major managed Postgres providers (RDS, Aurora, Cloud SQL, AlloyDB, Supabase, Neon); on self-managed Postgres, follow the [pg_cron setup guide](https://github.com/citusdata/pg_cron#setting-up-pg_cron). Any external scheduler (system `cron`, systemd, a worker loop in your app) works as an alternative — see below.
 
+Get the source — `\i sql/pgque.sql` resolves relative to the cwd, so run psql from the repo root:
+
+```bash
+git clone https://github.com/NikolayS/pgque
+cd pgque
+```
+
 Inside a psql session:
 
 ```sql
@@ -154,9 +161,9 @@ select pgque.start();
 Without `pg_cron`, PgQue still installs. Drive ticking and maintenance from your application or an external scheduler:
 
 ```bash
-PAGER=cat psql --no-psqlrc -c "select pgque.ticker()"              # every 1 second
-PAGER=cat psql --no-psqlrc -c "select pgque.maint_retry_events()"  # every 30 seconds
-PAGER=cat psql --no-psqlrc -c "select pgque.maint()"               # every 30 seconds
+PAGER=cat psql --no-psqlrc -d mydb -c "select pgque.ticker()"              # every 1 second
+PAGER=cat psql --no-psqlrc -d mydb -c "select pgque.maint_retry_events()"  # every 30 seconds
+PAGER=cat psql --no-psqlrc -d mydb -c "select pgque.maint()"               # every 30 seconds
 ```
 
 **Important:** PgQue does not deliver messages without a working ticker. Enqueueing still works, but consumers will see nothing new because no ticks are created. If you do not use `pg_cron`, run `pgque.ticker()`, `pgque.maint_retry_events()`, and `pgque.maint()` yourself. Skipping `maint_retry_events()` means nack'd events will never be redelivered.
@@ -233,7 +240,9 @@ select pgque.ticker();
 select * from pgque.receive('orders', 'processor', 100);
 --  msg_id | batch_id |  type   |             payload              | retry_count | ...
 -- --------+----------+---------+----------------------------------+-------------+----
---       1 |        1 | default | {"order_id": 42, "total": 99.95} |             |
+--       1 |        1 | default | {"total": 99.95, "order_id": 42} |             |
+-- (jsonb sorts object keys by length then alphabetically, so the input
+--  '{"order_id": 42, "total": 99.95}' comes back with "total" first)
 
 -- tx 5: ack the batch_id from the previous result
 select pgque.ack(1);
@@ -294,6 +303,10 @@ if (messages.length > 0) await client.ack(messages[0].batch_id);
 
 ```sql
 select pgque.send('orders', '{"order_id": 42}'::jsonb);
+
+-- without pg_cron, advance the queue manually (omit if a ticker is running)
+select pgque.force_tick('orders');
+select pgque.ticker();
 
 -- receive returns rows; every row carries the same batch_id
 select * from pgque.receive('orders', 'processor', 100);

--- a/README.md
+++ b/README.md
@@ -250,7 +250,14 @@ select * from pgque.receive('orders', 'processor', 100);
 select pgque.ack(1);
 ```
 
-Send, tick, and receive **must** run in separate transactions — that's a hard requirement of PgQ's snapshot-based design, not a recommendation. A `tick` records a snapshot of committed transaction IDs; a `send` in the same xact is still in-progress at that moment and gets excluded from the next batch's visibility window, so the event never surfaces. In normal operation, `pg_cron` or an external scheduler drives `pgque.ticker()`; `force_tick()` is mainly for demos, tests, and manual operation. In application code, capture `batch_id` from any returned row and pass it to `ack`. In psql, `... \gset` followed by `select pgque.ack(:batch_id)` is the scriptable equivalent of the manual call above.
+Send, tick, and receive **must** run in separate transactions — that's a hard requirement of PgQ's snapshot-based design, not a recommendation. A `tick` records a snapshot of committed transaction IDs; a `send` in the same xact is still in-progress at that moment and gets excluded from the next batch's visibility window, so the event never surfaces. In normal operation, `pg_cron` or an external scheduler drives `pgque.ticker()`; `force_tick()` is mainly for demos, tests, and manual operation. In application code, capture `batch_id` from any returned row and pass it to `ack`.
+
+The scriptable psql idiom (replaces tx 4 + tx 5 above):
+
+```sql
+select batch_id from pgque.receive('orders', 'processor', 100) limit 1 \gset
+select pgque.ack(:batch_id);
+```
 
 Longer walkthrough in the [tutorial](docs/tutorial.md); patterns like fan-out, exactly-once, and recurring jobs in [examples](docs/examples.md).
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ select * from pgque.receive('orders', 'processor', 100);
 select pgque.ack(1);
 ```
 
-Send, tick, and receive should be separate transactions — that's PgQ's snapshot-based design working as intended. In normal operation, `pg_cron` or an external scheduler drives `pgque.ticker()`; `force_tick()` is mainly for demos, tests, and manual operation. In application code, capture `batch_id` from any returned row and pass it to `ack`. In psql, `... \gset` followed by `select pgque.ack(:batch_id)` is the scriptable equivalent of the manual call above.
+Send, tick, and receive **must** run in separate transactions — that's a hard requirement of PgQ's snapshot-based design, not a recommendation. A `tick` records a snapshot of committed transaction IDs; a `send` in the same xact is still in-progress at that moment and gets excluded from the next batch's visibility window, so the event never surfaces. In normal operation, `pg_cron` or an external scheduler drives `pgque.ticker()`; `force_tick()` is mainly for demos, tests, and manual operation. In application code, capture `batch_id` from any returned row and pass it to `ack`. In psql, `... \gset` followed by `select pgque.ack(:batch_id)` is the scriptable equivalent of the manual call above.
 
 Longer walkthrough in the [tutorial](docs/tutorial.md); patterns like fan-out, exactly-once, and recurring jobs in [examples](docs/examples.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ Short docs for users, plus a contributor primer.
 - **[Tutorial](tutorial.md)** — a hands-on walkthrough. Send, tick, receive,
   retry, DLQ, observability. Start here if you are new.
 - **[Reference](reference.md)** — every function, return type, and role
-  grant in the v0.1 default install.
+  grant in the default install.
 - **[Examples](examples.md)** — short patterns: fan-out, exactly-once,
   batch send, recurring jobs, DLQ inspection.
 - **[Benchmarks](benchmarks.md)** — current throughput numbers and
@@ -24,5 +24,6 @@ Short docs for users, plus a contributor primer.
 - **[PgQ history](pgq-history.md)** — short timeline from Skype to PgQue.
 
 For the full specification and implementation plan, see
-[`blueprints/SPECx.md`](../blueprints/SPECx.md). For what ships in v0.1 vs
-experimental, see [`blueprints/PHASES.md`](../blueprints/PHASES.md).
+[`blueprints/SPECx.md`](../blueprints/SPECx.md). For what ships in the
+default install vs experimental, see
+[`blueprints/PHASES.md`](../blueprints/PHASES.md).

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -61,4 +61,4 @@ Key takeaways:
 > `synchronous_commit=off` can be set per session or per transaction for
 > queue-heavy workloads if that trade-off makes sense for your system.
 
-These numbers are preliminary, from a single laptop. Server-class numbers to follow.
+These numbers are preliminary, from a single laptop.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -63,11 +63,11 @@ begin;
     select (payload::jsonb->>'order_id')::int, 'done'
     from msgs
   )
-  select pgque.ack(batch_id) from msgs limit 1;
+  select pgque.ack((select batch_id from msgs limit 1));
 commit;
 ```
 
-The `inserted` CTE runs to completion even though the main query does not reference it (data-modifying CTEs always execute). Every row in `msgs` shares the same `batch_id`. **Batch-ownership caveat:** `pgque.ack(batch_id)` advances the consumer past the entire underlying batch, even if `receive()` returned fewer rows than the batch contains (due to `max_return`). Either consume the full batch before acking, or use `max_return >= ticker_max_count` (default 500) to ensure all rows are returned.
+The `inserted` CTE runs to completion even though the main query does not reference it (data-modifying CTEs always execute). Every row in `msgs` shares the same `batch_id`, so the scalar subquery picks any one of them and `pgque.ack` runs exactly once. **Batch-ownership caveat:** `pgque.ack(batch_id)` advances the consumer past the entire underlying batch, even if `receive()` returned fewer rows than the batch contains (due to `max_return`). Either consume the full batch before acking, or use `max_return >= ticker_max_count` (default 500) to ensure all rows are returned.
 
 ## Recurring jobs with pg_cron
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -53,18 +53,20 @@ Wrap the receive, your writes, and the ack in one transaction — either all com
 
 ```sql
 begin;
-  create temp table msgs as
-    select * from pgque.receive('orders', 'processor', 100);
-
-  insert into processed_orders (order_id, status)
-  select (payload::jsonb->>'order_id')::int, 'done'
-  from msgs;
-
-  select pgque.ack((select batch_id from msgs limit 1));
+  with msgs as (
+    select * from pgque.receive('orders', 'processor', 100)
+  ),
+  inserted as (
+    insert into processed_orders (order_id, status)
+    select (payload::jsonb->>'order_id')::int, 'done'
+    from msgs
+    returning 1
+  )
+  select pgque.ack(batch_id) from msgs limit 1;
 commit;
 ```
 
-Every row in `msgs` shares the same `batch_id`. **Batch-ownership caveat:** `pgque.ack(batch_id)` advances the consumer past the entire underlying batch, even if `receive()` returned fewer rows than the batch contains (due to `max_return`). Either consume the full batch before acking, or use `max_return >= ticker_max_count` (default 500) to ensure all rows are returned.
+The `inserted` CTE runs to completion even though the main query does not reference it (data-modifying CTEs always execute). Every row in `msgs` shares the same `batch_id`. **Batch-ownership caveat:** `pgque.ack(batch_id)` advances the consumer past the entire underlying batch, even if `receive()` returned fewer rows than the batch contains (due to `max_return`). Either consume the full batch before acking, or use `max_return >= ticker_max_count` (default 500) to ensure all rows are returned.
 
 ## Recurring jobs with pg_cron
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -37,6 +37,8 @@ select pgque.subscribe('orders', 'audit_logger');
 select pgque.subscribe('orders', 'notification_sender');
 select pgque.subscribe('orders', 'analytics_pipeline');
 
+-- send / force_tick / ticker / receive are separate transactions in psql
+-- autocommit. Do not wrap them in begin/commit — the snapshot rule applies.
 select pgque.send('orders', 'order.created', '{"order_id": 1}'::jsonb);
 select pgque.force_tick('orders');
 select pgque.ticker();

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -60,7 +60,6 @@ begin;
     insert into processed_orders (order_id, status)
     select (payload::jsonb->>'order_id')::int, 'done'
     from msgs
-    returning 1
   )
   select pgque.ack(batch_id) from msgs limit 1;
 commit;

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -42,7 +42,7 @@ Available publishing overloads:
 
 Use explicit casts (`::jsonb`, `::jsonb[]`, `::text[]`) when overload resolution would otherwise be ambiguous. Untyped string literals choose the `text` fast path.
 
-**Named-argument note:** PR #159 standardized modern publishing argument names to `queue_name`, `type_name`, `payload`, and `payloads`. Positional calls are unchanged. Named calls using the previous implementation-only names (`i_queue`, `i_type`, `i_payload`, `i_payloads`) must switch to the documented names.
+**Named-argument note:** modern publishing argument names are `queue_name`, `type_name`, `payload`, and `payloads`. Positional calls are unchanged.
 
 #### `pgque.send(queue_name text, payload jsonb) → bigint`
 
@@ -113,7 +113,7 @@ Grant: none (internal). Source: `sql/pgque-api/send.sql`.
 
 The consume API wraps `pgque.next_batch`, `pgque.get_batch_events`, `pgque.finish_batch`, and `pgque.event_retry`. Typical loop: `receive` → process → `ack` (or `nack` on failure).
 
-All consume-side functions (`receive`, `ack`, `nack`, `subscribe`, `unsubscribe`) are granted to `pgque_reader`, mirroring upstream PgQ's producer/consumer role split. Apps that both produce and consume must hold both `pgque_reader` and `pgque_writer` — `pgque_writer` does not inherit `pgque_reader` (see issues #102, #106).
+All consume-side functions (`receive`, `ack`, `nack`, `subscribe`, `unsubscribe`) are granted to `pgque_reader`, mirroring upstream PgQ's producer/consumer role split. Apps that both produce and consume must hold both `pgque_reader` and `pgque_writer` — `pgque_writer` does not inherit `pgque_reader`.
 
 #### `pgque.receive(queue text, consumer text, max_return int default 100) → setof pgque.message`
 
@@ -485,7 +485,7 @@ Returned by `pgque.receive()` and consumed by `pgque.nack()`.
 
 ## Roles and grants
 
-Three roles. `pgque_reader` (consume) and `pgque_writer` (produce) are **siblings**, not parent/child — this mirrors upstream PgQ's role model and prevents a producer-only role from acking another consumer's batch (#102, #106). `pgque_admin` is a member of both. Source: `sql/pgque-additions/roles.sql` (plus colocated grants in `sql/pgque-api/*.sql` and `sql/pgque-additions/dlq.sql`).
+Three roles. `pgque_reader` (consume) and `pgque_writer` (produce) are **siblings**, not parent/child — this mirrors upstream PgQ's role model and prevents a producer-only role from acking another consumer's batch. `pgque_admin` is a member of both. Source: `sql/pgque-additions/roles.sql` (plus colocated grants in `sql/pgque-api/*.sql` and `sql/pgque-additions/dlq.sql`).
 
 Apps that produce **and** consume must be granted both `pgque_reader` and `pgque_writer` explicitly.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -499,7 +499,7 @@ PgQue roles are coarse **database-level** roles. They are intended for trusted a
 - `pgque_writer` can produce to **any** queue (`pgque.send`, `pgque.send_batch`, `pgque.insert_event`).
 - There is **no per-queue ACL** and no per-tenant isolation built into PgQue. Queue names and consumer names are plain strings — any role with the matching grant can interact with them.
 
-This is an intentional design decision for the current release. The batch-ID-based primitives (`ack`, `nack`, `event_retry`) operate on IDs and do not enforce ownership; the producer/consumer split closes only the producer-vs-consumer boundary, not the consumer-vs-consumer one.
+This is intentional, by design. The batch-ID-based primitives (`ack`, `nack`, `event_retry`) operate on IDs and do not enforce ownership; the producer/consumer split closes only the producer-vs-consumer boundary, not the consumer-vs-consumer one.
 
 **Recommended isolation patterns** if you need mutually untrusted tenants in one database:
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -356,7 +356,7 @@ Grant: `pgque_writer`. Source: `sql/pgque-additions/dlq.sql`.
 
 Replays every dead-letter entry for `queue`. Per-event failures are isolated (one bad row does not abort the rest), surfaced via `raise warning`, and counted in `failed`; `first_error` carries the first failure's `dl_id` and `sqlerrm` for diagnostics.
 
-Breaking change in v0.2: previously returned a single `integer` count. Existing callers should switch to:
+Read the result with the columns by name:
 
 ```sql
 select replayed, failed, first_error from pgque.dlq_replay_all('orders');

--- a/docs/three-latencies.md
+++ b/docs/three-latencies.md
@@ -18,7 +18,7 @@ The default 1-second tick is a `pg_cron` schedule, not a design floor. PgQue's e
 - **In-tick sleep loop.** Single cron callout that internally does `pg_sleep(0.01)` ×100 inside one invocation — same effective cadence, fewer scheduler wakeups.
 - **Native sub-second cron.** `pg_cron` does not yet support sub-second schedules natively; the staggered-job or in-tick-sleep workarounds are the current approach.
 
-Trade-off at very high tick rates: every tick UPDATEs `pgque.tick` and `pgque.subscription`, so more ticks = more dead tuples on those metadata tables under held-xmin conditions. The event tables stay bloat-free (TRUNCATE rotation); the metadata-table bloat is a separate story. PgQue v0.2.0 has the same UPDATE pattern on the small subscription/tick tables as upstream PgQ — the bloat shape is bounded but real under sustained held-xmin.
+Trade-off at very high tick rates: every tick UPDATEs `pgque.tick` and `pgque.subscription`, so more ticks = more dead tuples on those metadata tables under held-xmin conditions. The event tables stay bloat-free (TRUNCATE rotation); the metadata-table bloat is a separate story. PgQue uses the same UPDATE pattern on the small subscription/tick tables as upstream PgQ — the bloat shape is bounded but real under sustained held-xmin.
 
 Rough guidance:
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -121,6 +121,8 @@ See the [concepts glossary](pgq-concepts.md) for the full definitions of event, 
 For demos and tests, PgQue provides `pgque.force_tick` to bypass the tick thresholds for one queue. It does **not** create the tick by itself — you still have to call `pgque.ticker()` afterwards to produce the tick:
 
 ```sql
+-- separate transactions (psql autocommit). Do not wrap in begin/commit:
+-- ticker() must see the prior send committed before it can include it in a batch.
 select pgque.force_tick('orders');
 select pgque.ticker();
 ```
@@ -216,6 +218,8 @@ The parameter is `max_retries`, not `queue_max_retries` — `set_queue_config` p
 Send another event, tick, and receive:
 
 ```sql
+-- send / force_tick / ticker / receive are four separate transactions in psql
+-- autocommit. Do not wrap them in begin/commit — the snapshot rule still applies.
 select pgque.send('orders', '{"order_id": 43, "total": 10.00}'::jsonb);
 select pgque.force_tick('orders');
 select pgque.ticker();
@@ -247,6 +251,7 @@ end $$;
 The event is now in PgQ's retry queue. Moving it back into the main event stream is a separate maintenance step: `pgque.maint_retry_events()`. After that, the next tick makes it visible again:
 
 ```sql
+-- four separate transactions (psql autocommit). Do not wrap in begin/commit.
 select pgque.maint_retry_events();
 select pgque.force_tick('orders');
 select pgque.ticker();
@@ -280,6 +285,8 @@ begin
     perform pgque.ack(v_msg.batch_id);
 end $$;
 
+-- the do-block above is one transaction; the three statements below are
+-- three more, in psql autocommit. Do not wrap them in begin/commit.
 select pgque.maint_retry_events();
 select pgque.force_tick('orders');
 select pgque.ticker();

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -39,7 +39,20 @@ select pgque.version();
  [[your version]]
 ```
 
-The install creates the `pgque` schema, three roles (`pgque_reader`, `pgque_writer`, `pgque_admin`), and every function you will call in the rest of this tutorial. See the [reference](reference.md) for the full surface.
+The install creates the `pgque` schema, three roles (`pgque_reader`, `pgque_writer`, `pgque_admin`), and every function you will call in the rest of this tutorial. The roles are siblings: `pgque_writer` produces (`send`, `send_batch`); `pgque_reader` consumes (`subscribe`, `receive`, `ack`, `nack`); `pgque_admin` is a member of both. Apps that produce **and** consume need both:
+
+```sql
+-- Produce + consume:
+grant pgque_reader, pgque_writer to app_orders;
+
+-- Pure producer:
+grant pgque_writer to app_webhook;
+
+-- Pure consumer / dashboard / metrics:
+grant pgque_reader to metrics;
+```
+
+This tutorial runs every step as the install owner, so no extra grants are needed to follow along. See the [reference](reference.md) for the full surface.
 
 ## Step 2: Create the queue and the consumer
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -39,7 +39,9 @@ select pgque.version();
  [[your version]]
 ```
 
-The install creates the `pgque` schema, three roles (`pgque_reader`, `pgque_writer`, `pgque_admin`), and every function you will call in the rest of this tutorial. The roles are siblings: `pgque_writer` produces (`send`, `send_batch`); `pgque_reader` consumes (`subscribe`, `receive`, `ack`, `nack`); `pgque_admin` is a member of both. Apps that produce **and** consume need both:
+The install creates the `pgque` schema, three roles (`pgque_reader`, `pgque_writer`, `pgque_admin`), and every function you will call in the rest of this tutorial. The roles are siblings: `pgque_writer` produces (`send`, `send_batch`); `pgque_reader` consumes (`subscribe`, `receive`, `ack`, `nack`); `pgque_admin` is a member of both.
+
+Apps that produce **and** consume need both — the typical app setup looks like this (illustrative; `app_orders`/`app_webhook`/`metrics` are placeholder app-role names you would create yourself):
 
 ```sql
 -- Produce + consume:
@@ -52,7 +54,7 @@ grant pgque_writer to app_webhook;
 grant pgque_reader to metrics;
 ```
 
-This tutorial runs every step as the install owner, so no extra grants are needed to follow along. See the [reference](reference.md) for the full surface.
+This tutorial runs every step as the install owner, so no extra grants are needed to follow along — skip the snippet above on a fresh box. See the [reference](reference.md) for the full surface.
 
 ## Step 2: Create the queue and the consumer
 
@@ -144,7 +146,7 @@ select * from pgque.receive('orders', 'processor', 100);
 ```
  msg_id | batch_id | type    | payload                            | retry_count | created_at
 --------+----------+---------+------------------------------------+-------------+----------------------
-      1 |        1 | default | {"order_id": 42, "total": 99.95}   |             | 2026-04-17 10:00:00+00
+      1 |        1 | default | {"total": 99.95, "order_id": 42}   |             | 2026-04-17 10:00:00+00
 (1 row)
 ```
 
@@ -223,7 +225,7 @@ select * from pgque.receive('orders', 'processor', 100);
 ```
  msg_id | batch_id | type    | payload                            | retry_count | ...
 --------+----------+---------+------------------------------------+-------------+----
-      2 |        2 | default | {"order_id": 43, "total": 10.00}   |             |
+      2 |        2 | default | {"total": 10.00, "order_id": 43}   |             |
 (1 row)
 ```
 
@@ -256,7 +258,7 @@ In production, `pgque.start()` schedules `maint_retry_events` on its own cadence
 ```
  msg_id | batch_id | type    | payload                            | retry_count | ...
 --------+----------+---------+------------------------------------+-------------+----
-      2 |        3 | default | {"order_id": 43, "total": 10.00}   |           1 |
+      2 |        3 | default | {"total": 10.00, "order_id": 43}   |           1 |
 (1 row)
 ```
 
@@ -295,7 +297,7 @@ from pgque.dlq_inspect('orders');
 ```
  dl_id | dl_reason     | ev_id | ev_retry | ev_data
 -------+---------------+-------+----------+----------------------------------
-     1 | still failing |     2 |        2 | {"order_id": 43, "total": 10.00}
+     1 | still failing |     2 |        2 | {"total": 10.00, "order_id": 43}
 (1 row)
 ```
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -41,7 +41,7 @@ select pgque.version();
 
 The install creates the `pgque` schema, three roles (`pgque_reader`, `pgque_writer`, `pgque_admin`), and every function you will call in the rest of this tutorial. The roles are siblings: `pgque_writer` produces (`send`, `send_batch`); `pgque_reader` consumes (`subscribe`, `receive`, `ack`, `nack`); `pgque_admin` is a member of both.
 
-Apps that produce **and** consume need both — the typical app setup looks like this (illustrative; `app_orders`/`app_webhook`/`metrics` are placeholder app-role names you would create yourself):
+**Skip the next snippet if you are following this tutorial as the install owner** — the rest of the tutorial works without any extra grants. The block below is the typical app-role setup you would do in production, where `app_orders` / `app_webhook` / `metrics` are app-role names you create yourself:
 
 ```sql
 -- Produce + consume:
@@ -54,7 +54,7 @@ grant pgque_writer to app_webhook;
 grant pgque_reader to metrics;
 ```
 
-This tutorial runs every step as the install owner, so no extra grants are needed to follow along — skip the snippet above on a fresh box. See the [reference](reference.md) for the full surface.
+See the [reference](reference.md) for the full surface.
 
 ## Step 2: Create the queue and the consumer
 


### PR DESCRIPTION
## Summary

Tightens the README and `docs/` for someone arriving today, not someone migrating from an older state.

- **No more "pre-#X" framing.** Drop the pre-#163 upgrade block from the README. Migration notes belong in release notes (`CHANGELOG.md` / GitHub releases), not in docs new readers see first.
- **No PR/issue numbers in README or `docs/`.** Removed PgQue's own `#102`, `#106`, `#163`, `#159` references. Behavior is described directly; change history stays in commits and release notes. (External citations to other projects' issue trackers, used as evidence, are fine.)
- **Installation docs are self-complete but brief.** Added a tight role-grants block to `docs/tutorial.md` Step 1 (the zero-to-hero walkthrough) so it covers install + roles in one place. README already has adjacent **Installation** + **Roles and grants** sections; left intact.
- **No temp tables in user-facing examples.** Replaced `create temp table msgs as ...` patterns in the README quick start, the README "Any language" block, and `docs/examples.md` (exactly-once). README now shows `select * from pgque.receive(...)` and a manual `pgque.ack(<batch_id>)`; `docs/examples.md` uses a data-modifying CTE so the exactly-once pattern stays one transaction.
- **Tightened README benchmarks paragraph.** Clarified the 86k ev/s figure is **batched** PL/pgSQL insert. Noted the 30-minute sustained test ran under a **blocked xmin horizon** (concurrent long-running transaction holding an assigned XID — the worst case for SKIP LOCKED queues). Dropped "Server-class numbers to follow" from both the README and `docs/benchmarks.md`.
- **CLAUDE.md.** Added a `### Documentation` block under Style Rules with the two principles (write for new users; no PR/issue numbers in README or `docs/`) and the install-doc completeness rule, so future agents apply them by default.

## Test plan

- [ ] Render the README and `docs/tutorial.md` and confirm no broken anchors or stray PR refs.
- [ ] Eyeball the README Quick start and "Any language" snippets for clarity without temp tables.
- [ ] Confirm `docs/examples.md` exactly-once block still tells one transactional story (CTE form).
- [ ] `grep -rE '(create temp|create temporary)' README.md docs/` returns nothing.
- [ ] `grep -nE '(pre-#|Server-class)' README.md docs/` returns nothing.

https://claude.ai/code/session_011MgPQfBT3Ai8i4BozkBW1W

---
_Generated by [Claude Code](https://claude.ai/code/session_011MgPQfBT3Ai8i4BozkBW1W)_