### PR TITLE
fix(clients/python): rename to unknown_handler_policy, align with Go/TS

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -71,11 +71,13 @@ consumer.start()  # blocks until SIGTERM / SIGINT
 
 ### Consumer options
 
-`Consumer(..., max_messages=...)` controls the per-`receive` limit. By
-default the consumer requests PostgreSQL's `int` maximum, so it drains
-the whole PgQ batch before acknowledging it. If you lower this value
-below the real batch size, `ack()` still finishes the batch and
-unreturned rows are skipped.
+`Consumer(..., max_messages=...)` controls the per-`receive` limit.
+The default is PostgreSQL's `int` maximum, so the consumer requests
+the whole PgQ batch before acknowledging it. `ack()` finishes the
+entire underlying PgQ batch, including rows beyond `max_messages`;
+only lower this value when it is at least as large as the queue's
+worst-case batch size, otherwise rows past the limit are silently
+skipped by the batch ack.
 
 ### Handling unknown event types
 
@@ -84,14 +86,14 @@ registered handler and no `"*"` catch-all. The message is retried (or
 dead-lettered once `queue_max_retries` is exhausted) so unknown types
 are never silently dropped.
 
-To ack unknown types instead, pass `unknown_handler="ack"`:
+To ack unknown types instead, pass `unknown_handler_policy="ack"`:
 
 ```python
 consumer = pgque.Consumer(
     dsn="postgresql://localhost/mydb",
     queue="orders",
     name="order_worker",
-    unknown_handler="ack",  # log WARNING and ack; do not nack
+    unknown_handler_policy="ack",  # log WARNING and ack; do not nack
 )
 ```
 

--- a/clients/python/pgque/consumer.py
+++ b/clients/python/pgque/consumer.py
@@ -52,7 +52,7 @@ class Consumer:
           default ``"*"`` handler exists), the message is nacked
           (sent to retry_queue, or to the dead-letter queue once
           ``queue_max_retries`` is exhausted). To ack unknown types
-          instead, pass ``unknown_handler="ack"``.
+          instead, pass ``unknown_handler_policy="ack"``.
 
     After all messages in a batch have been dispatched, the batch is
     acked automatically.
@@ -67,7 +67,7 @@ class Consumer:
         poll_interval: int = 30,
         max_messages: int = _DEFAULT_MAX_MESSAGES,
         retry_after: int = 60,
-        unknown_handler: Literal["nack", "ack"] = "nack",
+        unknown_handler_policy: Literal["nack", "ack"] = "nack",
     ):
         self.dsn = dsn
         self.queue = queue
@@ -75,12 +75,12 @@ class Consumer:
         self.poll_interval = poll_interval
         self.max_messages = max_messages
         self.retry_after = retry_after
-        if unknown_handler not in ("nack", "ack"):
+        if unknown_handler_policy not in ("nack", "ack"):
             raise ValueError(
-                "unknown_handler must be 'nack' or 'ack', "
-                f"got {unknown_handler!r}"
+                "unknown_handler_policy must be 'nack' or 'ack', "
+                f"got {unknown_handler_policy!r}"
             )
-        self._unknown_handler = unknown_handler
+        self._unknown_handler_policy = unknown_handler_policy
 
         self._handlers: dict[str, Callable] = {}
         self._default_handler: Optional[Callable] = None
@@ -217,11 +217,13 @@ class Consumer:
     def _poll_once(self, conn: psycopg.Connection) -> None:
         """Receive one batch and dispatch messages.
 
-        If any per-message ``nack()`` raises, the batch is NOT acked --
-        the receive transaction commits without finishing the batch, so
-        PgQ redelivers the same batch on the next poll. Without this
-        guard, swallowing a nack failure and then acking would advance
-        past the batch and silently drop the failed message.
+        If any per-message ``nack()`` raises, all remaining messages in
+        the batch are still dispatched (their handlers run), but the
+        batch is NOT acked at the end -- the receive transaction commits
+        without finishing the batch, so PgQ redelivers the whole batch
+        on the next poll. Without this guard, swallowing a nack failure
+        and then acking would advance past the batch and silently drop
+        the failed message.
         """
         # Use a transaction block for receive + ack
         with conn.transaction():
@@ -243,7 +245,7 @@ class Consumer:
             for msg in msgs:
                 handler = self._handlers.get(msg.type, self._default_handler)
                 if handler is None:
