### PR TITLE
fix(clients/typescript): nack reasons, retryAfter seconds, coverage

### DIFF
--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -237,12 +237,27 @@ export class Client {
    * Negatively acknowledge a single message. Routes to the retry queue if
    * `retry_count < queue_max_retries`, otherwise to the dead-letter queue.
    * Other messages in the same batch are not affected.
+   *
+   * `opts.retryAfter` is the retry delay in **seconds** (default `60`).
+   * The driver binds it as a PostgreSQL `interval` (`'<n> seconds'`) for
+   * `pgque.nack`'s `i_retry_after` parameter; cross-driver parity with
+   * `pgque-py` and `pgque-go`.
    */
   async nack(batchId: bigint, msg: Message, opts: NackOptions = {}): Promise<void> {
     if (typeof batchId !== 'bigint') {
       throw new PgqueSqlError('nack', { cause: new Error('batchId must be bigint') });
     }
-    const retryAfter = opts.retryAfter ?? '60 seconds';
+    const retryAfterSeconds = opts.retryAfter ?? 60;
+    if (
+      typeof retryAfterSeconds !== 'number' ||
+      !Number.isFinite(retryAfterSeconds) ||
+      retryAfterSeconds < 0
+    ) {
+      throw new PgqueSqlError('nack', {
+        cause: new Error('retryAfter must be a non-negative finite number of seconds'),
+      });
+    }
+    const retryAfter = `${retryAfterSeconds} seconds`;
     const reason = opts.reason ?? null;
     // pgque.message has 10 fields: (msg_id, batch_id, type, payload,
     // retry_count, created_at, extra1, extra2, extra3, extra4). The ROW()

--- a/clients/typescript/src/consumer.ts
+++ b/clients/typescript/src/consumer.ts
@@ -4,7 +4,12 @@
 import type { Client } from './client.js';
 import type { ConsumerOptions, HandlerFunc, Message } from './types.js';
 
-const DEFAULT_MAX_MESSAGES = 2_147_483_647; // PostgreSQL int4 max; request the whole batch by default.
+/**
+ * Default `maxMessages` for the high-level Consumer. PostgreSQL `int4` max
+ * (`2^31 - 1`); request the whole PgQ batch by default so a subsequent
+ * `pgque.ack(batch_id)` does not strand events the client never saw.
+ */
+export const DEFAULT_MAX_MESSAGES = 2_147_483_647;
 
 /**
  * High-level consumer that polls `pgque.receive`, dispatches each message
@@ -88,7 +93,7 @@ export class Consumer {
           this.logger.warn(
             `pgque: no handler registered for event type "${msg.type}", nacking msg ${msg.msgId}`,
           );
-          if (!(await this.tryNack(batchId, msg, 'unknown event type'))) {
+          if (!(await this.tryNack(batchId, msg, `unknown event type: ${msg.type}`))) {
             anyNackFailed = true;
           }
           continue;
@@ -97,7 +102,7 @@ export class Consumer {
           await handler(msg);
         } catch (err) {
           this.logger.error(`pgque: handler error for "${msg.type}": ${formatErr(err)}`);
-          if (!(await this.tryNack(batchId, msg, 'handler error'))) {
+          if (!(await this.tryNack(batchId, msg, `handler error: ${formatErr(err)}`))) {
             anyNackFailed = true;
           }
         }

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -35,7 +35,7 @@
  */
 
 export { Client, connect, pgqueTypes } from './client.js';
-export { Consumer } from './consumer.js';
+export { Consumer, DEFAULT_MAX_MESSAGES } from './consumer.js';
 export {
   PgqueConnectionError,
   PgqueConsumerNotFoundError,

--- a/clients/typescript/src/types.ts
+++ b/clients/typescript/src/types.ts
@@ -35,15 +35,25 @@ export interface Event {
 
 /** Options for {@link Client.nack}. */
 export interface NackOptions {
-  /** Retry delay if the message has not exceeded `queue_max_retries`. Default `60s`. */
-  retryAfter?: string;
+  /**
+   * Retry delay in **seconds** if the message has not exceeded
+   * `queue_max_retries`. Default `60`.
+   *
+   * The driver binds this as a PostgreSQL `interval` (`'<n> seconds'`) for
+   * `pgque.nack`'s `i_retry_after` parameter. Cross-driver parity with
+   * `pgque-py` and `pgque-go`.
+   */
+  retryAfter?: number;
   /** Free-form reason recorded on the dead-letter row when the retry limit is hit. */
   reason?: string;
 }
 
 /** Options for {@link Client.newConsumer}. */
 export interface ConsumerOptions {
-  /** Interval between poll cycles when no messages are available. Default `30s`. */
+  /**
+   * Interval between poll cycles when no messages are available, in
+   * **milliseconds**. Default `30000` (30 seconds).
+   */
   pollInterval?: number;
   /**
    * Maximum messages returned per `receive()` call. By default the

--- a/clients/typescript/test/consumer.test.ts
+++ b/clients/typescript/test/consumer.test.ts
@@ -2,7 +2,7 @@
 // Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { Consumer } from '../src/consumer.js';
+import { Consumer, DEFAULT_MAX_MESSAGES } from '../src/consumer.js';
 import type { Client } from '../src/client.js';
 import type { Message } from '../src/types.js';
 import { TEST_DSN, setupTestQueue, teardownTestQueue, advanceQueue, type TestEnv } from './helpers.js';
@@ -134,6 +134,165 @@ describe('Consumer (env-gated)', () => {
     );
     expect(retry.rows[0]!.count).toBe('1');
   });
+
+  // Coverage gap (#a): the formatted handler-error reason must reach
+  // pgque.dead_letter.dl_reason. We force `queue_max_retries=0` so the
+  // first nack routes straight to the DLQ, then assert the stored reason.
+  skipIfNoDb('handler-error reason lands in dead_letter.dl_reason', async () => {
+    await env.client.rawPool.query(
+      `update pgque.queue set queue_max_retries = 0 where queue_name = $1`,
+      [env.queue],
+    );
+
+    await env.client.send(env.queue, { type: 'boom', payload: { v: 1 } });
+    await advanceQueue(env.client, env.queue);
+
+    const consumer = env.client.newConsumer(env.queue, env.consumer, {
+      pollInterval: 50,
+      logger: { warn: () => undefined, error: () => undefined },
+    });
+    consumer.handle('boom', async () => {
+      throw new Error('kaboom');
+    });
+
+    const ac = new AbortController();
+    const start = consumer.start(ac.signal);
+
+    const deadline = Date.now() + 4000;
+    while (Date.now() < deadline) {
+      const dlq = await env.client.rawPool.query<{ count: string }>(
+        `select count(*)::text as count
+           from pgque.dead_letter dl
+           join pgque.queue q on q.queue_id = dl.dl_queue_id
+          where q.queue_name = $1`,
+        [env.queue],
+      );
+      if (dlq.rows[0]!.count !== '0') break;
+      await sleep(50);
+    }
+    ac.abort();
+    await start;
+
+    const dlq = await env.client.rawPool.query<{ dl_reason: string }>(
+      `select dl.dl_reason
+         from pgque.dead_letter dl
+         join pgque.queue q on q.queue_id = dl.dl_queue_id
+        where q.queue_name = $1
+        order by dl.dl_id desc
+        limit 1`,
+      [env.queue],
+    );
+    expect(dlq.rows.length).toBe(1);
+    expect(dlq.rows[0]!.dl_reason).toBe('handler error: kaboom');
+  });
+
+  // Coverage gap (#b): the default Consumer must drain the entire underlying
+  // PgQ batch in one poll. Mirrors Go's
+  // TestConsumer_WithMaxMessages_FetchesEntireBatch.
+  skipIfNoDb('default Consumer drains the whole batch in one poll', async () => {
+    const total = 105;
+    for (let i = 0; i < total; i++) {
+      await env.client.send(env.queue, { type: 'bulk', payload: { i } });
+    }
+    await advanceQueue(env.client, env.queue);
+
+    // Default options: no maxMessages override, no pollInterval override.
+    // pollInterval defaults to 30s, so a second poll is effectively
+    // impossible within the test window.
+    const consumer = env.client.newConsumer(env.queue, env.consumer, {
+      logger: { warn: () => undefined, error: () => undefined },
+    });
+    let seen = 0;
+    consumer.handle('bulk', async () => {
+      seen += 1;
+    });
+
+    const ac = new AbortController();
+    const start = consumer.start(ac.signal);
+
+    const deadline = Date.now() + 8000;
+    while (Date.now() < deadline && seen < total) {
+      await sleep(25);
+    }
+    ac.abort();
+    await start;
+
+    expect(seen).toBe(total);
+  });
+
+  // Coverage gap (#c): partial-batch success+failure. Three messages (ok,
+  // boom, ok); the failing one should reappear on the next poll while the
+  // succeeding ones are acked away.
+  skipIfNoDb('partial-batch failure: only the failing message reappears', async () => {
+    await env.client.send(env.queue, { type: 'ok', payload: { i: 0 } });
+    await env.client.send(env.queue, { type: 'boom', payload: { i: 1 } });
+    await env.client.send(env.queue, { type: 'ok', payload: { i: 2 } });
+    await advanceQueue(env.client, env.queue);
+
+    const consumer = env.client.newConsumer(env.queue, env.consumer, {
+      pollInterval: 50,
+      logger: { warn: () => undefined, error: () => undefined },
+    });
+
+    let okSeen = 0;
+    let boomSeen = 0;
+    consumer.handle('ok', async () => {
+      okSeen += 1;
+    });
+    consumer.handle('boom', async () => {
+      boomSeen += 1;
+      throw new Error('boom-err');
+    });
+
+    const ac = new AbortController();
+    const start = consumer.start(ac.signal);
+
+    // Wait until the first batch has been processed: both oks ran and the
+    // initial nack/ack cycle for boom has completed (retry row exists).
+    const firstDeadline = Date.now() + 6000;
+    while (Date.now() < firstDeadline && (okSeen < 2 || boomSeen < 1)) {
+      await sleep(25);
+    }
+    expect(okSeen).toBe(2);
+    expect(boomSeen).toBeGreaterThanOrEqual(1);
+
+    // The retry queue defaults to ev_retry_after = now() + 60s, so the
+    // boom message is not yet redeliverable. Pull it forward, ask PgQ to
+    // move the retry row back into the main queue, then force_tick +
+    // ticker so the next consumer poll observes it.
+    await env.client.rawPool.query(
+      `update pgque.retry_queue
+          set ev_retry_after = now() - interval '1 second'
+        where ev_queue = (select queue_id from pgque.queue where queue_name = $1)`,
+      [env.queue],
+    );
+    await env.client.rawPool.query(`select pgque.maint_retry_events()`);
+    await advanceQueue(env.client, env.queue);
+
+    // Now wait for redelivery of `boom`.
+    const redeliveredDeadline = Date.now() + 6000;
+    while (Date.now() < redeliveredDeadline && boomSeen < 2) {
+      await sleep(25);
+    }
+    ac.abort();
+    await start;
+
+    expect(okSeen).toBe(2); // both `ok` messages acked, never redelivered
+    expect(boomSeen).toBeGreaterThanOrEqual(2); // initial + at least one retry
+
+    // Any rows still in retry_queue for this queue must be the `boom`
+    // message — `ok` must never have been redirected to retry/DLQ.
+    const retryRows = await env.client.rawPool.query<{ ev_type: string }>(
+      `select rq.ev_type
+         from pgque.retry_queue rq
+         join pgque.queue q on q.queue_id = rq.ev_queue
+        where q.queue_name = $1`,
+      [env.queue],
+    );
+    for (const r of retryRows.rows) {
+      expect(r.ev_type).toBe('boom');
+    }
+  });
 });
 
 describe('Consumer (in-memory mocks)', () => {
@@ -211,7 +370,7 @@ describe('Consumer (in-memory mocks)', () => {
     await startPromise;
 
     expect(fakeClient.receive).toHaveBeenCalled();
-    expect(fakeClient.receive.mock.calls[0]).toEqual(['q', 'c', 2_147_483_647]);
+    expect(fakeClient.receive.mock.calls[0]).toEqual(['q', 'c', DEFAULT_MAX_MESSAGES]);
   });
 
   it('passes configured maxMessages to receive', async () => {

--- a/clients/typescript/test/nack.test.ts
+++ b/clients/typescript/test/nack.test.ts
@@ -55,7 +55,7 @@ describe('nack routing (env-gated)', () => {
     expect(m).toBeDefined();
 
     await env.client.nack(m!.batchId, m!, {
-      retryAfter: '5 seconds',
+      retryAfter: 5,
       reason: 'simulated transient failure',
     });
     await env.client.ack(m!.batchId);


### PR DESCRIPTION
## Summary

Follow-up to merged #154 addressing review feedback. Repo has no users yet, so the public API change to `nack`'s `retryAfter` (now `number` seconds) is unconstrained.

## Changes

- **Thread real error message into nack reason** (consumer.ts):
  - Unknown type → `` `unknown event type: ${msg.type}` ``
  - Handler error → `` `handler error: ${formatErr(err)}` ``
- **Document units explicitly**:
  - `ConsumerOptions.pollInterval` JSDoc says **milliseconds**.
  - `Client.nack` `retryAfter` is now **`number` seconds** (was `string` interval). Picked seconds to match the Python client (`retry_after: int = 60`) and align the cross-driver convention.
  - `nack` validates non-negative finite numbers; builds `'<n> seconds'` interval text internally.
- **Export `DEFAULT_MAX_MESSAGES`** constant (re-exported from `index.ts`); tests now import it instead of the magic literal `2_147_483_647`.
- **Three new env-gated live-PG tests**:
  - `dl_reason` lands the threaded reason string in `pgque.dead_letter`.
  - Default consumer drains a 105-message batch in one poll.
  - Partial-batch `ok`/`boom`/`ok` asserts only `boom` is redelivered.

## Test plan

- [x] `tsc --noEmit` (src + test tsconfigs) clean
- [x] `vitest --run` without `PGQUE_TEST_DSN`: 5 passed, 35 skipped (env-gated)
- [x] `vitest --run` with `PGQUE_TEST_DSN`: 40 passed, 0 failed
- [ ] CI green on PG 14–18

## Notes

- `nack(... { retryAfter: '5 seconds' })` callers must update to `nack(... { retryAfter: 5 })`. Acceptable per the no-users policy.
- The orphaned source branch `fix/clients-typescript-v0.2.0` was resurrected by an automated step. The three commits on this branch are the cherry-picked, freshly-signed versions. Safe to delete the resurrected branch.

https://claude.ai/code/session_0153x6qY6bLADom5d5wwMYRm

---
_Generated by [Claude Code](https://claude.ai/code/session_0153x6qY6bLADom5d5wwMYRm)_