### PR TITLE
chore(clients): add distribution release plumbing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,16 @@ jobs:
           python -m pip install -e 'clients/python[dev]'
           pytest -v clients/python/tests/
 
+      - name: Python package smoke
+        run: |
+          set -Eeuo pipefail
+          python3 -m venv /tmp/pgque-python-package-venv
+          . /tmp/pgque-python-package-venv/bin/activate
+          python -m pip install -U pip build twine
+          cd clients/python
+          python -m build
+          python -m twine check dist/*
+
       - name: Cleanup Python test DB
         if: always()
         run: docker rm -f pgque-python-test
@@ -211,6 +221,13 @@ jobs:
           bun install --frozen-lockfile
           bun run check
           bun run test
+
+      - name: TypeScript package smoke
+        run: |
+          set -Eeuo pipefail
+          cd clients/typescript
+          bun run build
+          npm pack --dry-run
 
       - name: Cleanup TypeScript test DB
         if: always()

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -7,6 +7,11 @@ on:
         description: "Go client version, e.g. v0.2.0"
         required: true
         type: string
+      dry_run:
+        description: "Validate release without creating a tag/release"
+        required: true
+        default: true
+        type: boolean
       create_release:
         description: "Create a GitHub Release for the submodule tag"
         required: true
@@ -18,10 +23,15 @@ permissions:
 
 jobs:
   tag:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: go-release
+    env:
+      VERSION: ${{ inputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: main
           fetch-depth: 0
 
       - uses: actions/setup-go@v5
@@ -32,35 +42,46 @@ jobs:
       - name: Validate version and tests
         run: |
           set -Eeuo pipefail
-          case "${{ inputs.version }}" in
-            v[0-9]*.[0-9]*.[0-9]*) ;;
-            *) echo "version must look like v0.2.0"; exit 1 ;;
-          esac
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "version must look like v0.2.0"
+            exit 1
+          fi
           cd clients/go
           go test ./...
 
-      - name: Create and push submodule tag
+      - name: Show tag that would be created
+        if: inputs.dry_run
         run: |
           set -Eeuo pipefail
-          tag="clients/go/${{ inputs.version }}"
+          echo "dry run: would create and push clients/go/$VERSION"
+
+      - name: Create and push submodule tag
+        if: ${{ !inputs.dry_run }}
+        run: |
+          set -Eeuo pipefail
+          tag="clients/go/$VERSION"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if git rev-parse "$tag" >/dev/null 2>&1; then
             echo "tag $tag already exists"
             exit 1
           fi
-          git tag -a "$tag" -m "Go client ${{ inputs.version }}"
+          git tag -a "$tag" -m "Go client $VERSION"
           git push origin "$tag"
 
       - name: Create GitHub Release
-        if: inputs.create_release
+        if: ${{ !inputs.dry_run && inputs.create_release }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -Eeuo pipefail
-          gh release create "clients/go/${{ inputs.version }}" \
-            --title "Go client ${{ inputs.version }}" \
-            --notes "Go client release for module github.com/NikolayS/pgque/clients/go. Install with: go get github.com/NikolayS/pgque/clients/go@${{ inputs.version }}"
+          tag="clients/go/$VERSION"
+          gh release create "$tag" \
+            --title "Go client $VERSION" \
+            --notes "Go client release for module github.com/NikolayS/pgque/clients/go. Install with: go get github.com/NikolayS/pgque/clients/go@$VERSION"
 
-      - name: Ask pkg.go.dev to index the version
+      - name: Warm Go module proxy cache
+        if: ${{ !inputs.dry_run }}
         run: |
           set -Eeuo pipefail
-          curl -fsSL "https://proxy.golang.org/github.com/!nikolay!s/pgque/clients/go/@v/${{ inputs.version }}.info" >/dev/null || true
+          curl -fsSL "https://proxy.golang.org/github.com/!nikolay!s/pgque/clients/go/@v/$VERSION.info" >/dev/null || true

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -1,0 +1,66 @@
+name: Release Go client
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Go client version, e.g. v0.2.0"
+        required: true
+        type: string
+      create_release:
+        description: "Create a GitHub Release for the submodule tag"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: clients/go/go.mod
+          cache-dependency-path: clients/go/go.sum
+
+      - name: Validate version and tests
+        run: |
+          set -Eeuo pipefail
+          case "${{ inputs.version }}" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *) echo "version must look like v0.2.0"; exit 1 ;;
+          esac
+          cd clients/go
+          go test ./...
+
+      - name: Create and push submodule tag
+        run: |
+          set -Eeuo pipefail
+          tag="clients/go/${{ inputs.version }}"
+          if git rev-parse "$tag" >/dev/null 2>&1; then
+            echo "tag $tag already exists"
+            exit 1
+          fi
+          git tag -a "$tag" -m "Go client ${{ inputs.version }}"
+          git push origin "$tag"
+
+      - name: Create GitHub Release
+        if: inputs.create_release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          gh release create "clients/go/${{ inputs.version }}" \
+            --title "Go client ${{ inputs.version }}" \
+            --notes "Go client release for module github.com/NikolayS/pgque/clients/go. Install with: go get github.com/NikolayS/pgque/clients/go@${{ inputs.version }}"
+
+      - name: Ask pkg.go.dev to index the version
+        run: |
+          set -Eeuo pipefail
+          curl -fsSL "https://proxy.golang.org/github.com/!nikolay!s/pgque/clients/go/@v/${{ inputs.version }}.info" >/dev/null || true

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -74,6 +74,17 @@ jobs:
             fi
           fi
 
+      - name: Validate mirror-root tree
+        run: |
+          set -Eeuo pipefail
+          tmp=$(mktemp -d)
+          git worktree add --detach "$tmp" "$split_sha"
+          trap 'git worktree remove --force "$tmp"' EXIT
+          cd "$tmp"
+          test "$(go list -m)" = "github.com/NikolayS/pgque-go"
+          go list ./...
+          go test ./...
+
       - name: Show mirror update dry run
         if: inputs.dry_run
         run: |

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -62,10 +62,17 @@ jobs:
           GH_TOKEN: ${{ secrets.PGQUE_GO_MIRROR_TOKEN }}
         run: |
           set -Eeuo pipefail
-          git ls-remote --exit-code --tags "https://x-access-token:${GH_TOKEN}@github.com/${MIRROR_REPO}.git" "refs/tags/$VERSION" && {
+          remote="https://x-access-token:${GH_TOKEN}@github.com/${MIRROR_REPO}.git"
+          if git ls-remote --exit-code --tags "$remote" "refs/tags/$VERSION" >/dev/null; then
             echo "mirror tag $VERSION already exists"
             exit 1
-          } || true
+          else
+            rc=$?
+            if [ "$rc" -ne 2 ]; then
+              echo "failed to check mirror tag $VERSION"
+              exit "$rc"
+            fi
+          fi
 
       - name: Show mirror update dry run
         if: inputs.dry_run
@@ -79,12 +86,19 @@ jobs:
           GH_TOKEN: ${{ secrets.PGQUE_GO_MIRROR_TOKEN }}
         run: |
           set -Eeuo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           remote="https://x-access-token:${GH_TOKEN}@github.com/${MIRROR_REPO}.git"
+          candidate="refs/heads/release-candidate/$VERSION"
+          git push "$remote" "$split_sha:$candidate"
+
+          tmp=$(mktemp -d)
+          git clone --no-checkout --filter=blob:none "$remote" "$tmp"
+          git -C "$tmp" config user.name "github-actions[bot]"
+          git -C "$tmp" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C "$tmp" fetch origin "$candidate"
+          git -C "$tmp" tag -a "$VERSION" FETCH_HEAD -m "Go client $VERSION"
+          git -C "$tmp" push origin "refs/tags/$VERSION"
           git push "$remote" "$split_sha:refs/heads/main"
-          git tag -a "$VERSION" "$split_sha" -m "Go client $VERSION"
-          git push "$remote" "refs/tags/$VERSION"
+          git push "$remote" ":$candidate"
 
       - name: Create GitHub Release in mirror
         if: ${{ !inputs.dry_run && inputs.create_release }}

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -8,26 +8,27 @@ on:
         required: true
         type: string
       dry_run:
-        description: "Validate release without creating a tag/release"
+        description: "Validate release without pushing to mirror"
         required: true
         default: true
         type: boolean
       create_release:
-        description: "Create a GitHub Release for the submodule tag"
+        description: "Create a GitHub Release in the mirror repository"
         required: true
         default: true
         type: boolean
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  tag:
+  mirror-and-tag:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: go-release
     env:
       VERSION: ${{ inputs.version }}
+      MIRROR_REPO: NikolayS/pgque-go
     steps:
       - uses: actions/checkout@v4
         with:
@@ -49,39 +50,56 @@ jobs:
           cd clients/go
           go test ./...
 
-      - name: Show tag that would be created
+      - name: Split clients/go subtree
+        run: |
+          set -Eeuo pipefail
+          split_sha=$(git subtree split --prefix=clients/go HEAD)
+          echo "split_sha=$split_sha" >> "$GITHUB_ENV"
+          echo "mirror commit: $split_sha"
+
+      - name: Check mirror tag does not exist
+        env:
+          GH_TOKEN: ${{ secrets.PGQUE_GO_MIRROR_TOKEN }}
+        run: |
+          set -Eeuo pipefail
+          git ls-remote --exit-code --tags "https://x-access-token:${GH_TOKEN}@github.com/${MIRROR_REPO}.git" "refs/tags/$VERSION" && {
+            echo "mirror tag $VERSION already exists"
+            exit 1
+          } || true
+
+      - name: Show mirror update dry run
         if: inputs.dry_run
         run: |
           set -Eeuo pipefail
-          echo "dry run: would create and push clients/go/$VERSION"
+          echo "dry run: would push subtree $split_sha to ${MIRROR_REPO}:main and tag $VERSION"
 
-      - name: Create and push submodule tag
+      - name: Push mirror main and tag
         if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ secrets.PGQUE_GO_MIRROR_TOKEN }}
         run: |
           set -Eeuo pipefail
-          tag="clients/go/$VERSION"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git rev-parse "$tag" >/dev/null 2>&1; then
-            echo "tag $tag already exists"
-            exit 1
-          fi
-          git tag -a "$tag" -m "Go client $VERSION"
-          git push origin "$tag"
+          remote="https://x-access-token:${GH_TOKEN}@github.com/${MIRROR_REPO}.git"
+          git push "$remote" "$split_sha:refs/heads/main"
+          git tag -a "$VERSION" "$split_sha" -m "Go client $VERSION"
+          git push "$remote" "refs/tags/$VERSION"
 
-      - name: Create GitHub Release
+      - name: Create GitHub Release in mirror
         if: ${{ !inputs.dry_run && inputs.create_release }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PGQUE_GO_MIRROR_TOKEN }}
         run: |
           set -Eeuo pipefail
-          tag="clients/go/$VERSION"
-          gh release create "$tag" \
+          gh release create "$VERSION" \
+            --repo "$MIRROR_REPO" \
+            --target "$split_sha" \
             --title "Go client $VERSION" \
-            --notes "Go client release for module github.com/NikolayS/pgque/clients/go. Install with: go get github.com/NikolayS/pgque/clients/go@$VERSION"
+            --notes "Go client release for module github.com/NikolayS/pgque-go. Install with: go get github.com/NikolayS/pgque-go@$VERSION"
 
       - name: Warm Go module proxy cache
         if: ${{ !inputs.dry_run }}
         run: |
           set -Eeuo pipefail
-          curl -fsSL "https://proxy.golang.org/github.com/!nikolay!s/pgque/clients/go/@v/$VERSION.info" >/dev/null || true
+          curl -fsSL "https://proxy.golang.org/github.com/!nikolay!s/pgque-go/@v/$VERSION.info" >/dev/null || true

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -1,0 +1,68 @@
+name: Release Python client
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish, matching clients/python/pyproject.toml"
+        required: true
+        type: string
+      repository:
+        description: "Package index"
+        required: true
+        default: "testpypi"
+        type: choice
+        options:
+          - testpypi
+          - pypi
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.repository == 'pypi' && 'pypi' || 'testpypi' }}
+    defaults:
+      run:
+        working-directory: clients/python
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Verify version input
+        run: |
+          set -Eeuo pipefail
+          actual=$(python - <<'PY'
+          import tomllib
+          print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])
+          PY
+          )
+          test "$actual" = "${{ inputs.version }}" || {
+            echo "version input ${{ inputs.version }} != pyproject.toml $actual"
+            exit 1
+          }
+
+      - name: Build distribution
+        run: |
+          set -Eeuo pipefail
+          python -m pip install -U build twine
+          python -m build
+          python -m twine check dist/*
+
+      - name: Publish to TestPyPI
+        if: inputs.repository == 'testpypi'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: clients/python/dist
+          repository-url: https://test.pypi.org/legacy/
+
+      - name: Publish to PyPI
+        if: inputs.repository == 'pypi'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: clients/python/dist

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -15,6 +15,11 @@ on:
         options:
           - testpypi
           - pypi
+      dry_run:
+        description: "Build and validate without publishing"
+        required: true
+        default: true
+        type: boolean
 
 permissions:
   contents: read
@@ -62,15 +67,28 @@ jobs:
           python -m build
           python -m twine check dist/*
 
+      - name: Verify built wheel installs
+        run: |
+          set -Eeuo pipefail
+          python -m venv /tmp/pgque-python-wheel-check
+          . /tmp/pgque-python-wheel-check/bin/activate
+          python -m pip install dist/*.whl
+          python - <<'PY'
+          import importlib.metadata as md
+          import pgque
+          assert md.version('pgque-py')
+          assert hasattr(pgque, 'PgqueClient')
+          PY
+
       - name: Publish to TestPyPI
-        if: inputs.repository == 'testpypi'
+        if: ${{ !inputs.dry_run && inputs.repository == 'testpypi' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: clients/python/dist
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish to PyPI
-        if: inputs.repository == 'pypi'
+        if: ${{ !inputs.dry_run && inputs.repository == 'pypi' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: clients/python/dist

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -47,9 +47,10 @@ jobs:
       - name: Verify version input
         run: |
           set -Eeuo pipefail
-          case "$VERSION" in
-            *[!0-9.]*|*..*|.*|*.) echo "version must look like 0.2.0"; exit 1 ;;
-          esac
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "version must look like 0.2.0"
+            exit 1
+          fi
           actual=$(python - <<'PY'
           import tomllib
           print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -22,13 +22,18 @@ permissions:
 
 jobs:
   build-and-publish:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: ${{ inputs.repository == 'pypi' && 'pypi' || 'testpypi' }}
+    env:
+      VERSION: ${{ inputs.version }}
     defaults:
       run:
         working-directory: clients/python
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
 
       - uses: actions/setup-python@v5
         with:
@@ -37,13 +42,16 @@ jobs:
       - name: Verify version input
         run: |
           set -Eeuo pipefail
+          case "$VERSION" in
+            *[!0-9.]*|*..*|.*|*.) echo "version must look like 0.2.0"; exit 1 ;;
+          esac
           actual=$(python - <<'PY'
           import tomllib
           print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])
           PY
           )
-          test "$actual" = "${{ inputs.version }}" || {
-            echo "version input ${{ inputs.version }} != pyproject.toml $actual"
+          test "$actual" = "$VERSION" || {
+            echo "version input $VERSION != pyproject.toml $actual"
             exit 1
           }
 

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -19,13 +19,18 @@ permissions:
 
 jobs:
   build-and-publish:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: npm
+    env:
+      VERSION: ${{ inputs.version }}
     defaults:
       run:
         working-directory: clients/typescript
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -34,15 +39,21 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "22.14.0"
           registry-url: https://registry.npmjs.org
+
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@^11.5.1
 
       - name: Verify version input
         run: |
           set -Eeuo pipefail
+          case "$VERSION" in
+            *[!0-9.]*|*..*|.*|*.) echo "version must look like 0.2.0"; exit 1 ;;
+          esac
           actual=$(node -p "require('./package.json').version")
-          test "$actual" = "${{ inputs.version }}" || {
-            echo "version input ${{ inputs.version }} != package.json $actual"
+          test "$actual" = "$VERSION" || {
+            echo "version input $VERSION != package.json $actual"
             exit 1
           }
 

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -1,0 +1,65 @@
+name: Release TypeScript client
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish, matching clients/typescript/package.json"
+        required: true
+        type: string
+      dry_run:
+        description: "Run npm publish --dry-run instead of publishing"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    environment: npm
+    defaults:
+      run:
+        working-directory: clients/typescript
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.8
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: https://registry.npmjs.org
+
+      - name: Verify version input
+        run: |
+          set -Eeuo pipefail
+          actual=$(node -p "require('./package.json').version")
+          test "$actual" = "${{ inputs.version }}" || {
+            echo "version input ${{ inputs.version }} != package.json $actual"
+            exit 1
+          }
+
+      - name: Install and build
+        run: |
+          set -Eeuo pipefail
+          bun install --frozen-lockfile
+          bun run check
+          bun run build
+
+      - name: Pack smoke test
+        run: npm pack --dry-run
+
+      - name: Publish dry run
+        if: inputs.dry_run
+        run: npm publish --dry-run --provenance
+
+      - name: Publish to npm
+        if: ${{ !inputs.dry_run }}
+        run: npm publish --provenance

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -62,6 +62,7 @@ jobs:
           set -Eeuo pipefail
           bun install --frozen-lockfile
           bun run check
+          bun run test
           bun run build
 
       - name: Pack smoke test

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -48,9 +48,10 @@ jobs:
       - name: Verify version input
         run: |
           set -Eeuo pipefail
-          case "$VERSION" in
-            *[!0-9.]*|*..*|.*|*.) echo "version must look like 0.2.0"; exit 1 ;;
-          esac
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "version must look like 0.2.0"
+            exit 1
+          fi
           actual=$(node -p "require('./package.json').version")
           test "$actual" = "$VERSION" || {
             echo "version input $VERSION != package.json $actual"

--- a/README.md
+++ b/README.md
@@ -269,18 +269,26 @@ Longer walkthrough in the [tutorial](docs/tutorial.md); patterns like fan-out, e
 
 ## Client libraries
 
-PgQue is SQL-first, so any Postgres driver works. Example client libraries exist for **Python**, **Go**, and **TypeScript** — unpublished, still evolving, demonstrating integration patterns rather than stable SDKs. **Contributions welcome.**
+PgQue is SQL-first, so any Postgres driver works. First-party client libraries are available for **Python**, **Go**, and **TypeScript**.
 
 ### Python (`pgque-py`) — psycopg 3
 
+```bash
+pip install pgque-py
+```
+
 ```python
-from pgque import PgqueClient, Consumer
+from pgque import Consumer, connect
 
-client = PgqueClient(conn)
-# type= must match the event type the consumer listens on
-client.send("orders", {"order_id": 42}, type="order.created")
+with connect("postgresql://localhost/mydb") as client:
+    client.send("orders", {"order_id": 42}, type="order.created")
+    client.conn.commit()
 
-consumer = Consumer(dsn, queue="orders", name="processor", poll_interval=30)
+consumer = Consumer(
+    "postgresql://localhost/mydb",
+    queue="orders",
+    name="processor",
+)
 
 @consumer.on("order.created")
 def handle_order(msg):
@@ -289,10 +297,20 @@ def handle_order(msg):
 consumer.start()
 ```
 
-### Go (`pgque-go`) — pgx/v5
+### Go (`github.com/NikolayS/pgque/clients/go`) — pgx/v5
+
+```bash
+go get github.com/NikolayS/pgque/clients/go@v0.2.0
+```
 
 ```go
 client, _ := pgque.Connect(ctx, "postgresql://localhost/mydb")
+defer client.Close()
+
+_, _ = client.Send(ctx, "orders", pgque.Event{
+    Type:    "order.created",
+    Payload: map[string]any{"order_id": 42},
+})
 
 consumer := client.NewConsumer("orders", "processor")
 consumer.Handle("order.created", func(ctx context.Context, msg pgque.Message) error {
@@ -301,17 +319,28 @@ consumer.Handle("order.created", func(ctx context.Context, msg pgque.Message) er
 consumer.Start(ctx)
 ```
 
-### TypeScript (`pgque-ts`) — node-postgres
+### TypeScript (`pgque`) — node-postgres
+
+```bash
+npm install pgque
+```
 
 ```ts
-const client = new PgqueClient('postgresql://localhost/mydb');
-await client.connect();
+import { connect } from 'pgque';
 
-await client.send('orders', { order_id: 42 }, 'order.created');
-await client.subscribe('orders', 'processor');
+const client = await connect('postgresql://localhost/mydb');
+try {
+  await client.send('orders', {
+    type: 'order.created',
+    payload: { order_id: 42 },
+  });
+  await client.subscribe('orders', 'processor');
 
-const messages = await client.receive('orders', 'processor', 100);
-if (messages.length > 0) await client.ack(messages[0].batch_id);
+  const messages = await client.receive('orders', 'processor', 100);
+  if (messages.length > 0) await client.ack(messages[0]!.batchId);
+} finally {
+  await client.close();
+}
 ```
 
 ### Any language

--- a/README.md
+++ b/README.md
@@ -297,10 +297,10 @@ def handle_order(msg):
 consumer.start()
 ```
 
-### Go (`github.com/NikolayS/pgque/clients/go`) — pgx/v5
+### Go (`github.com/NikolayS/pgque-go`) — pgx/v5
 
 ```bash
-go get github.com/NikolayS/pgque/clients/go@v0.2.0
+go get github.com/NikolayS/pgque-go@latest
 ```
 
 ```go

--- a/README.md
+++ b/README.md
@@ -269,11 +269,12 @@ Longer walkthrough in the [tutorial](docs/tutorial.md); patterns like fan-out, e
 
 ## Client libraries
 
-PgQue is SQL-first, so any Postgres driver works. First-party client libraries are available for **Python**, **Go**, and **TypeScript**.
+PgQue is SQL-first, so any Postgres driver works. First-party client libraries live in this repo for **Python**, **Go**, and **TypeScript**. The install commands below apply after the first client packages are published.
 
 ### Python (`pgque-py`) — psycopg 3
 
 ```bash
+# after the first Python client release
 pip install pgque-py
 ```
 
@@ -300,6 +301,7 @@ consumer.start()
 ### Go (`github.com/NikolayS/pgque-go`) — pgx/v5
 
 ```bash
+# after the first Go client release
 go get github.com/NikolayS/pgque-go@latest
 ```
 
@@ -322,6 +324,7 @@ consumer.Start(ctx)
 ### TypeScript (`pgque`) — node-postgres
 
 ```bash
+# after the first TypeScript client release
 npm install pgque
 ```
 

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -7,7 +7,7 @@ universal PostgreSQL queue. A thin, idiomatic wrapper over the
 ## Install
 
 ```bash
-go get github.com/NikolayS/pgque/clients/go@latest
+go get github.com/NikolayS/pgque-go@latest
 ```
 
 Requires Go 1.21+ and PostgreSQL 14+ with the PgQue schema installed
@@ -22,7 +22,7 @@ import (
     "context"
     "log"
 
-    pgque "github.com/NikolayS/pgque/clients/go"
+    pgque "github.com/NikolayS/pgque-go"
 )
 
 func main() {
@@ -115,8 +115,9 @@ Without `PGQUE_TEST_DSN`, the tests skip.
 ## Distribution
 
 This client is published as the Go module
-`github.com/NikolayS/pgque/clients/go`. Because it lives in a subdirectory,
-release tags use the Go submodule form, for example `clients/go/vX.Y.Z`.
+`github.com/NikolayS/pgque-go`. Source lives in this monorepo under
+`clients/go`; releases sync that subtree to the mirror repository and use
+normal Go module tags such as `vX.Y.Z`.
 
 See [RELEASE.md](RELEASE.md) for publishing steps.
 

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -6,6 +6,8 @@ universal PostgreSQL queue. A thin, idiomatic wrapper over the
 
 ## Install
 
+After the first Go client release:
+
 ```bash
 go get github.com/NikolayS/pgque-go@latest
 ```

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -7,7 +7,7 @@ universal PostgreSQL queue. A thin, idiomatic wrapper over the
 ## Install
 
 ```bash
-go get github.com/NikolayS/pgque/clients/go
+go get github.com/NikolayS/pgque/clients/go@v0.2.0
 ```
 
 Requires Go 1.21+ and PostgreSQL 14+ with the PgQue schema installed
@@ -111,6 +111,14 @@ PGQUE_TEST_DSN=postgres://postgres:pgque_test@localhost/pgque_test \
 ```
 
 Without `PGQUE_TEST_DSN`, the tests skip.
+
+## Distribution
+
+This client is published as the Go module
+`github.com/NikolayS/pgque/clients/go`. Because it lives in a subdirectory,
+release tags use the Go submodule form, for example `clients/go/v0.2.0`.
+
+See [RELEASE.md](RELEASE.md) for publishing steps.
 
 ## More
 

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -7,7 +7,7 @@ universal PostgreSQL queue. A thin, idiomatic wrapper over the
 ## Install
 
 ```bash
-go get github.com/NikolayS/pgque/clients/go@v0.2.0
+go get github.com/NikolayS/pgque/clients/go@latest
 ```
 
 Requires Go 1.21+ and PostgreSQL 14+ with the PgQue schema installed
@@ -116,7 +116,7 @@ Without `PGQUE_TEST_DSN`, the tests skip.
 
 This client is published as the Go module
 `github.com/NikolayS/pgque/clients/go`. Because it lives in a subdirectory,
-release tags use the Go submodule form, for example `clients/go/v0.2.0`.
+release tags use the Go submodule form, for example `clients/go/vX.Y.Z`.
 
 See [RELEASE.md](RELEASE.md) for publishing steps.
 

--- a/clients/go/RELEASE.md
+++ b/clients/go/RELEASE.md
@@ -1,11 +1,15 @@
 # Go client release
 
-Module path: `github.com/NikolayS/pgque/clients/go`.
+Public module path: `github.com/NikolayS/pgque-go`.
+
+Source of truth lives in this monorepo under `clients/go/`. Releases use a
+hybrid mirror: the release workflow splits `clients/go` into a root-level tree
+and pushes it to the read-only mirror repository `NikolayS/pgque-go`.
 
 Install:
 
 ```bash
-go get github.com/NikolayS/pgque/clients/go@latest
+go get github.com/NikolayS/pgque-go@latest
 ```
 
 ## Versioning
@@ -16,24 +20,32 @@ SQL changes do not require a Go client release.
 
 ## Tagging convention
 
-This module lives in a subdirectory. Go requires tags scoped to the module root:
+The mirror repository uses normal Go module tags:
 
 ```bash
-clients/go/v0.2.0
+vX.Y.Z
 ```
 
-A plain repository tag like `v0.2.0` does **not** identify this submodule for
-`go get`.
+Do not use monorepo subdirectory tags such as `clients/go/vX.Y.Z` for public
+Go client releases.
+
+## Mirror setup
+
+Create `github.com/NikolayS/pgque-go` as the public mirror repository. It should
+be treated as generated/read-only; changes happen in `clients/go` in this repo.
+
+Configure repository secret `PGQUE_GO_MIRROR_TOKEN` in this repo. The token must
+be able to push branches/tags and create GitHub Releases in `NikolayS/pgque-go`.
+A fine-grained PAT scoped only to the mirror repository is preferred.
 
 ## Release process
 
 The release workflow is `.github/workflows/release-go.yml`.
 
 1. Update `clients/go` docs/code as needed and merge the release prep PR.
-2. Run **Release Go client** with `version=vX.Y.Z` and `dry_run=true`.
+2. Run **Release Go client** from `main` with `version=vX.Y.Z` and `dry_run=true`.
 3. If the dry run is clean, run it again with `dry_run=false`.
-4. The workflow runs `go test ./...`, creates annotated tag
-   `clients/go/vX.Y.Z`, pushes it, and optionally creates a GitHub Release.
+4. The workflow runs `go test ./...`, splits `clients/go`, pushes the mirror's
+   `main`, creates annotated tag `vX.Y.Z` in the mirror, and optionally creates
+   a GitHub Release in `NikolayS/pgque-go`.
 5. pkg.go.dev indexes the module after the tag is visible through the Go proxy.
-
-No package registry credentials are required.

--- a/clients/go/RELEASE.md
+++ b/clients/go/RELEASE.md
@@ -1,0 +1,38 @@
+# Go client release
+
+Module path: `github.com/NikolayS/pgque/clients/go`.
+
+Install:
+
+```bash
+go get github.com/NikolayS/pgque/clients/go@v0.2.0
+```
+
+## Versioning
+
+The Go client version is independent from the SQL/server `pgque.version()`.
+Bump this module when the Go API, behavior, or packaging changes; server-only
+SQL changes do not require a Go client release.
+
+## Tagging convention
+
+This module lives in a subdirectory. Go requires tags scoped to the module root:
+
+```bash
+clients/go/v0.2.0
+```
+
+A plain repository tag like `v0.2.0` does **not** identify this submodule for
+`go get`.
+
+## Release process
+
+The release workflow is `.github/workflows/release-go.yml`.
+
+1. Update `clients/go` docs/code as needed and merge the release prep PR.
+2. Run **Release Go client** with `version=vX.Y.Z`.
+3. The workflow runs `go test ./...`, creates annotated tag
+   `clients/go/vX.Y.Z`, pushes it, and optionally creates a GitHub Release.
+4. pkg.go.dev indexes the module after the tag is visible through the Go proxy.
+
+No package registry credentials are required.

--- a/clients/go/RELEASE.md
+++ b/clients/go/RELEASE.md
@@ -15,8 +15,8 @@ go get github.com/NikolayS/pgque-go@latest
 ## Versioning
 
 The Go client version is independent from the SQL/server `pgque.version()`.
-Bump this module when the Go API, behavior, or packaging changes; server-only
-SQL changes do not require a Go client release.
+Choose the next Go module tag when the Go API, behavior, or packaging changes;
+server-only SQL changes do not require a Go client release.
 
 ## Tagging convention
 

--- a/clients/go/RELEASE.md
+++ b/clients/go/RELEASE.md
@@ -5,7 +5,7 @@ Module path: `github.com/NikolayS/pgque/clients/go`.
 Install:
 
 ```bash
-go get github.com/NikolayS/pgque/clients/go@v0.2.0
+go get github.com/NikolayS/pgque/clients/go@latest
 ```
 
 ## Versioning
@@ -30,9 +30,10 @@ A plain repository tag like `v0.2.0` does **not** identify this submodule for
 The release workflow is `.github/workflows/release-go.yml`.
 
 1. Update `clients/go` docs/code as needed and merge the release prep PR.
-2. Run **Release Go client** with `version=vX.Y.Z`.
-3. The workflow runs `go test ./...`, creates annotated tag
+2. Run **Release Go client** with `version=vX.Y.Z` and `dry_run=true`.
+3. If the dry run is clean, run it again with `dry_run=false`.
+4. The workflow runs `go test ./...`, creates annotated tag
    `clients/go/vX.Y.Z`, pushes it, and optionally creates a GitHub Release.
-4. pkg.go.dev indexes the module after the tag is visible through the Go proxy.
+5. pkg.go.dev indexes the module after the tag is visible through the Go proxy.
 
 No package registry credentials are required.

--- a/clients/go/RELEASE.md
+++ b/clients/go/RELEASE.md
@@ -38,14 +38,23 @@ Configure repository secret `PGQUE_GO_MIRROR_TOKEN` in this repo. The token must
 be able to push branches/tags and create GitHub Releases in `NikolayS/pgque-go`.
 A fine-grained PAT scoped only to the mirror repository is preferred.
 
+## GitHub environment prerequisite
+
+Before the first real release, create GitHub environment `go-release` in
+`NikolayS/pgque`. Protect it as appropriate for releases (for example, required
+reviewers and `main` branch restrictions). The workflow also checks that it is
+running from `main`, but environment protection is the human approval gate.
+
 ## Release process
 
 The release workflow is `.github/workflows/release-go.yml`.
 
 1. Update `clients/go` docs/code as needed and merge the release prep PR.
-2. Run **Release Go client** from `main` with `version=vX.Y.Z` and `dry_run=true`.
-3. If the dry run is clean, run it again with `dry_run=false`.
-4. The workflow runs `go test ./...`, splits `clients/go`, pushes the mirror's
+2. Ensure the `go-release` GitHub environment exists and is protected.
+3. Ensure `PGQUE_GO_MIRROR_TOKEN` is configured.
+4. Run **Release Go client** from `main` with `version=vX.Y.Z` and `dry_run=true`.
+5. If the dry run is clean, run it again with `dry_run=false`.
+6. The workflow runs `go test ./...`, splits `clients/go`, pushes the mirror's
    `main`, creates annotated tag `vX.Y.Z` in the mirror, and optionally creates
    a GitHub Release in `NikolayS/pgque-go`.
-5. pkg.go.dev indexes the module after the tag is visible through the Go proxy.
+7. pkg.go.dev indexes the module after the tag is visible through the Go proxy.

--- a/clients/go/bench_test.go
+++ b/clients/go/bench_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	pgque "github.com/NikolayS/pgque/clients/go"
+	pgque "github.com/NikolayS/pgque-go"
 )
 
 // BenchmarkSend measures single-Send latency.

--- a/clients/go/concurrency_test.go
+++ b/clients/go/concurrency_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	pgque "github.com/NikolayS/pgque/clients/go"
+	pgque "github.com/NikolayS/pgque-go"
 )
 
 // TestRace_ConcurrentSend: many goroutines call Send concurrently; no race,

--- a/clients/go/consumer_nackfail_test.go
+++ b/clients/go/consumer_nackfail_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	pgque "github.com/NikolayS/pgque/clients/go"
+	pgque "github.com/NikolayS/pgque-go"
 )
 
 // stubBackend is a Consumer backend that returns a single message on the

--- a/clients/go/consumer_test.go
+++ b/clients/go/consumer_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	pgque "github.com/NikolayS/pgque/clients/go"
+	pgque "github.com/NikolayS/pgque-go"
 )
 
 // TestConsumer_StartStop_Clean: Start should return ctx.Err() promptly when

--- a/clients/go/doc.go
+++ b/clients/go/doc.go
@@ -6,7 +6,7 @@
 //
 // Install the Go module:
 //
-//	go get github.com/NikolayS/pgque/clients/go
+//	go get github.com/NikolayS/pgque-go
 //
 // Quick start:
 //

--- a/clients/go/edge_test.go
+++ b/clients/go/edge_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	pgque "github.com/NikolayS/pgque/clients/go"
+	pgque "github.com/NikolayS/pgque-go"
 )
 
 // TestEvent_EmptyPayload: a nil Payload marshals to JSON null and round-trips.

--- a/clients/go/errors_test.go
+++ b/clients/go/errors_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	pgque "github.com/NikolayS/pgque/clients/go"
+	pgque "github.com/NikolayS/pgque-go"
 )
 
 // TestConnect_BadDSN: a syntactically invalid DSN must error from Connect,

--- a/clients/go/examples_test.go
+++ b/clients/go/examples_test.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"log"
 
-	pgque "github.com/NikolayS/pgque/clients/go"
+	pgque "github.com/NikolayS/pgque-go"
 )
 
 // Example showing the canonical send / receive / ack flow.

--- a/clients/go/go.mod
+++ b/clients/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/NikolayS/pgque/clients/go
+module github.com/NikolayS/pgque-go
 
 go 1.21
 

--- a/clients/go/helpers_test.go
+++ b/clients/go/helpers_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	pgque "github.com/NikolayS/pgque/clients/go"
+	pgque "github.com/NikolayS/pgque-go"
 )
 
 // freshDSN returns the DSN for the integration test database.

--- a/clients/go/integration_test.go
+++ b/clients/go/integration_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	pgque "github.com/NikolayS/pgque/clients/go"
+	pgque "github.com/NikolayS/pgque-go"
 )
 
 // TestSend_DefaultEventType verifies that an Event with empty Type is sent

--- a/clients/go/pgque_test.go
+++ b/clients/go/pgque_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	pgque "github.com/NikolayS/pgque/clients/go"
+	pgque "github.com/NikolayS/pgque-go"
 )
 
 func getDSN() string {

--- a/clients/go/producer_benchmark_test.go
+++ b/clients/go/producer_benchmark_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	pgque "github.com/NikolayS/pgque/clients/go"
+	pgque "github.com/NikolayS/pgque-go"
 )
 
 // TestProducerBenchmarks compares send-loop and SendBatch producer paths.

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -7,6 +7,8 @@ universal PostgreSQL queue. Thin wrapper over `pgque-api` SQL functions:
 
 ## Install
 
+After the first Python client release:
+
 ```bash
 pip install pgque-py
 ```

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -8,7 +8,7 @@ universal PostgreSQL queue. Thin wrapper over `pgque-api` SQL functions:
 ## Install
 
 ```bash
-pip install pgque
+pip install pgque-py
 ```
 
 Requires Python 3.10+ and PostgreSQL 14+ with the PgQue schema installed
@@ -93,6 +93,16 @@ PGQUE_TEST_DSN=postgresql://postgres:pgque_test@localhost/pgque_test \
 ```
 
 Without `PGQUE_TEST_DSN`, the tests skip.
+
+## Distribution
+
+The PyPI distribution is `pgque-py`; the import package is `pgque`:
+
+```python
+import pgque
+```
+
+See [RELEASE.md](RELEASE.md) for publishing steps.
 
 ## More
 

--- a/clients/python/RELEASE.md
+++ b/clients/python/RELEASE.md
@@ -31,8 +31,9 @@ The release workflow is `.github/workflows/release-python.yml`.
    - environment: `pypi`
    - package: `pgque-py`
 4. In TestPyPI, configure the same workflow with environment `testpypi`.
-5. Run **Release Python client** with `repository=testpypi` first.
-6. Verify the TestPyPI artifact installs in a clean environment, using PyPI
+5. Run **Release Python client** with `dry_run=true` first.
+6. Run it with `dry_run=false` and `repository=testpypi`.
+7. Verify the TestPyPI artifact installs in a clean environment, using PyPI
    as the extra index for dependencies:
 
    ```bash
@@ -41,7 +42,7 @@ The release workflow is `.github/workflows/release-python.yml`.
      --extra-index-url https://pypi.org/simple \
      pgque-py
    ```
-7. Run the workflow again with `repository=pypi`.
+8. Run the workflow again with `dry_run=false` and `repository=pypi`.
 
 The workflow builds with `python -m build`, validates with `twine check`, and
 publishes via PyPI Trusted Publisher / OIDC. No long-lived PyPI token is needed.

--- a/clients/python/RELEASE.md
+++ b/clients/python/RELEASE.md
@@ -19,21 +19,33 @@ The Python client version is independent from the SQL/server
 `pgque.version()`. Bump this package when the Python API or packaging changes;
 server-only SQL changes do not require a Python client release.
 
+## GitHub environment prerequisite
+
+Before the first real publish, create GitHub environments in `NikolayS/pgque`:
+
+- `testpypi`
+- `pypi`
+
+Protect them as appropriate for releases (for example, required reviewers and
+`main` branch restrictions). The workflow also checks that it is running from
+`main`, but environment protection is the human approval gate.
+
 ## Release process
 
 The release workflow is `.github/workflows/release-python.yml`.
 
 1. Update `clients/python/pyproject.toml` version and any release notes/changelog if present.
 2. Merge the release prep PR.
-3. In PyPI, configure Trusted Publisher for:
+3. Ensure the `testpypi` and `pypi` GitHub environments exist and are protected.
+4. In PyPI, configure Trusted Publisher for:
    - repository: `NikolayS/pgque`
    - workflow: `release-python.yml`
    - environment: `pypi`
    - package: `pgque-py`
-4. In TestPyPI, configure the same workflow with environment `testpypi`.
-5. Run **Release Python client** with `dry_run=true` first.
-6. Run it with `dry_run=false` and `repository=testpypi`.
-7. Verify the TestPyPI artifact installs in a clean environment, using PyPI
+5. In TestPyPI, configure the same workflow with environment `testpypi`.
+6. Run **Release Python client** with `dry_run=true` first.
+7. Run it with `dry_run=false` and `repository=testpypi`.
+8. Verify the TestPyPI artifact installs in a clean environment, using PyPI
    as the extra index for dependencies:
 
    ```bash
@@ -42,7 +54,7 @@ The release workflow is `.github/workflows/release-python.yml`.
      --extra-index-url https://pypi.org/simple \
      pgque-py
    ```
-8. Run the workflow again with `dry_run=false` and `repository=pypi`.
+9. Run the workflow again with `dry_run=false` and `repository=pypi`.
 
 The workflow builds with `python -m build`, validates with `twine check`, and
 publishes via PyPI Trusted Publisher / OIDC. No long-lived PyPI token is needed.

--- a/clients/python/RELEASE.md
+++ b/clients/python/RELEASE.md
@@ -23,7 +23,7 @@ server-only SQL changes do not require a Python client release.
 
 The release workflow is `.github/workflows/release-python.yml`.
 
-1. Update `clients/python/pyproject.toml` version and changelog/release notes.
+1. Update `clients/python/pyproject.toml` version and any release notes/changelog if present.
 2. Merge the release prep PR.
 3. In PyPI, configure Trusted Publisher for:
    - repository: `NikolayS/pgque`

--- a/clients/python/RELEASE.md
+++ b/clients/python/RELEASE.md
@@ -1,0 +1,39 @@
+# Python client release
+
+Distribution name: `pgque-py` on PyPI. Import package: `pgque`.
+
+`pgque` is already taken on PyPI by an unrelated project, so PgQue's Python
+client uses a distinct distribution name while preserving the natural import:
+
+```bash
+pip install pgque-py
+```
+
+```python
+import pgque
+```
+
+## Versioning
+
+The Python client version is independent from the SQL/server
+`pgque.version()`. Bump this package when the Python API or packaging changes;
+server-only SQL changes do not require a Python client release.
+
+## Release process
+
+The release workflow is `.github/workflows/release-python.yml`.
+
+1. Update `clients/python/pyproject.toml` version and changelog/release notes.
+2. Merge the release prep PR.
+3. In PyPI, configure Trusted Publisher for:
+   - repository: `NikolayS/pgque`
+   - workflow: `release-python.yml`
+   - environment: `pypi`
+   - package: `pgque-py`
+4. In TestPyPI, configure the same workflow with environment `testpypi`.
+5. Run **Release Python client** with `repository=testpypi` first.
+6. Verify the TestPyPI artifact installs in a clean environment.
+7. Run the workflow again with `repository=pypi`.
+
+The workflow builds with `python -m build`, validates with `twine check`, and
+publishes via PyPI Trusted Publisher / OIDC. No long-lived PyPI token is needed.

--- a/clients/python/RELEASE.md
+++ b/clients/python/RELEASE.md
@@ -32,7 +32,15 @@ The release workflow is `.github/workflows/release-python.yml`.
    - package: `pgque-py`
 4. In TestPyPI, configure the same workflow with environment `testpypi`.
 5. Run **Release Python client** with `repository=testpypi` first.
-6. Verify the TestPyPI artifact installs in a clean environment.
+6. Verify the TestPyPI artifact installs in a clean environment, using PyPI
+   as the extra index for dependencies:
+
+   ```bash
+   python -m pip install \
+     --index-url https://test.pypi.org/simple \
+     --extra-index-url https://pypi.org/simple \
+     pgque-py
+   ```
 7. Run the workflow again with `repository=pypi`.
 
 The workflow builds with `python -m build`, validates with `twine check`, and

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "pgque"
+name = "pgque-py"
 version = "0.2.0"
 description = "Python client for PgQue -- PgQ Universal Edition"
 readme = "README.md"
@@ -18,11 +18,12 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Operating System :: OS Independent",
     "Topic :: Database",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "psycopg[binary]>=3.1",
+    "psycopg[binary]>=3.1,<4",
 ]
 
 [project.optional-dependencies]

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -7,8 +7,8 @@ PgQ-based universal PostgreSQL queue. Thin, idiomatic wrapper over the
 
 ## Install
 
-For application code, install the published package with any npm-compatible
-package manager:
+After the first TypeScript client release, install the published package with
+any npm-compatible package manager:
 
 ```bash
 npm install pgque

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -162,6 +162,13 @@ PGQUE_TEST_DSN=postgresql://postgres:pgque_test@localhost/pgque_test \
 
 Without `PGQUE_TEST_DSN` the integration tests skip.
 
+## Distribution
+
+The npm package is `pgque`. It publishes ESM JavaScript and TypeScript
+declarations from `dist/`, built from the Bun-managed source tree.
+
+See [RELEASE.md](RELEASE.md) for publishing steps.
+
 ## License
 
 Apache-2.0. Copyright 2026 Nikolay Samokhvalov.

--- a/clients/typescript/RELEASE.md
+++ b/clients/typescript/RELEASE.md
@@ -1,0 +1,48 @@
+# TypeScript client release
+
+Package name: `pgque` on npm.
+
+Install:
+
+```bash
+npm install pgque
+# or
+bun add pgque
+```
+
+## Versioning
+
+The TypeScript client version is independent from the SQL/server
+`pgque.version()`. Bump this package when the TypeScript API, runtime behavior,
+or packaging changes; server-only SQL changes do not require an npm release.
+
+## Package shape
+
+- Runtime: Node.js 20+
+- Module format: ESM
+- Entry point: `dist/index.js`
+- Type declarations: `dist/index.d.ts`
+- Development package manager: Bun
+- Published package contents are controlled by `package.json#files`.
+
+The package is for server-side Node/Bun applications. It depends on
+`node-postgres` and is not intended for browsers.
+
+## Release process
+
+The release workflow is `.github/workflows/release-typescript.yml`.
+
+1. Update `clients/typescript/package.json` version and changelog/release notes.
+2. Merge the release prep PR.
+3. In npm, configure Trusted Publishing for:
+   - package: `pgque`
+   - repository: `NikolayS/pgque`
+   - workflow: `release-typescript.yml`
+   - environment: `npm`
+4. Run **Release TypeScript client** with `dry_run=true` first.
+5. Verify the packed file list and build output.
+6. Run the workflow again with `dry_run=false`.
+
+The workflow installs with `bun install --frozen-lockfile`, runs `bun run check`,
+builds `dist/`, and publishes with npm provenance via OIDC. No long-lived npm
+token is needed.

--- a/clients/typescript/RELEASE.md
+++ b/clients/typescript/RELEASE.md
@@ -44,5 +44,5 @@ The release workflow is `.github/workflows/release-typescript.yml`.
 6. Run the workflow again with `dry_run=false`.
 
 The workflow installs with `bun install --frozen-lockfile`, runs `bun run check`,
-builds `dist/`, and publishes with npm provenance via OIDC. No long-lived npm
-token is needed.
+builds `dist/`, ensures npm >= 11.5.1 for Trusted Publishing, and publishes
+with npm provenance via OIDC. No long-lived npm token is needed.

--- a/clients/typescript/RELEASE.md
+++ b/clients/typescript/RELEASE.md
@@ -32,7 +32,7 @@ The package is for server-side Node/Bun applications. It depends on
 
 The release workflow is `.github/workflows/release-typescript.yml`.
 
-1. Update `clients/typescript/package.json` version and changelog/release notes.
+1. Update `clients/typescript/package.json` version and any release notes/changelog if present.
 2. Merge the release prep PR.
 3. In npm, configure Trusted Publishing for:
    - package: `pgque`

--- a/clients/typescript/RELEASE.md
+++ b/clients/typescript/RELEASE.md
@@ -44,5 +44,5 @@ The release workflow is `.github/workflows/release-typescript.yml`.
 6. Run the workflow again with `dry_run=false`.
 
 The workflow installs with `bun install --frozen-lockfile`, runs `bun run check`,
-builds `dist/`, ensures npm >= 11.5.1 for Trusted Publishing, and publishes
-with npm provenance via OIDC. No long-lived npm token is needed.
+`bun run test`, builds `dist/`, ensures npm >= 11.5.1 for Trusted Publishing,
+and publishes with npm provenance via OIDC. No long-lived npm token is needed.

--- a/clients/typescript/RELEASE.md
+++ b/clients/typescript/RELEASE.md
@@ -28,20 +28,29 @@ or packaging changes; server-only SQL changes do not require an npm release.
 The package is for server-side Node/Bun applications. It depends on
 `node-postgres` and is not intended for browsers.
 
+## GitHub environment prerequisite
+
+Before the first real publish, create GitHub environment `npm` in
+`NikolayS/pgque`. Protect it as appropriate for releases (for example,
+required reviewers and `main` branch restrictions). The workflow also checks
+that it is running from `main`, but environment protection is the human approval
+gate.
+
 ## Release process
 
 The release workflow is `.github/workflows/release-typescript.yml`.
 
 1. Update `clients/typescript/package.json` version and any release notes/changelog if present.
 2. Merge the release prep PR.
-3. In npm, configure Trusted Publishing for:
+3. Ensure the `npm` GitHub environment exists and is protected.
+4. In npm, configure Trusted Publishing for:
    - package: `pgque`
    - repository: `NikolayS/pgque`
    - workflow: `release-typescript.yml`
    - environment: `npm`
-4. Run **Release TypeScript client** with `dry_run=true` first.
-5. Verify the packed file list and build output.
-6. Run the workflow again with `dry_run=false`.
+5. Run **Release TypeScript client** with `dry_run=true` first.
+6. Verify the packed file list and build output.
+7. Run the workflow again with `dry_run=false`.
 
 The workflow installs with `bun install --frozen-lockfile`, runs `bun run check`,
 `bun run test`, builds `dist/`, ensures npm >= 11.5.1 for Trusted Publishing,

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -4,6 +4,10 @@
   "description": "TypeScript client for PgQue — the PgQ-based universal PostgreSQL queue",
   "license": "Apache-2.0",
   "packageManager": "bun@1.3.8",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "author": "Nikolay Samokhvalov",
   "homepage": "https://github.com/NikolayS/pgque",
   "repository": {
@@ -34,8 +38,8 @@
   },
   "files": [
     "dist",
-    "src",
     "README.md",
+    "RELEASE.md",
     "LICENSE"
   ],
   "engines": {

--- a/clients/typescript/tsconfig.json
+++ b/clients/typescript/tsconfig.json
@@ -8,13 +8,19 @@
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
+    "declarationMap": false,
+    "sourceMap": false,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "types": ["node"],
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*.ts"],
+  "include": [
+    "src/client.ts",
+    "src/consumer.ts",
+    "src/errors.ts",
+    "src/index.ts",
+    "src/types.ts"
+  ],
   "exclude": ["dist", "node_modules", "test"]
 }


### PR DESCRIPTION
## Summary

Adds release/distribution plumbing for all three first-party clients:

- Python: choose `pgque-py` as PyPI distribution name because `pgque` is already taken; keep `import pgque`.
- Go: keep current submodule path `github.com/NikolayS/pgque/clients/go`; document `clients/go/vX.Y.Z` tag convention for Go submodules.
- TypeScript: keep npm package name `pgque`; publish ESM + declarations from `dist/` using Bun for build/checks.

Adds release workflows:

- `.github/workflows/release-python.yml` — manual TestPyPI/PyPI publish via Trusted Publisher / OIDC.
- `.github/workflows/release-go.yml` — manual submodule tag + optional GitHub Release.
- `.github/workflows/release-typescript.yml` — manual npm dry-run/publish with provenance / OIDC.

Adds `RELEASE.md` per client and updates install/distribution docs.

Refs #181, #182, #183.

## Validation

- Python package build:
  - `python -m build`
  - `python -m twine check dist/*`
  - install built wheel in clean venv and `import pgque`
- TypeScript package build:
  - `bun install --frozen-lockfile`
  - `bun run check`
  - `bun run build`
  - `npm pack --dry-run` confirms no `node_modules` / tests / bench/smoke files in package
- Go package:
  - `go test ./...` via `golang:1.23` Docker image
  - `go test -run '^Example' ./...` via `golang:1.23` Docker image
- Workflow YAML parse check with Ruby YAML loader.