-                    if self._unknown_handler == "ack":
+                    if self._unknown_handler_policy == "ack":
                         self._log.warning(
                             "no handler for event type=%s ev_id=%s; acking",
                             msg.type,
@@ -264,18 +266,18 @@ class Consumer:
                         )
                     except Exception:
                         nack_failed = True
-                        logger.exception(
+                        self._log.exception(
                             "nack failed for unhandled msg_id=%d; "
                             "skipping batch ack so PgQ redelivers",
                             msg.msg_id,
                         )
-                        break
+                        continue
                     continue
 
                 try:
                     handler(msg)
                 except Exception:
-                    logger.exception(
+                    self._log.exception(
                         "handler failed for msg_id=%d, nacking",
                         msg.msg_id,
                     )
@@ -285,12 +287,12 @@ class Consumer:
                         )
                     except Exception:
                         nack_failed = True
-                        logger.exception(
+                        self._log.exception(
                             "nack failed for msg_id=%d; "
                             "skipping batch ack so PgQ redelivers",
                             msg.msg_id,
                         )
-                        break
+                        continue
 
             if nack_failed:
                 # Do NOT ack -- redeliver on next poll.

--- a/clients/python/tests/test_consumer.py
+++ b/clients/python/tests/test_consumer.py
@@ -208,7 +208,7 @@ def test_consumer_nacks_unhandled_event_type(dsn, conn, setup_queue):
 def test_consumer_acks_unhandled_event_type_when_opt_in(
     dsn, conn, setup_queue, caplog
 ):
-    """Opt-in: unknown_handler='ack' restores warn+ack semantics.
+    """Opt-in: unknown_handler_policy='ack' restores warn+ack semantics.
 
     Must NOT appear in retry_queue, must log a WARNING, and a follow-up
     receive must not return the same msg_id.
@@ -226,12 +226,15 @@ def test_consumer_acks_unhandled_event_type_when_opt_in(
         queue=queue,
         name=consumer_name,
         poll_interval=1,
-        unknown_handler="ack",
+        unknown_handler_policy="ack",
     )
 
-    with caplog.at_level(logging.WARNING, logger="pgque"):
+    with caplog.at_level(logging.WARNING, logger="pgque"), \
+            mock.patch.object(pgque.PgqueClient, "nack") as nack_mock:
         t = _run_consumer_for(cons, 3.0)
         t.join(timeout=5.0)
+
+    nack_mock.assert_not_called()
 
     # Must NOT be in retry_queue or dead_letter -- it was acked, not nacked.
     rq = _retry_count_for_msg(conn, queue, msg_id)
@@ -261,7 +264,7 @@ def test_consumer_acks_unhandled_event_type_when_opt_in(
     )
 
 
-def test_consumer_rejects_invalid_unknown_handler(dsn, setup_queue):
+def test_consumer_rejects_invalid_unknown_handler_policy(dsn, setup_queue):
     """Constructor must reject values other than 'nack' / 'ack'."""
     queue, consumer_name = setup_queue
     try:
@@ -269,11 +272,13 @@ def test_consumer_rejects_invalid_unknown_handler(dsn, setup_queue):
             dsn=dsn,
             queue=queue,
             name=consumer_name,
-            unknown_handler="bogus",  # type: ignore[arg-type]
+            unknown_handler_policy="bogus",  # type: ignore[arg-type]
         )
     except ValueError:
         return
-    raise AssertionError("expected ValueError for invalid unknown_handler")
+    raise AssertionError(
+        "expected ValueError for invalid unknown_handler_policy"
+    )
 
 
 def test_consumer_stop_returns_promptly(dsn, setup_queue):
@@ -307,34 +312,16 @@ def test_consumer_does_not_ack_when_unknown_type_nack_fails(
         dsn=dsn, queue=queue, name=consumer_name, poll_interval=1
     )
 
-    real_client_init = pgque.PgqueClient.__init__
-    ack_calls: list[int] = []
-    nack_calls: list[int] = []
-
-    def fake_init(self, c):
-        real_client_init(self, c)
-        original_ack = self.ack
-        original_nack = self.nack
-
-        def spy_ack(batch_id):
-            ack_calls.append(batch_id)
-            return original_ack(batch_id)
-
-        def explode_nack(batch_id, msg, retry_after=60, reason=None):
-            nack_calls.append(msg.msg_id)
-            raise RuntimeError("simulated nack failure")
-
-        self.ack = spy_ack  # type: ignore[method-assign]
-        self.nack = explode_nack  # type: ignore[method-assign]
-
-    with mock.patch.object(pgque.PgqueClient, "__init__", fake_init):
+    with mock.patch.object(
+        pgque.PgqueClient,
+        "nack",
+        side_effect=RuntimeError("simulated nack failure"),
+    ) as nack_mock, mock.patch.object(pgque.PgqueClient, "ack") as ack_mock:
         t = _run_consumer_for(cons, 3.0)
         t.join(timeout=5.0)
 
-    assert nack_calls, "nack was never called for the unhandled message"
-    assert ack_calls == [], (
-        f"ack must not be called when nack raised; got ack_calls={ack_calls}"
-    )
+    assert nack_mock.called, "nack was never called for the unhandled message"
+    ack_mock.assert_not_called()
 
     # Message must still be visible: re-receive returns the same msg_id.
     follow_up = client.receive(queue, consumer_name, max_messages=10)
@@ -370,33 +357,16 @@ def test_consumer_does_not_ack_when_handler_error_nack_fails(
     def _boom(m: pgque.Message):
         raise RuntimeError("handler boom")
 
-    real_client_init = pgque.PgqueClient.__init__
-    ack_calls: list[int] = []
-    nack_calls: list[int] = []
-
-    def fake_init(self, c):
-        real_client_init(self, c)
-        original_ack = self.ack
-
-        def spy_ack(batch_id):
-            ack_calls.append(batch_id)
-            return original_ack(batch_id)
-
-        def explode_nack(batch_id, msg, retry_after=60, reason=None):
-            nack_calls.append(msg.msg_id)
-            raise RuntimeError("simulated nack failure")
-
-        self.ack = spy_ack  # type: ignore[method-assign]
-        self.nack = explode_nack  # type: ignore[method-assign]
-
-    with mock.patch.object(pgque.PgqueClient, "__init__", fake_init):
+    with mock.patch.object(
+        pgque.PgqueClient,
+        "nack",
+        side_effect=RuntimeError("simulated nack failure"),
+    ) as nack_mock, mock.patch.object(pgque.PgqueClient, "ack") as ack_mock:
         t = _run_consumer_for(cons, 3.0)
         t.join(timeout=5.0)
 
-    assert nack_calls, "nack was never called after handler raised"
-    assert ack_calls == [], (
-        f"ack must not be called when nack raised; got ack_calls={ack_calls}"
-    )
+    assert nack_mock.called, "nack was never called after handler raised"
+    ack_mock.assert_not_called()
 
     follow_up = client.receive(queue, consumer_name, max_messages=10)
     assert any(m.msg_id == msg_id for m in follow_up), (
@@ -534,3 +504,84 @@ def test_consumer_wakes_on_pg_notify_before_poll_interval(
         f"consumer woke too slowly ({elapsed:.2f}s); LISTEN/NOTIFY did not "
         f"unblock the wait"
     )
+
+
+def test_consumer_partial_batch_acks_good_messages_only(
+    dsn, conn, setup_queue
+):
+    """Mixed batch: good messages are acked via the batch ack; only the
+    failing message reappears on next receive (in retry_queue).
+
+    With ``continue`` (not ``break``) on nack failure, all handlers in
+    the batch run. With nack succeeding for the failing message, the
+    batch is acked at the end -- so the surviving good messages are
+    finished by the batch ack and only the nacked message is redelivered
+    via ``retry_queue``.
+    """
+    queue, consumer_name = setup_queue
+    client = pgque.PgqueClient(conn)
+    ok1_id = client.send(queue, {"i": 1}, type="ok")
+    boom_id = client.send(queue, {"i": 2}, type="boom")
+    ok2_id = client.send(queue, {"i": 3}, type="ok")
+    conn.commit()
+    conn.execute("select pgque.force_tick(%s)", (queue,))
+    conn.execute("select pgque.ticker()")
+    conn.commit()
+
+    seen_ok: list[int] = []
+    # Use a generous retry_after so the failed message stays in
+    # retry_queue while we inspect it (and is not pulled into a
+    # subsequent batch by the same consumer cycle).
+    cons = pgque.Consumer(
+        dsn=dsn, queue=queue, name=consumer_name,
+        poll_interval=1, retry_after=3600,
+    )
+
+    @cons.on("ok")
+    def _ok(m: pgque.Message):
+        seen_ok.append(m.msg_id)
+
+    @cons.on("boom")
+    def _boom(m: pgque.Message):
+        raise RuntimeError("handler boom")
+
+    t = _run_consumer_for(cons, 3.0)
+    t.join(timeout=5.0)
+
+    # Both `ok` handlers must have run -- proving dispatch continued past
+    # the failing message rather than breaking out of the loop.
+    assert ok1_id in seen_ok and ok2_id in seen_ok, (
+        f"good messages not dispatched: seen_ok={seen_ok}"
+    )
+
+    # Refresh the test connection's snapshot so it can see writes
+    # committed by the consumer's connection.
+    conn.rollback()
+
+    # Only the failing message lands in retry_queue; the good ones were
+    # finished by the batch ack.
+    assert _retry_count_for_msg(conn, queue, boom_id) >= 1, (
+        "failing 'boom' message is not in retry_queue"
+    )
+    assert _retry_count_for_msg(conn, queue, ok1_id) == 0, (
+        "good 'ok' message #1 leaked into retry_queue"
+    )
+    assert _retry_count_for_msg(conn, queue, ok2_id) == 0, (
+        "good 'ok' message #2 leaked into retry_queue"
+    )
+
+    # A fresh receive must NOT return the good messages -- they were
+    # finished by the batch ack. The boom message is held in
+    # retry_queue (verified above) until ev_retry_after expires; the
+    # combination proves the batch advanced past the good rows while
+    # the failing row was preserved for redelivery.
+    conn.execute("select pgque.force_tick(%s)", (queue,))
+    conn.execute("select pgque.ticker()")
+    conn.commit()
+    follow_up = client.receive(queue, consumer_name, max_messages=10)
+    follow_ids = [m.msg_id for m in follow_up]
+    assert ok1_id not in follow_ids, "good message #1 was redelivered"
+    assert ok2_id not in follow_ids, "good message #2 was redelivered"
+    if follow_up:
+        client.ack(follow_up[0].batch_id)
+        conn.commit()


### PR DESCRIPTION
## Summary

Follow-up to merged #155 addressing review feedback. Repo has no users yet, so renaming `unknown_handler` is fine.

## Changes

- **Rename `unknown_handler` → `unknown_handler_policy`** (cross-driver alignment with TS `unknownHandlerPolicy` and Go `WithUnknownHandlerPolicy`). Constructor param, attribute, validation message, `Literal` type ann, docstring, README, and tests all updated.
- **`break` → `continue`** in `_poll_once` for both nack-failure branches. Now matches Go/TS: all messages dispatch (handlers run); `nack_failed` flag still skips the final ack so PgQ redelivers the batch. Docstring updated.
- **Logger consistency**: replaced `logger.exception(...)` with `self._log.exception(...)` in the new branches.
- **Refactor monkey-patch tests** to use `mock.patch.object(PgqueClient, "nack", side_effect=...)` and `mock.patch.object(PgqueClient, "ack")` — both `_does_not_ack_when_*_nack_fails` tests are now shorter and survive future implementation refactors.
- **Strengthen ack-unknown test**: `test_consumer_acks_unhandled_event_type_when_opt_in` now asserts `nack_mock.assert_not_called()`.
- **README parity** with Go/TS: explicit "`ack()` finishes the entire underlying PgQ batch", "rows beyond `max_messages` are silently skipped", "size to your worst-case batch".
- **New test**: `test_consumer_partial_batch_acks_good_messages_only` — sends `ok`/`boom`/`ok`, asserts both `ok` handlers ran, `boom` is in `retry_queue`, the two `ok` rows are NOT in `retry_queue`, and the next `receive()` does not return the `ok` rows.

## Test plan

- [x] `pytest tests/` with `PGQUE_TEST_DSN`: **55 passed in 31.31s**
- [x] Without `PGQUE_TEST_DSN`: 50 skip cleanly, 5 unit tests pass
- [ ] CI green on PG 14–18

## Notes

- Test `test_consumer_partial_batch_*` doesn't assert on the redelivery of the failing message after `maint_retry_events()` because PgQ's tick-snapshot ordering didn't promote the row in a single test cycle. Coverage is still strong: only `boom` ends up in `retry_queue` and the `ok` rows do not reappear, which proves the `break`→`continue` change.
- The orphaned source branch `fix/clients-python-v0.2.0` was resurrected by an automated step. The three commits on this branch are the cherry-picked, freshly-signed versions. Safe to delete the resurrected branch.

https://claude.ai/code/session_0153x6qY6bLADom5d5wwMYRm

---
_Generated by [Claude Code](https://claude.ai/code/session_0153x6qY6bLADom5d5wwMYRm)_