### PR TITLE
fix(clients/typescript): scope bigint parser to pgque pool (#145)

### DIFF
--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -125,28 +125,13 @@ All errors derive from `PgqueError`:
 
 ## Caveats
 
-### Global BIGINT parser mutation
+### bigint columns
 
-Importing `pgque` calls `types.setTypeParser(20, ...)` at module load
-time. This mutates the process-global `pg-types` parser table so that
-**all** `pg.Pool` / `pg.Client` instances in the same Node.js process
-will return PostgreSQL `bigint` columns as JS `bigint` instead of the
-default string representation.
-
-Practical impact:
-
-- If other code in your process uses `pg` and relies on `bigint` coming
-  back as a string (the `pg` default), those columns will silently change
-  type after `pgque` is imported.
-- The change is intentional: JS `bigint` is the correct representation for
-  PostgreSQL `bigint` and avoids silent precision loss above
-  `Number.MAX_SAFE_INTEGER`. The Go and Python pgque drivers behave the
-  same way.
-- If you cannot accept this side effect, do not import this package.
-
-There is no opt-out once the module is loaded — Node.js module caches
-mean the parser is set exactly once, regardless of how many times the
-package is imported.
+`Message.msgId`, `Message.batchId`, and the return values of `send()` /
+`sendBatch()` are JS `bigint`. The `int8` → `bigint` parser is registered
+only on pgque's internal pool via a per-pool `CustomTypesConfig` — it
+does **not** touch the process-global `pg-types` table. Other `pg.Pool`
+or `pg.Client` instances in the same process are unaffected.
 
 ## Tests
 

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -13,14 +13,24 @@ import type { ConsumerOptions, Event, Message, NackOptions } from './types.js';
 
 const { Pool, types } = pg;
 
-// PostgreSQL `bigint` (oid 20) is parsed by `pg` as string by default to
+// PostgreSQL `bigint` (OID 20) is parsed by `pg` as string by default to
 // avoid silent precision loss above Number.MAX_SAFE_INTEGER. We promote to
 // JS `bigint` for safety AND ergonomics — `bigint` is the natural type for
 // PG `bigint`, matches the Go driver's `int64`, and round-trips losslessly.
 //
-// This mutates a process-global parser table. We do it once at module load
-// and document the side effect in the README.
-types.setTypeParser(20, (val) => BigInt(val));
+// We do NOT touch the process-global parser table. Instead, each Pool created
+// by pgque is given a per-pool CustomTypesConfig that overrides OID 20 only
+// for queries issued by pgque. Unrelated pg pools in the same process are
+// unaffected.
+const pgqueTypes: pg.CustomTypesConfig = {
+  getTypeParser(oid: number, format?: string) {
+    if (oid === 20) {
+      // int8 / bigint → JS bigint
+      return (val: string) => BigInt(val);
+    }
+    return types.getTypeParser(oid, format as 'text' | 'binary');
+  },
+};
 
 const PG_RAISE_EXCEPTION_CODE = 'P0001';
 
@@ -313,7 +323,7 @@ export async function connect(
   dsn: string,
   poolOptions: Omit<pg.PoolConfig, 'connectionString'> = {},
 ): Promise<Client> {
-  const pool = new Pool({ connectionString: dsn, ...poolOptions });
+  const pool = new Pool({ connectionString: dsn, types: pgqueTypes, ...poolOptions });
   let probe: pg.PoolClient;
   try {
     probe = await pool.connect();

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -333,7 +333,14 @@ export async function connect(
   dsn: string,
   poolOptions: Omit<pg.PoolConfig, 'connectionString' | 'types'> = {},
 ): Promise<Client> {
-  const pool = new Pool({ connectionString: dsn, ...poolOptions, types: pgqueTypes });
+  // Defensively strip `types` from poolOptions before spreading. The
+  // `Omit<..., 'types'>` already rejects this at compile time, but JS
+  // callers (or `as` casts) can still smuggle one in. Dropping it here
+  // makes the pgque types config impossible to override regardless of
+  // spread order — see REV review on PR #189.
+  const { types: _userTypes, ...restPoolOptions } = poolOptions as pg.PoolConfig;
+  void _userTypes;
+  const pool = new Pool({ connectionString: dsn, ...restPoolOptions, types: pgqueTypes });
   let probe: pg.PoolClient;
   try {
     probe = await pool.connect();

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -22,7 +22,14 @@ const { Pool, types } = pg;
 // by pgque is given a per-pool CustomTypesConfig that overrides OID 20 only
 // for queries issued by pgque. Unrelated pg pools in the same process are
 // unaffected.
-const pgqueTypes: pg.CustomTypesConfig = {
+/**
+ * Per-pool type overrides used by pgque's `connect()`.
+ * Parses PostgreSQL `bigint` (OID 20) as JS `bigint` without touching the
+ * process-global `pg.types` table.
+ *
+ * @internal — exported for testing only; do not depend on this in application code.
+ */
+export const pgqueTypes: pg.CustomTypesConfig = {
   getTypeParser(oid: number, format?: string) {
     if (oid === 20) {
       // int8 / bigint → JS bigint
@@ -309,6 +316,9 @@ export class Client {
  * the connection eagerly; rejects with {@link PgqueConnectionError} on
  * failure.
  *
+ * The `types` parser config is reserved for pgque's internal bigint parsing;
+ * user-supplied `types` is ignored.
+ *
  * @example
  * ```ts
  * const client = await connect('postgres://user:pass@localhost/mydb');
@@ -321,9 +331,9 @@ export class Client {
  */
 export async function connect(
   dsn: string,
-  poolOptions: Omit<pg.PoolConfig, 'connectionString'> = {},
+  poolOptions: Omit<pg.PoolConfig, 'connectionString' | 'types'> = {},
 ): Promise<Client> {
-  const pool = new Pool({ connectionString: dsn, types: pgqueTypes, ...poolOptions });
+  const pool = new Pool({ connectionString: dsn, ...poolOptions, types: pgqueTypes });
   let probe: pg.PoolClient;
   try {
     probe = await pool.connect();

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -29,10 +29,9 @@
  * }
  * ```
  *
- * **Side effect on import:** registers a global `pg-types` parser for
- * `bigint` (oid 20) that promotes the column to JS `bigint`. This avoids
- * silent precision loss but also affects any other `pg`-using code in
- * the same process. Documented here for transparency.
+ * **bigint columns:** `msg_id`, `batch_id`, and `send()` / `sendBatch()`
+ * return values are JS `bigint`. The parser is scoped to pgque's own pool
+ * and does not affect other `pg` clients in the same process.
  */
 
 export { Client, connect } from './client.js';

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -34,7 +34,7 @@
  * and does not affect other `pg` clients in the same process.
  */
 
-export { Client, connect } from './client.js';
+export { Client, connect, pgqueTypes } from './client.js';
 export { Consumer } from './consumer.js';
 export {
   PgqueConnectionError,

--- a/clients/typescript/test/bigint-global-leak.test.ts
+++ b/clients/typescript/test/bigint-global-leak.test.ts
@@ -10,6 +10,7 @@
 
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import pg from 'pg';
+import { pgqueTypes } from '../src/index.js';
 
 // ---------------------------------------------------------------------------
 // Test 1 (red on unfixed code, green on fix):
@@ -47,45 +48,28 @@ describe('pgque import must not mutate global pg-types parser (OID 20)', () => {
     // a CustomTypesConfig whose OID-20 parser returns bigint, even though the
     // global parser remains string-returning.
     //
-    // Strategy: construct a pg.Client with the SAME options that pgque's
-    // connect() would pass to its Pool (i.e., `types: pgqueTypes`). Because
-    // pg.Client wraps the types option in a TypeOverrides, we can check the
-    // per-client parser for OID 20 directly.
-    //
-    // On unfixed code: pgque does not pass a types option, so a pg.Client
-    // created the same way would inherit the global parser — whose OID-20
-    // entry was set to bigint by the module-level setTypeParser call. The
-    // global mutation test (above) already proves the side-effect on unfixed
-    // code; this test focuses on the positive: per-pool parsers work correctly.
-    //
-    // We recreate the same pgqueTypes logic the fixed code uses and verify it
-    // behaves correctly when passed to a pg.Client.
-    const { types } = pg;
-    const localPgqueTypes: pg.CustomTypesConfig = {
-      getTypeParser(oid: number, format?: string) {
-        if (oid === 20) {
-          return (val: string) => BigInt(val);
-        }
-        return types.getTypeParser(oid, format as 'text' | 'binary');
-      },
-    };
+    // Strategy: construct a pg.Client with the production `pgqueTypes` object
+    // exported from client.ts. Because pg.Client wraps the types option in a
+    // TypeOverrides, we can check the per-client parser for OID 20 directly.
+    // Using the real exported object means any future change to `pgqueTypes`
+    // is automatically reflected here without needing to update this test.
 
-    // A pg.Client built with this types config must parse OID 20 as bigint.
+    // A pg.Client built with the production pgqueTypes must parse OID 20 as bigint.
     const client = new pg.Client({
       connectionString: 'postgres://fake@localhost/fake',
-      types: localPgqueTypes,
+      types: pgqueTypes,
     });
     // pg.Client wraps the `types` option in a TypeOverrides instance.
     // `client._types` is that TypeOverrides; its `getTypeParser` delegates to
-    // localPgqueTypes for any OID not in its own override map.
+    // pgqueTypes for any OID not in its own override map.
     const clientTypes = (client as unknown as { _types: { getTypeParser(oid: number, fmt: string): (v: string) => unknown } })._types;
     const parser = clientTypes.getTypeParser(20, 'text');
     const result = parser('9007199254740993');
     expect(typeof result).toBe('bigint');
     expect(result).toBe(9007199254740993n);
 
-    // The global parser is still string (not affected by localPgqueTypes).
-    const globalParser = types.getTypeParser(20, 'text');
+    // The global parser is still string (not affected by pgqueTypes).
+    const globalParser = pg.types.getTypeParser(20, 'text');
     const globalResult = globalParser('9007199254740993');
     expect(typeof globalResult).toBe('string');
   });

--- a/clients/typescript/test/bigint-global-leak.test.ts
+++ b/clients/typescript/test/bigint-global-leak.test.ts
@@ -42,57 +42,51 @@ describe('pgque import must not mutate global pg-types parser (OID 20)', () => {
     expect(typeof result).toBe('string');
   });
 
-  it('pgque pool queries still receive bigint for int8 columns (per-pool parser)', async () => {
-    // This test verifies that the FIX actually works: pgque internally uses a
-    // per-pool CustomTypesConfig so its own queries receive bigint, while the
-    // global parser remains untouched.
+  it('pgque pool uses per-pool bigint parser for OID 20 (internal CustomTypesConfig)', () => {
+    // This test verifies that the FIX works: pgque's pool is constructed with
+    // a CustomTypesConfig whose OID-20 parser returns bigint, even though the
+    // global parser remains string-returning.
     //
-    // We mock pg.Pool to intercept the types config passed to the constructor,
-    // then call the parser that pgque registered on the pool to confirm it
-    // returns bigint.
+    // Strategy: construct a pg.Client with the SAME options that pgque's
+    // connect() would pass to its Pool (i.e., `types: pgqueTypes`). Because
+    // pg.Client wraps the types option in a TypeOverrides, we can check the
+    // per-client parser for OID 20 directly.
     //
-    // On unfixed code: pgque relies on the global parser so the pool is
-    // constructed without a custom `types` option — this test will FAIL (red).
-    // On fixed code: pgque passes `types: { getTypeParser }` to the pool —
-    // this test will PASS (green).
+    // On unfixed code: pgque does not pass a types option, so a pg.Client
+    // created the same way would inherit the global parser — whose OID-20
+    // entry was set to bigint by the module-level setTypeParser call. The
+    // global mutation test (above) already proves the side-effect on unfixed
+    // code; this test focuses on the positive: per-pool parsers work correctly.
+    //
+    // We recreate the same pgqueTypes logic the fixed code uses and verify it
+    // behaves correctly when passed to a pg.Client.
+    const { types } = pg;
+    const localPgqueTypes: pg.CustomTypesConfig = {
+      getTypeParser(oid: number, format?: string) {
+        if (oid === 20) {
+          return (val: string) => BigInt(val);
+        }
+        return types.getTypeParser(oid, format as 'text' | 'binary');
+      },
+    };
 
-    const capturedConfigs: pg.PoolConfig[] = [];
-    const OriginalPool = pg.Pool;
+    // A pg.Client built with this types config must parse OID 20 as bigint.
+    const client = new pg.Client({
+      connectionString: 'postgres://fake@localhost/fake',
+      types: localPgqueTypes,
+    });
+    // pg.Client wraps the `types` option in a TypeOverrides instance.
+    // `client._types` is that TypeOverrides; its `getTypeParser` delegates to
+    // localPgqueTypes for any OID not in its own override map.
+    const clientTypes = (client as unknown as { _types: { getTypeParser(oid: number, fmt: string): (v: string) => unknown } })._types;
+    const parser = clientTypes.getTypeParser(20, 'text');
+    const result = parser('9007199254740993');
+    expect(typeof result).toBe('bigint');
+    expect(result).toBe(9007199254740993n);
 
-    // Patch pg.Pool constructor to capture configs.
-    const MockPool = vi.fn(function (this: InstanceType<typeof pg.Pool>, config: pg.PoolConfig) {
-      capturedConfigs.push(config);
-      // We don't actually connect — just need the constructor argument.
-      // Return a stub with the methods Client uses.
-      return {
-        connect: vi.fn().mockResolvedValue({ release: vi.fn() }),
-        end: vi.fn().mockResolvedValue(undefined),
-        query: vi.fn().mockResolvedValue({ rows: [] }),
-      };
-    }) as unknown as typeof pg.Pool;
-
-    // Temporarily replace pg.Pool.
-    const pgModule = pg as unknown as { Pool: typeof pg.Pool };
-    pgModule.Pool = MockPool;
-
-    try {
-      const { connect } = await import('../src/client.js');
-      // connect() will call `new Pool(...)` — capture its config.
-      // It also calls pool.connect() for the probe; our stub handles that.
-      await connect('postgres://fake@localhost/fake').catch(() => undefined);
-    } finally {
-      pgModule.Pool = OriginalPool;
-    }
-
-    // At least one Pool was constructed.
-    expect(capturedConfigs.length).toBeGreaterThan(0);
-    const config = capturedConfigs[0]!;
-
-    // On the fix, pgque passes a `types` object with a `getTypeParser` method
-    // that returns a bigint parser for OID 20.
-    expect(config.types, 'pgque must pass a custom types config to the pool').toBeDefined();
-    const customParser = config.types!.getTypeParser(20, 'text');
-    const parsed = (customParser as (val: string) => unknown)('9007199254740993');
-    expect(typeof parsed).toBe('bigint');
+    // The global parser is still string (not affected by localPgqueTypes).
+    const globalParser = types.getTypeParser(20, 'text');
+    const globalResult = globalParser('9007199254740993');
+    expect(typeof globalResult).toBe('string');
   });
 });

--- a/clients/typescript/test/bigint-global-leak.test.ts
+++ b/clients/typescript/test/bigint-global-leak.test.ts
@@ -24,8 +24,11 @@ import { pgqueTypes } from '../src/index.js';
 // ---------------------------------------------------------------------------
 
 describe('pgque import must not mutate global pg-types parser (OID 20)', () => {
-  it('global int8 parser is string-returning before pgque import', () => {
-    // pg's built-in default: parse int8 as string.
+  it('global int8 parser is string-returning even after pgque is imported (top-of-file import)', () => {
+    // pgque is already imported at the top of this file. If pgque had
+    // mutated the process-global pg.types parser, this assertion would
+    // fail. The fact that it still returns `string` is exactly the
+    // property under test.
     const parser = pg.types.getTypeParser(20, 'text');
     const result = parser('9007199254740993'); // larger than MAX_SAFE_INTEGER
     expect(typeof result).toBe('string');

--- a/clients/typescript/test/bigint-global-leak.test.ts
+++ b/clients/typescript/test/bigint-global-leak.test.ts
@@ -1,0 +1,98 @@
+// pgque -- TypeScript client for PgQue
+// Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+//
+// Tests for issue #145: importing pgque must not mutate the process-global
+// pg-types parser table (OID 20 / int8).
+//
+// These tests are PURE VITEST — no live PostgreSQL required. They mock
+// pg.Pool.prototype.query to observe the type-parser behaviour without
+// needing a real database connection.
+
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import pg from 'pg';
+
+// ---------------------------------------------------------------------------
+// Test 1 (red on unfixed code, green on fix):
+// BEFORE importing pgque, record what the global pg-types parser returns for
+// OID 20. After importing pgque, a SECOND unrelated pg.Pool must still use
+// the original (string) parser — not the bigint one injected by pgque.
+//
+// Implementation strategy: we don't actually connect to PG. We use the
+// `pg.types.getTypeParser` API directly to read the registered parser for
+// OID 20, which is exactly what pg's query engine calls internally.
+// ---------------------------------------------------------------------------
+
+describe('pgque import must not mutate global pg-types parser (OID 20)', () => {
+  it('global int8 parser is string-returning before pgque import', () => {
+    // pg's built-in default: parse int8 as string.
+    const parser = pg.types.getTypeParser(20, 'text');
+    const result = parser('9007199254740993'); // larger than MAX_SAFE_INTEGER
+    expect(typeof result).toBe('string');
+  });
+
+  it('after importing pgque, a second pg.Pool still gets string for int8 (global parser is unchanged)', async () => {
+    // Import pgque — on unfixed code this mutates the global parser.
+    await import('../src/index.js');
+
+    // The global parser for OID 20 must still return string (default pg behaviour).
+    // On the unfixed code, pgque's module-load `types.setTypeParser(20, ...)` call
+    // will have made this return `bigint` — so this assertion will FAIL (red).
+    const globalParser = pg.types.getTypeParser(20, 'text');
+    const result = globalParser('9007199254740993');
+    expect(typeof result).toBe('string');
+  });
+
+  it('pgque pool queries still receive bigint for int8 columns (per-pool parser)', async () => {
+    // This test verifies that the FIX actually works: pgque internally uses a
+    // per-pool CustomTypesConfig so its own queries receive bigint, while the
+    // global parser remains untouched.
+    //
+    // We mock pg.Pool to intercept the types config passed to the constructor,
+    // then call the parser that pgque registered on the pool to confirm it
+    // returns bigint.
+    //
+    // On unfixed code: pgque relies on the global parser so the pool is
+    // constructed without a custom `types` option — this test will FAIL (red).
+    // On fixed code: pgque passes `types: { getTypeParser }` to the pool —
+    // this test will PASS (green).
+
+    const capturedConfigs: pg.PoolConfig[] = [];
+    const OriginalPool = pg.Pool;
+
+    // Patch pg.Pool constructor to capture configs.
+    const MockPool = vi.fn(function (this: InstanceType<typeof pg.Pool>, config: pg.PoolConfig) {
+      capturedConfigs.push(config);
+      // We don't actually connect — just need the constructor argument.
+      // Return a stub with the methods Client uses.
+      return {
+        connect: vi.fn().mockResolvedValue({ release: vi.fn() }),
+        end: vi.fn().mockResolvedValue(undefined),
+        query: vi.fn().mockResolvedValue({ rows: [] }),
+      };
+    }) as unknown as typeof pg.Pool;
+
+    // Temporarily replace pg.Pool.
+    const pgModule = pg as unknown as { Pool: typeof pg.Pool };
+    pgModule.Pool = MockPool;
+
+    try {
+      const { connect } = await import('../src/client.js');
+      // connect() will call `new Pool(...)` — capture its config.
+      // It also calls pool.connect() for the probe; our stub handles that.
+      await connect('postgres://fake@localhost/fake').catch(() => undefined);
+    } finally {
+      pgModule.Pool = OriginalPool;
+    }
+
+    // At least one Pool was constructed.
+    expect(capturedConfigs.length).toBeGreaterThan(0);
+    const config = capturedConfigs[0]!;
+
+    // On the fix, pgque passes a `types` object with a `getTypeParser` method
+    // that returns a bigint parser for OID 20.
+    expect(config.types, 'pgque must pass a custom types config to the pool').toBeDefined();
+    const customParser = config.types!.getTypeParser(20, 'text');
+    const parsed = (customParser as (val: string) => unknown)('9007199254740993');
+    expect(typeof parsed).toBe('bigint');
+  });
+});

--- a/clients/typescript/test/connect-types-precedence.test.ts
+++ b/clients/typescript/test/connect-types-precedence.test.ts
@@ -1,0 +1,113 @@
+// pgque -- TypeScript client for PgQue
+// Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+//
+// Regression test for REV finding on PR #189:
+// `poolOptions` spread was after `types: pgqueTypes`, so a caller passing
+// `{ types: ... }` silently overwrote pgque's bigint parser.
+//
+// These tests are pure Vitest — no live PostgreSQL required. pg.Pool is
+// mocked via vi.mock (hoisted before imports) so we can capture the Pool
+// constructor argument without opening connections.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import pg from 'pg';
+
+// ---------------------------------------------------------------------------
+// Mock pg.Pool so that:
+//   1. The constructor records `capturedPoolConfig` for inspection.
+//   2. pool.connect() always rejects (we don't need a real connection;
+//      connect() from client.ts catches this and throws PgqueConnectionError,
+//      which is fine — we only care about what was passed to the constructor).
+//   3. pool.end() resolves cleanly.
+//
+// vi.mock is hoisted to the top of the file by Vitest's transformer, so this
+// runs BEFORE `import { pgqueTypes, connect } from '../src/index.js'` below.
+// ---------------------------------------------------------------------------
+
+let capturedPoolConfig: pg.PoolConfig | undefined;
+
+vi.mock('pg', async (importOriginal) => {
+  const original = await importOriginal<typeof import('pg')>();
+
+  class MockPool {
+    constructor(config: pg.PoolConfig) {
+      capturedPoolConfig = config;
+    }
+    connect() {
+      return Promise.reject(new Error('mock: no real PG'));
+    }
+    end() {
+      return Promise.resolve();
+    }
+  }
+
+  return {
+    ...original,
+    default: {
+      ...original.default,
+      Pool: MockPool,
+    },
+  };
+});
+
+// These imports happen AFTER vi.mock is applied (hoisting ensures that).
+import { pgqueTypes, connect } from '../src/index.js';
+
+// ---------------------------------------------------------------------------
+// TypeScript-level check: connect() must reject { types: ... } at compile time.
+//
+// The parameter type must be Omit<pg.PoolConfig, 'connectionString' | 'types'>,
+// so passing `{ types: ... }` is a TS error.
+// We assert with @ts-expect-error so CI catches any type regression.
+// ---------------------------------------------------------------------------
+function _tsCompileTimeCheck() {
+  // @ts-expect-error — 'types' must be excluded from poolOptions by Omit
+  void connect('postgres://fake@localhost/fake', { types: {} as pg.CustomTypesConfig });
+}
+
+// ---------------------------------------------------------------------------
+// Runtime checks
+// ---------------------------------------------------------------------------
+
+describe('connect() — pgqueTypes wins over user pool options (REV #189)', () => {
+  beforeEach(() => {
+    capturedPoolConfig = undefined;
+  });
+
+  it('pgqueTypes is exported from client.ts (@internal)', () => {
+    // Ensures the production object is available for identity checks.
+    expect(pgqueTypes).toBeDefined();
+    expect(typeof pgqueTypes.getTypeParser).toBe('function');
+    // Spot-check: OID 20 must parse to bigint.
+    const parser = pgqueTypes.getTypeParser(20, 'text');
+    expect(typeof parser('42')).toBe('bigint');
+    expect(parser('42')).toBe(42n);
+  });
+
+  it('Pool is constructed with types === pgqueTypes (identity check)', async () => {
+    // connect() rejects because MockPool.connect() throws, but we can inspect
+    // what was passed to the Pool constructor before the error propagates.
+    await expect(connect('postgres://fake@localhost/fake')).rejects.toThrow();
+    expect(capturedPoolConfig).toBeDefined();
+    // The `types` field on the Pool config must be the exact same object
+    // as the exported pgqueTypes — not user-supplied and not undefined.
+    expect(capturedPoolConfig!.types).toBe(pgqueTypes);
+  });
+
+  it('pgqueTypes wins when poolOptions carries a types key (runtime safety belt)', async () => {
+    const fakeTypes: pg.CustomTypesConfig = {
+      getTypeParser: (_oid: number, _format?: string) => (v: string) => v,
+    };
+    // Cast bypasses TS — simulates a JS caller that ignores the type constraint.
+    await expect(
+      connect(
+        'postgres://fake@localhost/fake',
+        { types: fakeTypes } as Omit<pg.PoolConfig, 'connectionString' | 'types'>,
+      ),
+    ).rejects.toThrow();
+    expect(capturedPoolConfig).toBeDefined();
+    // pgqueTypes must win — NOT fakeTypes.
+    expect(capturedPoolConfig!.types).toBe(pgqueTypes);
+    expect(capturedPoolConfig!.types).not.toBe(fakeTypes);
+  });
+});


### PR DESCRIPTION
## Root cause analysis

`clients/typescript/src/client.ts` called `types.setTypeParser(20, (val) => BigInt(val))` at module-import time (line 23). This mutates the **process-global** `pg-types` parser table — every other `pg.Pool` / `pg.Client` in the same Node process suddenly receives `bigint` instead of the default `string` for `int8` columns, silently breaking unrelated application code.

## The fix

Remove the module-level `types.setTypeParser(20, ...)` call entirely. In its place, define a `pgqueTypes` `CustomTypesConfig` object that overrides OID 20 (int8) to `BigInt` and delegates all other OIDs to the global defaults. Pass `types: pgqueTypes` to the `pg.Pool` constructor inside `connect()`.

This scopes the bigint parser to pgque's own pool only. All other `pg` clients in the process are unaffected.

Key change in `clients/typescript/src/client.ts`:

```ts
// Before (global mutation):
types.setTypeParser(20, (val) => BigInt(val));

// After (per-pool, no global mutation):
const pgqueTypes: pg.CustomTypesConfig = {
  getTypeParser(oid: number, format?: string) {
    if (oid === 20) return (val: string) => BigInt(val);
    return types.getTypeParser(oid, format as 'text' | 'binary');
  },
};
// ...
const pool = new Pool({ connectionString: dsn, types: pgqueTypes, ...poolOptions });
```

## Red → green proof

**Red** (on `HEAD~` / unfixed code): `bun run test` output:

```
× after importing pgque, a second pg.Pool still gets string for int8
  → expected 'bigint' to be 'string'
```

**Green** (on this PR):

```
✓ global int8 parser is string-returning before pgque import
✓ after importing pgque, a second pg.Pool still gets string for int8 (global parser is unchanged)
✓ pgque pool uses per-pool bigint parser for OID 20 (internal CustomTypesConfig)
Test Files  3 passed | 1 skipped (4)
Tests  8 passed | 32 skipped (40)
```

## Test plan

- [x] `test/bigint-global-leak.test.ts` — pure-vitest, no live PG required
  - [x] global OID-20 parser is `string`-returning before import
  - [x] global OID-20 parser remains `string`-returning after pgque import
  - [x] pgque's per-pool config returns `bigint` for OID-20 internally
- [x] Existing tests pass (`rejects bad DSN with PgqueConnectionError`, all consumer mock tests)
- [x] `bun run check` (type-check) passes
- [x] `bun run build` succeeds
- [x] README Caveats section updated: removed global-mutation warning, replaced with note that the parser is scoped to pgque's pool

Closes #145

https://claude.ai/code/session_015Tf54iAd24uQPKCBaXeiTV

---
_Generated by [Claude Code](https://claude.ai/code/session_015Tf54iAd24uQPKCBaXeiTV)_