### PR TITLE
chore: ignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ build/output/
 clients/python/*.egg-info/
 clients/typescript/node_modules/
 clients/typescript/package-lock.json
+
+# Claude Code agent worktrees (ephemeral isolation per agent run)
+.claude/worktrees/


### PR DESCRIPTION
## Summary

Adds `.claude/worktrees/` to `.gitignore`. The Claude Code agent harness materialises subagent isolation worktrees there during multi-agent runs; those directories are ephemeral and should not be tracked.

## Why

When multiple subagents are spawned with `isolation: "worktree"`, each one creates a directory under `.claude/worktrees/` that persists for the lifetime of the parent session. Without ignoring it, every orchestrated multi-agent run leaves the working tree "dirty" with untracked dirs.

## Test plan

- [x] `git status` is clean after a multi-agent orchestration run
- [x] `.gitignore` change is the only diff in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_015Tf54iAd24uQPKCBaXeiTV)_