### PR TITLE
fix(clients): surface SQL ack() rowcount (TS+Go) (#148)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,11 +213,6 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: clients/go/go.mod
-          cache: false
-
       - name: Start PostgreSQL 18
         run: |
           set -Eeuo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,21 @@ jobs:
         run: |
           set -Eeuo pipefail
           cd clients/go
-          go test -race -v ./...
+          go env GOROOT GOMOD GOPATH GOFLAGS
+          go version
+          # Tee test output so failures are visible in the step summary, not
+          # only in the raw log.
+          set +e
+          go test -race -v ./... 2>&1 | tee /tmp/gotest.log
+          exit_code=${PIPESTATUS[0]}
+          set -e
+          if [[ "${exit_code}" -ne 0 ]]; then
+            echo "::group::Last 80 lines of test output (failure)"
+            tail -80 /tmp/gotest.log
+            echo "::endgroup::"
+            echo "::error::go test exited with code ${exit_code}"
+          fi
+          exit "${exit_code}"
 
       - name: Cleanup Go test DB
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: clients/go/go.mod
+          cache-dependency-path: clients/go/go.sum
 
       - name: Start PostgreSQL 18
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: clients/go/go.mod
-          cache-dependency-path: clients/go/go.sum
+          cache: false
 
       - name: Start PostgreSQL 18
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,17 +242,26 @@ jobs:
           cd clients/go
           go env GOROOT GOMOD GOPATH GOFLAGS
           go version
-          # Tee test output so failures are visible in the step summary, not
-          # only in the raw log.
           set +e
           go test -race -v ./... 2>&1 | tee /tmp/gotest.log
           exit_code=${PIPESTATUS[0]}
           set -e
           if [[ "${exit_code}" -ne 0 ]]; then
-            echo "::group::Last 80 lines of test output (failure)"
-            tail -80 /tmp/gotest.log
+            # Emit each --- FAIL: / FAIL line as an explicit error annotation
+            # so the specific failing tests show up in the GitHub UI without
+            # needing access to the raw log.
+            grep -E '^(--- FAIL|FAIL|=== RUN.*FAIL)' /tmp/gotest.log | while read -r line; do
+              echo "::error::${line}"
+            done
+            # Also emit the surrounding compile / panic context if present.
+            if grep -qE '^(\\./|FAIL\s|panic|cannot find|undefined:)' /tmp/gotest.log; then
+              grep -nE '^(\\./|FAIL\s|panic|cannot find|undefined:)' /tmp/gotest.log | head -20 | while read -r line; do
+                echo "::error::${line}"
+              done
+            fi
+            echo "::group::Full test output tail (last 200 lines)"
+            tail -200 /tmp/gotest.log
             echo "::endgroup::"
-            echo "::error::go test exited with code ${exit_code}"
           fi
           exit "${exit_code}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,30 +240,7 @@ jobs:
         run: |
           set -Eeuo pipefail
           cd clients/go
-          go env GOROOT GOMOD GOPATH GOFLAGS
-          go version
-          set +e
-          go test -race -v ./... 2>&1 | tee /tmp/gotest.log
-          exit_code=${PIPESTATUS[0]}
-          set -e
-          if [[ "${exit_code}" -ne 0 ]]; then
-            # Emit each --- FAIL: / FAIL line as an explicit error annotation
-            # so the specific failing tests show up in the GitHub UI without
-            # needing access to the raw log.
-            grep -E '^(--- FAIL|FAIL|=== RUN.*FAIL)' /tmp/gotest.log | while read -r line; do
-              echo "::error::${line}"
-            done
-            # Also emit the surrounding compile / panic context if present.
-            if grep -qE '^(\\./|FAIL\s|panic|cannot find|undefined:)' /tmp/gotest.log; then
-              grep -nE '^(\\./|FAIL\s|panic|cannot find|undefined:)' /tmp/gotest.log | head -20 | while read -r line; do
-                echo "::error::${line}"
-              done
-            fi
-            echo "::group::Full test output tail (last 200 lines)"
-            tail -200 /tmp/gotest.log
-            echo "::endgroup::"
-          fi
-          exit "${exit_code}"
+          go test -race -v ./...
 
       - name: Cleanup Go test DB
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,10 @@ jobs:
         with:
           submodules: recursive
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: clients/go/go.mod
+
       - name: Start PostgreSQL 18
         run: |
           set -Eeuo pipefail

--- a/clients/README.md
+++ b/clients/README.md
@@ -15,7 +15,7 @@ SQL primitives. The matrix below tracks the public client API on current
 | `send` | ✓ | ✓ | ✓ |
 | `send_batch` / `SendBatch` / `sendBatch` | ✓ | ✓ | ✓ |
 | `receive` | ✓ | ✓ | ✓ |
-| `ack` | ✓ | ✓ | ✓ |
+| `ack` returns SQL rowcount (0 stale, 1 success) | ✓ (int) | ✓ (int64) | ✓ (number) |
 | `nack` | ✓ | ✓ | ✓ |
 | `nack` retry delay + reason options | ✓ | ✗ | ✓ |
 | High-level `Consumer` | ✓ | ✓ | ✓ |

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -95,6 +95,25 @@ err := client.Nack(ctx, batchID, msg,
 Calls without options preserve the historical defaults: 60-second retry
 delay, NULL reason.
 
+## Ack rowcount
+
+`Client.Ack` returns `(int64, error)`. The `int64` is the row-count from
+`pgque.finish_batch`:
+
+- `1` — batch was active and has been finished (normal success).
+- `0` — no active batch was finished: the `batchID` was not found, was already
+  finished (stale/double ack), or belongs to a different consumer. This is not a
+  SQL error — the `error` return is nil. Log it at warn level if you see it.
+
+```go
+n, err := client.Ack(ctx, batchID)
+if err != nil {
+    log.Printf("ack SQL error: %v", err)
+} else if n == 0 {
+    log.Printf("ack returned 0 — stale or double ack for batch %d", batchID)
+}
+```
+
 ## At-least-once contract
 
 If a per-message Nack call fails, the Consumer leaves the batch unacked

--- a/clients/go/ack_rowcount_test.go
+++ b/clients/go/ack_rowcount_test.go
@@ -76,6 +76,9 @@ func TestAck_StubReturnsOne(t *testing.T) {
 	if got := atomic.LoadInt32(&stub.ackCount); got == 0 {
 		t.Fatal("expected Ack to be called at least once")
 	}
+	if got := atomic.LoadInt32(&stub.nackCalled); got != 0 {
+		t.Fatalf("Nack must not be called on the success path; got %d", got)
+	}
 }
 
 // TestAck_StubReturnsZero confirms the consumer logs (not errors) when Ack
@@ -102,6 +105,9 @@ func TestAck_StubReturnsZero(t *testing.T) {
 
 	if got := atomic.LoadInt32(&stub.ackCount); got == 0 {
 		t.Fatal("expected Ack to be called at least once")
+	}
+	if got := atomic.LoadInt32(&stub.nackCalled); got != 0 {
+		t.Fatalf("Nack must not be called on the success path (rowcount 0 is informational); got %d", got)
 	}
 }
 

--- a/clients/go/ack_rowcount_test.go
+++ b/clients/go/ack_rowcount_test.go
@@ -126,7 +126,7 @@ func TestAck_DirectCall_ReturnsRowcount(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(msgs) == 0 {
-		t.Skip("no messages received — queue may not have ticked")
+		t.Fatal("no messages received after tick — harness bug, not a skip-worthy condition")
 	}
 
 	batchID := msgs[0].BatchID

--- a/clients/go/ack_rowcount_test.go
+++ b/clients/go/ack_rowcount_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+package pgque_test
+
+// TestAck_ReturnsRowcount_Unit uses a stub backend to verify that Ack
+// returns the integer row-count from pgque.finish_batch: 1 on success, 0
+// for a stale/double ack. This is a unit test — no live database required.
+//
+// Red: stubBackend.Ack still has the OLD signature (error), so the test
+// file will not compile until the signature is widened to (int64, error).
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	pgque "github.com/NikolayS/pgque/clients/go"
+)
+
+// ackRowcountBackend is a minimal consumerBackend stub where Ack returns a
+// configurable (int64, error) pair, exercising the new contract.
+type ackRowcountBackend struct {
+	mu sync.Mutex
+
+	delivered  bool
+	msg        pgque.Message
+	ackResult  int64
+	ackErr     error
+	ackCount   int32
+	nackCalled int32
+}
+
+func (s *ackRowcountBackend) Receive(_ context.Context, _, _ string, _ int) ([]pgque.Message, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.delivered {
+		return nil, nil
+	}
+	s.delivered = true
+	return []pgque.Message{s.msg}, nil
+}
+
+func (s *ackRowcountBackend) Ack(_ context.Context, _ int64) (int64, error) {
+	atomic.AddInt32(&s.ackCount, 1)
+	return s.ackResult, s.ackErr
+}
+
+func (s *ackRowcountBackend) Nack(_ context.Context, _ int64, _ pgque.Message, _ ...pgque.NackOption) error {
+	atomic.AddInt32(&s.nackCalled, 1)
+	return nil
+}
+
+// TestAck_StubReturnsOne confirms the consumer calls Ack and accepts a
+// rowcount of 1 (normal success path).
+func TestAck_StubReturnsOne(t *testing.T) {
+	var client *pgque.Client
+	stub := &ackRowcountBackend{
+		msg: pgque.Message{
+			MsgID:   1,
+			BatchID: 10,
+			Type:    "ok.type",
+			Payload: `{}`,
+		},
+		ackResult: 1,
+	}
+	c := client.NewConsumer("q", "c", pgque.WithPollInterval(20*time.Millisecond))
+	pgque.SetConsumerBackend(c, stub)
+	c.Handle("ok.type", func(_ context.Context, _ pgque.Message) error { return nil })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+	_ = c.Start(ctx)
+
+	if got := atomic.LoadInt32(&stub.ackCount); got == 0 {
+		t.Fatal("expected Ack to be called at least once")
+	}
+}
+
+// TestAck_StubReturnsZero confirms the consumer logs (not errors) when Ack
+// returns 0 (stale/double ack). The batch loop must continue rather than panic
+// or propagate an error.
+func TestAck_StubReturnsZero(t *testing.T) {
+	var client *pgque.Client
+	stub := &ackRowcountBackend{
+		msg: pgque.Message{
+			MsgID:   2,
+			BatchID: 20,
+			Type:    "stale.type",
+			Payload: `{}`,
+		},
+		ackResult: 0,
+	}
+	c := client.NewConsumer("q", "c", pgque.WithPollInterval(20*time.Millisecond))
+	pgque.SetConsumerBackend(c, stub)
+	c.Handle("stale.type", func(_ context.Context, _ pgque.Message) error { return nil })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+	_ = c.Start(ctx)
+
+	if got := atomic.LoadInt32(&stub.ackCount); got == 0 {
+		t.Fatal("expected Ack to be called at least once")
+	}
+}
+
+// TestAck_DirectCall_ReturnsRowcount verifies the Client.Ack method itself
+// returns (int64, error). This test requires a live database; it is skipped
+// when PGQUE_TEST_DSN is not reachable.
+func TestAck_DirectCall_ReturnsRowcount(t *testing.T) {
+	client := connectOrSkip(t)
+	defer client.Close()
+	queue, consumer := setupFreshQueue(t, client)
+	ctx := context.Background()
+
+	if _, err := client.Send(ctx, queue, pgque.Event{
+		Type: "ack.rowcount.test", Payload: map[string]any{"v": 1},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	tick(t, client, queue)
+
+	msgs, err := client.Receive(ctx, queue, consumer, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) == 0 {
+		t.Skip("no messages received — queue may not have ticked")
+	}
+
+	batchID := msgs[0].BatchID
+
+	// First ack: expects rowcount 1.
+	n1, err := client.Ack(ctx, batchID)
+	if err != nil {
+		t.Fatalf("first Ack returned error: %v", err)
+	}
+	if n1 != 1 {
+		t.Fatalf("first Ack: expected rowcount 1, got %d", n1)
+	}
+
+	// Second ack of the same batch: expects rowcount 0 (stale ack).
+	n2, err := client.Ack(ctx, batchID)
+	if err != nil {
+		t.Fatalf("second Ack returned error: %v", err)
+	}
+	if n2 != 0 {
+		t.Fatalf("second Ack (double-ack): expected rowcount 0, got %d", n2)
+	}
+}

--- a/clients/go/ack_rowcount_test.go
+++ b/clients/go/ack_rowcount_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	pgque "github.com/NikolayS/pgque/clients/go"
+	pgque "github.com/NikolayS/pgque-go"
 )
 
 // ackRowcountBackend is a minimal consumerBackend stub where Ack returns a

--- a/clients/go/bench_test.go
+++ b/clients/go/bench_test.go
@@ -74,7 +74,7 @@ func BenchmarkSendReceiveAck(b *testing.B) {
 			b.Fatal(err)
 		}
 		if len(msgs) > 0 {
-			if err := client.Ack(ctx, msgs[0].BatchID); err != nil {
+			if _, err := client.Ack(ctx, msgs[0].BatchID); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/clients/go/concurrency_test.go
+++ b/clients/go/concurrency_test.go
@@ -59,7 +59,7 @@ func TestRace_ConcurrentSend(t *testing.T) {
 			break
 		}
 		total += len(msgs)
-		if err := client.Ack(ctx, msgs[0].BatchID); err != nil {
+		if _, err := client.Ack(ctx, msgs[0].BatchID); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -131,7 +131,7 @@ func TestRace_SendReceiveLoop(t *testing.T) {
 			}
 			if len(msgs) > 0 {
 				atomic.AddInt64(&received, int64(len(msgs)))
-				client.Ack(ctx, msgs[0].BatchID)
+				_, _ = client.Ack(ctx, msgs[0].BatchID)
 			}
 			time.Sleep(20 * time.Millisecond)
 		}

--- a/clients/go/consumer.go
+++ b/clients/go/consumer.go
@@ -23,7 +23,9 @@ type HandlerFunc func(ctx context.Context, msg Message) error
 // simulate Nack failures without a live database.
 type consumerBackend interface {
 	Receive(ctx context.Context, queue, consumer string, maxMessages int) ([]Message, error)
-	Ack(ctx context.Context, batchID int64) error
+	// Ack returns the row-count from pgque.finish_batch: 1 on success,
+	// 0 for a stale/double ack (batch already finished or not found).
+	Ack(ctx context.Context, batchID int64) (int64, error)
 	Nack(ctx context.Context, batchID int64, msg Message, opts ...NackOption) error
 }
 
@@ -136,8 +138,11 @@ func (c *Consumer) Start(ctx context.Context) error {
 				log.Printf("pgque: skipping ack for batch %d due to prior nack failures; PgQue will redeliver", batchID)
 				continue
 			}
-			if err := c.backend.Ack(ctx, batchID); err != nil {
+			n, err := c.backend.Ack(ctx, batchID)
+			if err != nil {
 				log.Printf("pgque: ack error: %v", err)
+			} else if n == 0 {
+				log.Printf("pgque: ack batch %d returned 0 rows — stale or double ack (batch already finished or not found)", batchID)
 			}
 		}
 	}

--- a/clients/go/consumer_nackfail_test.go
+++ b/clients/go/consumer_nackfail_test.go
@@ -42,9 +42,9 @@ func (s *stubBackend) Receive(_ context.Context, _, _ string, maxMessages int) (
 	return []pgque.Message{s.msg}, nil
 }
 
-func (s *stubBackend) Ack(_ context.Context, _ int64) error {
+func (s *stubBackend) Ack(_ context.Context, _ int64) (int64, error) {
 	atomic.AddInt32(&s.ackCount, 1)
-	return nil
+	return 1, nil
 }
 
 func (s *stubBackend) Nack(_ context.Context, _ int64, _ pgque.Message, _ ...pgque.NackOption) error {

--- a/clients/go/edge_test.go
+++ b/clients/go/edge_test.go
@@ -33,7 +33,7 @@ func TestEvent_EmptyPayload(t *testing.T) {
 	if !strings.Contains(msgs[0].Payload, "null") {
 		t.Logf("payload for nil Payload is %q (acceptable as long as Receive does not panic)", msgs[0].Payload)
 	}
-	client.Ack(ctx, msgs[0].BatchID)
+	_, _ = client.Ack(ctx, msgs[0].BatchID)
 }
 
 // TestEvent_LargePayload: 1 MiB payload round-trips without truncation.
@@ -62,7 +62,7 @@ func TestEvent_LargePayload(t *testing.T) {
 	if !strings.Contains(msgs[0].Payload, big) {
 		t.Fatalf("large payload truncated: received %d bytes, expected ≥ %d", len(msgs[0].Payload), size)
 	}
-	client.Ack(ctx, msgs[0].BatchID)
+	_, _ = client.Ack(ctx, msgs[0].BatchID)
 }
 
 // TestEvent_UnicodeEverything: type and payload contain unicode (CJK + emoji).
@@ -93,7 +93,7 @@ func TestEvent_UnicodeEverything(t *testing.T) {
 	if !strings.Contains(msgs[0].Payload, "中文") || !strings.Contains(msgs[0].Payload, "🎉") {
 		t.Fatalf("payload unicode mangled: %s", msgs[0].Payload)
 	}
-	client.Ack(ctx, msgs[0].BatchID)
+	_, _ = client.Ack(ctx, msgs[0].BatchID)
 }
 
 // TestEvent_TypeWithSpecialChars: types with dots, dashes, and slashes are
@@ -136,7 +136,7 @@ func TestEvent_TypeWithSpecialChars(t *testing.T) {
 		}
 	}
 	if len(msgs) > 0 {
-		client.Ack(ctx, msgs[0].BatchID)
+		_, _ = client.Ack(ctx, msgs[0].BatchID)
 	}
 }
 
@@ -171,7 +171,7 @@ func TestMessage_TimestampSensible(t *testing.T) {
 	if msgs[0].CreatedAt.Before(before) || msgs[0].CreatedAt.After(after) {
 		t.Fatalf("CreatedAt %v not within [%v, %v]", msgs[0].CreatedAt, before, after)
 	}
-	client.Ack(ctx, msgs[0].BatchID)
+	_, _ = client.Ack(ctx, msgs[0].BatchID)
 }
 
 // TestMessage_RetryCountInitiallyNilOrZero: a freshly-sent event has retry_count
@@ -199,7 +199,7 @@ func TestMessage_RetryCountInitiallyNilOrZero(t *testing.T) {
 	if msgs[0].RetryCount != nil && *msgs[0].RetryCount != 0 {
 		t.Fatalf("expected RetryCount nil or 0 for fresh event, got %d", *msgs[0].RetryCount)
 	}
-	client.Ack(ctx, msgs[0].BatchID)
+	_, _ = client.Ack(ctx, msgs[0].BatchID)
 }
 
 // TestEvent_PayloadIsString: a string Payload marshals to a JSON string.
@@ -226,7 +226,7 @@ func TestEvent_PayloadIsString(t *testing.T) {
 	if msgs[0].Payload != `"just a string"` {
 		t.Fatalf("expected JSON-quoted string payload, got %q", msgs[0].Payload)
 	}
-	client.Ack(ctx, msgs[0].BatchID)
+	_, _ = client.Ack(ctx, msgs[0].BatchID)
 }
 
 // TestEvent_PayloadIsArray: a slice payload marshals to a JSON array.
@@ -253,7 +253,7 @@ func TestEvent_PayloadIsArray(t *testing.T) {
 	if msgs[0].Payload != "[1, 2, 3]" {
 		t.Fatalf("expected [1, 2, 3], got %q", msgs[0].Payload)
 	}
-	client.Ack(ctx, msgs[0].BatchID)
+	_, _ = client.Ack(ctx, msgs[0].BatchID)
 }
 
 // NOTE: The Send API does not currently accept Extra1..Extra4 fields on

--- a/clients/go/errors_test.go
+++ b/clients/go/errors_test.go
@@ -153,7 +153,7 @@ func TestAck_NonExistentBatch(t *testing.T) {
 	defer client.Close()
 	ctx := context.Background()
 
-	err := client.Ack(ctx, 9_999_999_999)
+	_, err := client.Ack(ctx, 9_999_999_999)
 	if err == nil {
 		t.Skip("Ack of non-existent batch did not error — backend treats this as no-op (acceptable)")
 	}
@@ -169,7 +169,7 @@ func TestAck_AfterClose(t *testing.T) {
 			t.Fatalf("Ack after Close panicked: %v", r)
 		}
 	}()
-	if err := client.Ack(context.Background(), 1); err == nil {
+	if _, err := client.Ack(context.Background(), 1); err == nil {
 		t.Fatal("expected error from Ack after Close")
 	}
 }

--- a/clients/go/errors_test.go
+++ b/clients/go/errors_test.go
@@ -146,16 +146,24 @@ func TestReceive_ContextCancelled(t *testing.T) {
 	}
 }
 
-// TestAck_NonExistentBatch: acking a non-existent batch must surface an
-// error rather than silently succeeding.
-func TestAck_NonExistentBatch(t *testing.T) {
+// TestAck_NonExistentBatch_ReturnsZero verifies the new contract: acking a
+// batch_id that does not exist returns (0, nil). pgque.finish_batch is
+// defined to return the count of rows updated; a non-existent batch_id
+// matches no rows, so the count is 0 and no SQL error is raised. Callers
+// should treat a 0 rowcount as a warn-level log, not a hard error.
+func TestAck_NonExistentBatch_ReturnsZero(t *testing.T) {
 	client := connectOrSkip(t)
 	defer client.Close()
 	ctx := context.Background()
 
-	_, err := client.Ack(ctx, 9_999_999_999)
-	if err == nil {
-		t.Skip("Ack of non-existent batch did not error — backend treats this as no-op (acceptable)")
+	// 999_999_999 is far outside the range of any real batch_id that could
+	// exist in a freshly-initialised test database.
+	n, err := client.Ack(ctx, 999_999_999)
+	if err != nil {
+		t.Fatalf("expected (0, nil) for non-existent batch, got err: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected rowcount 0 for non-existent batch, got %d", n)
 	}
 }
 

--- a/clients/go/examples_test.go
+++ b/clients/go/examples_test.go
@@ -38,7 +38,7 @@ func Example_sendReceiveAck() {
 		log.Printf("got %s: %s", msg.Type, msg.Payload)
 	}
 	if len(msgs) > 0 {
-		if err := client.Ack(ctx, msgs[0].BatchID); err != nil {
+		if _, err := client.Ack(ctx, msgs[0].BatchID); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/clients/go/integration_test.go
+++ b/clients/go/integration_test.go
@@ -34,7 +34,7 @@ func TestSend_DefaultEventType(t *testing.T) {
 	if msgs[0].Type != "default" {
 		t.Fatalf("expected default type, got %q", msgs[0].Type)
 	}
-	if err := client.Ack(ctx, msgs[0].BatchID); err != nil {
+	if _, err := client.Ack(ctx, msgs[0].BatchID); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -71,7 +71,7 @@ func TestSend_MultipleEventsOneBatch(t *testing.T) {
 			t.Fatalf("expected all messages in one batch, got mixed batch ids %d and %d", first, m.BatchID)
 		}
 	}
-	if err := client.Ack(ctx, first); err != nil {
+	if _, err := client.Ack(ctx, first); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -101,7 +101,7 @@ func TestReceive_RespectsMaxBatch(t *testing.T) {
 		t.Fatalf("Receive returned %d messages, expected ≤ 10", len(msgs))
 	}
 	if len(msgs) > 0 {
-		client.Ack(ctx, msgs[0].BatchID)
+		_, _ = client.Ack(ctx, msgs[0].BatchID)
 	}
 }
 
@@ -181,7 +181,7 @@ func TestNack_ToDLQAtRetryLimit(t *testing.T) {
 		}
 		// Close the batch so PgQ advances the consumer cursor and the
 		// retry_queue rows become eligible for redelivery on the next cycle.
-		if err := client.Ack(ctx, batchID); err != nil {
+		if _, err := client.Ack(ctx, batchID); err != nil {
 			t.Fatalf("ack after nack: %v", err)
 		}
 	}
@@ -243,7 +243,7 @@ func TestSendReceive_PayloadRoundTrip(t *testing.T) {
 	if !strings.Contains(msgs[0].Payload, `"string"`) || !strings.Contains(msgs[0].Payload, `"hello"`) {
 		t.Fatalf("payload missing expected fields: %s", msgs[0].Payload)
 	}
-	client.Ack(ctx, msgs[0].BatchID)
+	_, _ = client.Ack(ctx, msgs[0].BatchID)
 }
 
 // TestSendBatch_RoundTrip verifies that SendBatch publishes every payload
@@ -285,7 +285,7 @@ func TestSendBatch_RoundTrip(t *testing.T) {
 			t.Fatalf("expected batch.type, got %q", m.Type)
 		}
 	}
-	if err := client.Ack(ctx, msgs[0].BatchID); err != nil {
+	if _, err := client.Ack(ctx, msgs[0].BatchID); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -338,7 +338,7 @@ func TestNack_WithRetryAfter(t *testing.T) {
 		pgque.WithReason("custom-reason-string")); err != nil {
 		t.Fatal(err)
 	}
-	if err := client.Ack(ctx, msgs[0].BatchID); err != nil {
+	if _, err := client.Ack(ctx, msgs[0].BatchID); err != nil {
 		t.Fatal(err)
 	}
 

--- a/clients/go/pgque.go
+++ b/clients/go/pgque.go
@@ -132,12 +132,20 @@ func (c *Client) Receive(ctx context.Context, queue, consumer string, maxMessage
 // Ack finishes a batch, advancing the consumer's position past it. PgQue
 // delivers at-least-once: failing to Ack a batch causes redelivery on
 // the next Receive.
-func (c *Client) Ack(ctx context.Context, batchID int64) error {
-	_, err := c.pool.Exec(ctx, "SELECT pgque.ack($1)", batchID)
+//
+// The returned int64 is the row-count from pgque.finish_batch:
+//   - 1: the batch was active and has been finished (normal success).
+//   - 0: no active batch was finished — the batch_id was not found,
+//     already finished (stale/double ack), or belongs to a different
+//     consumer. Callers should log this at warn level; it is not a SQL
+//     error and does not indicate a connection problem.
+func (c *Client) Ack(ctx context.Context, batchID int64) (int64, error) {
+	var n int64
+	err := c.pool.QueryRow(ctx, "SELECT pgque.ack($1)", batchID).Scan(&n)
 	if err != nil {
-		return wrapSQLError("ack", err)
+		return 0, wrapSQLError("ack", err)
 	}
-	return nil
+	return n, nil
 }
 
 // Nack negatively acknowledges a single message, routing it to retry or DLQ.

--- a/clients/go/pgque_test.go
+++ b/clients/go/pgque_test.go
@@ -251,8 +251,7 @@ func TestSendAndReceive(t *testing.T) {
 	}
 
 	// Ack
-	err = client.Ack(ctx, msgs[0].BatchID)
-	if err != nil {
+	if _, err = client.Ack(ctx, msgs[0].BatchID); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -289,7 +288,7 @@ func TestNack(t *testing.T) {
 	if err := client.Nack(ctx, msgs[0].BatchID, msgs[0]); err != nil {
 		t.Fatal(err)
 	}
-	if err := client.Ack(ctx, msgs[0].BatchID); err != nil {
+	if _, err := client.Ack(ctx, msgs[0].BatchID); err != nil {
 		t.Fatal(err)
 	}
 

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -65,8 +65,8 @@ try {
 | `connect(dsn, poolOptions?)` | Connect via `pg.Pool`. Eagerly probes the connection. |
 | `client.send(queue, event)` | Publish; returns event id (`bigint`). |
 | `client.sendBatch(queue, type, payloads)` | Publish a same-type batch atomically; returns event ids (`bigint[]`). |
-| `client.receive(queue, consumer, max?)` | Fetch up to `max` (default 100) messages from the next batch. |
-| `client.ack(batchId)` | Finish the batch. |
+| `client.receive(queue, consumer, max?)` | Fetch up to `max` (default 100) messages from the next batch. If you later call `ack(batchId)`, PgQue finishes the whole underlying batch, including rows beyond `max`; size `max` for your queue or use the high-level consumer default. |
+| `client.ack(batchId)` | Finish the batch. Returns `1` on success, `0` if the batch was already finished or not found (stale/double ack — log at warn level, not an error). |
 | `client.nack(batchId, msg, opts?)` | Single-message retry/DLQ. |
 | `client.subscribe(queue, consumer)` | Wraps `pgque.register_consumer`. |
 | `client.unsubscribe(queue, consumer)` | Wraps `pgque.unregister_consumer`. |
@@ -92,6 +92,15 @@ All errors derive from `PgqueError`:
 - `PgqueSqlError` — generic SQL failure (with `cause`)
 
 ## Caveats
+
+### `ack()` returns a rowcount, not void
+
+`client.ack(batchId)` returns `Promise<number>`. The value is `1` when the
+batch was active and has been finished, or `0` when the batch was not found or
+had already been finished (stale/double ack). A `0` result is not a SQL error —
+the promise resolves normally. Callers that need to detect double-ack should
+check the return value; the high-level `Consumer` logs a warning when it sees
+`0`.
 
 ### bigint columns
 

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -159,6 +159,10 @@ export class Client {
   /**
    * Fetch up to `maxMessages` from the next batch for `consumer` on `queue`.
    * Returns an empty array when no batch is currently available.
+   *
+   * WARNING: `ack(batchId)` finishes the whole underlying PgQ batch, including
+   * rows beyond `maxMessages`. Direct receive callers should pass a value large
+   * enough for the queue's possible batch size before acknowledging the batch.
    */
   async receive(queue: string, consumer: string, maxMessages = 100): Promise<Message[]> {
     if (!queue) {
@@ -186,13 +190,43 @@ export class Client {
     }
   }
 
-  /** Acknowledge (finish) a batch, advancing the consumer's position. */
-  async ack(batchId: bigint): Promise<void> {
+  /**
+   * Acknowledge (finish) a batch, advancing the consumer's position.
+   *
+   * Returns the row-count from `pgque.finish_batch`:
+   * - `1` — the batch was active and has been finished (normal success).
+   * - `0` — no active batch was finished: the `batchId` was not found,
+   *   was already finished (stale/double ack), or belongs to a different
+   *   consumer (race). Callers should log this at warn level; it is not a
+   *   SQL error and does not indicate a connection problem.
+   */
+  async ack(batchId: bigint): Promise<number> {
     if (typeof batchId !== 'bigint') {
       throw new PgqueSqlError('ack', { cause: new Error('batchId must be bigint') });
     }
     try {
-      await this.pool.query('select pgque.ack($1)', [batchId.toString()]);
+      // pgque.ack returns SQL integer (OID 23). pg parses OID 23 as JS
+      // number — only OID 20 (int8) is mapped to BigInt by pgqueTypes for
+      // our pool. The generic is `{ ack: number }` to reflect actual driver
+      // behaviour.
+      const result = await this.pool.query<{ ack: number }>(
+        'select pgque.ack($1) as ack',
+        [batchId.toString()],
+      );
+      const row = result.rows[0];
+      // pgque.ack always returns exactly one row (the integer result of
+      // pgque.finish_batch). The fallback path is unreachable in practice;
+      // the throw is a defensive sentinel so a malformed driver result is
+      // not silently misread as a stale/double ack (rowcount 0).
+      if (!row) {
+        throw new PgqueSqlError('ack', {
+          cause: new Error('pgque.ack returned no rows'),
+        });
+      }
+      // `Number(...)` is a defensive no-op: `pg` already returns OID 23
+      // (integer) as JS `number`. Coercing here guards against a future
+      // parser change that would yield bigint or string.
+      return Number(row.ack);
     } catch (err) {
       if (err instanceof PgqueError) throw err;
       throw mapPgError('ack', err);

--- a/clients/typescript/src/consumer.ts
+++ b/clients/typescript/src/consumer.ts
@@ -113,7 +113,12 @@ export class Consumer {
           );
         } else {
           try {
-            await this.client.ack(batchId);
+            const n = await this.client.ack(batchId);
+            if (n === 0) {
+              this.logger.warn(
+                `pgque: ack batch ${batchId} returned 0 — stale or double ack (batch already finished or not found)`,
+              );
+            }
           } catch (err) {
             this.logger.error(`pgque: ack error: ${formatErr(err)}`);
           }

--- a/clients/typescript/test/ack_rowcount.test.ts
+++ b/clients/typescript/test/ack_rowcount.test.ts
@@ -27,8 +27,10 @@ const skipIfNoDb = TEST_DSN ? it : it.skip;
 describe('Client.ack returns rowcount (unit stubs)', () => {
   it('returns 1 when SQL returns { ack: 1 }', async () => {
     // Construct a Client with a stubbed pool that returns ack=1.
+    // The `pg` driver returns OID-23 (integer) columns as JS `number`, not
+    // `bigint`, so the stub uses plain numeric literals to match real behaviour.
     const fakePool = {
-      query: vi.fn().mockResolvedValue({ rows: [{ ack: 1n }] }),
+      query: vi.fn().mockResolvedValue({ rows: [{ ack: 1 }] }),
       end: vi.fn().mockResolvedValue(undefined),
     } as unknown as import('pg').Pool;
 
@@ -44,7 +46,7 @@ describe('Client.ack returns rowcount (unit stubs)', () => {
 
   it('returns 0 when SQL returns { ack: 0 } (stale/double ack)', async () => {
     const fakePool = {
-      query: vi.fn().mockResolvedValue({ rows: [{ ack: 0n }] }),
+      query: vi.fn().mockResolvedValue({ rows: [{ ack: 0 }] }),
       end: vi.fn().mockResolvedValue(undefined),
     } as unknown as import('pg').Pool;
 

--- a/clients/typescript/test/ack_rowcount.test.ts
+++ b/clients/typescript/test/ack_rowcount.test.ts
@@ -1,0 +1,92 @@
+// pgque -- TypeScript client for PgQue
+// Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+// ack_rowcount.test.ts -- red/green tests for issue #148
+//
+// Red: client.ack() returns Promise<void>, so the return-value assertions
+//   below will fail at type-check and at runtime.
+// Green: client.ack() is widened to Promise<number> (0 or 1).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Client } from '../src/client.js';
+import { connect } from '../src/index.js';
+import {
+  TEST_DSN,
+  setupTestQueue,
+  teardownTestQueue,
+  advanceQueue,
+  type TestEnv,
+} from './helpers.js';
+
+const skipIfNoDb = TEST_DSN ? it : it.skip;
+
+// ---------------------------------------------------------------------------
+// Pure-vitest unit tests with a stubbed pool (no live database)
+// ---------------------------------------------------------------------------
+
+describe('Client.ack returns rowcount (unit stubs)', () => {
+  it('returns 1 when SQL returns { ack: 1 }', async () => {
+    // Construct a Client with a stubbed pool that returns ack=1.
+    const fakePool = {
+      query: vi.fn().mockResolvedValue({ rows: [{ ack: 1n }] }),
+      end: vi.fn().mockResolvedValue(undefined),
+    } as unknown as import('pg').Pool;
+
+    // Access the internal constructor via a small cast; Client is exported
+    // but connect() is the documented entry point. The unit test bypasses
+    // connect() to inject the stub pool.
+    const { Client } = await import('../src/client.js');
+    const client = new Client(fakePool);
+
+    const result = await client.ack(42n);
+    expect(result).toBe(1);
+  });
+
+  it('returns 0 when SQL returns { ack: 0 } (stale/double ack)', async () => {
+    const fakePool = {
+      query: vi.fn().mockResolvedValue({ rows: [{ ack: 0n }] }),
+      end: vi.fn().mockResolvedValue(undefined),
+    } as unknown as import('pg').Pool;
+
+    const { Client } = await import('../src/client.js');
+    const client = new Client(fakePool);
+
+    const result = await client.ack(99n);
+    expect(result).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Live-database integration tests (gated on PGQUE_TEST_DSN)
+// ---------------------------------------------------------------------------
+
+describe('Client.ack live-db rowcount (requires PGQUE_TEST_DSN)', () => {
+  let env: TestEnv;
+
+  beforeEach(async () => {
+    if (!TEST_DSN) return;
+    env = await setupTestQueue();
+  });
+
+  afterEach(async () => {
+    if (!TEST_DSN) return;
+    await teardownTestQueue(env);
+  });
+
+  skipIfNoDb('first ack returns 1, second ack (double) returns 0', async () => {
+    await env.client.send(env.queue, { type: 'ack.rowcount', payload: { v: 1 } });
+    await advanceQueue(env.client, env.queue);
+
+    const msgs = await env.client.receive(env.queue, env.consumer, 10);
+    expect(msgs.length).toBeGreaterThan(0);
+    const batchId = msgs[0]!.batchId;
+
+    // First ack — the batch is active: should return 1.
+    const first = await env.client.ack(batchId);
+    expect(first).toBe(1);
+
+    // Second ack — the batch is already finished: should return 0.
+    const second = await env.client.ack(batchId);
+    expect(second).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- **RCA:** `pgque.ack(batch_id)` (SQL `pgque.finish_batch`) returns an integer: `1` on success, `0` on stale/double ack. TypeScript discarded it (`Promise<void>`) and Go discarded it (`Exec`, `error` only), masking silent no-ops.
- **Fix (option a):** Surface the rowcount from both drivers. TS: `ack(batchId): Promise<number>`. Go: `Ack(ctx, batchID) (int64, error)`. Python already returns the int — unchanged.
- **Unified contract:** `1` = batch finished; `0` = no active batch (stale/double ack, batch not found, wrong consumer race). `0` is not a SQL error in either driver. The high-level `Consumer` logs a `warn` when it sees `0`.

## Breaking change note (Go)

The Go signature change is **source-breaking**: callers using the old single-return `error` form must accept the new `(int64, error)` shape. Examples:

| Old call site                           | After this PR                                  |
|-----------------------------------------|------------------------------------------------|
| `if err := client.Ack(ctx, id); ...`    | `if _, err := client.Ack(ctx, id); ...`        |
| `_ = client.Ack(ctx, id)`               | `_, _ = client.Ack(ctx, id)`                   |
| `client.Ack(ctx, id)` (statement)       | unchanged — still valid                         |

Pre-1.0 — acceptable per SemVer.

## TypeScript signature note

TS goes from `Promise<void>` to `Promise<number>`. Callers that did `await client.ack(id)` and discarded the value continue to compile without change.

## Red/green proof

**Red commit** (`73154e1`): tests written to the new API, implementation still old.
- TS unit stubs assert `await client.ack(123)` returns `0` or `1` → `AssertionError: expected undefined to be 1`.
- Go stub backend uses `Ack(...) (int64, error)` → `go vet` fails: `*ackRowcountBackend does not implement pgque.consumerBackend`.

**Green commit** (`6cdf4fd`) + **review fixes** (`7c572d8` round-1, `79c29f6` round-2):
- `bun run check && bun run build` — clean (TS type-check + compile).
- `go vet ./... && go build ./...` — clean.
- `bun run test` — 7 passed (33 skipped without `PGQUE_TEST_DSN`).
- Live-db integration tests covered when `PGQUE_TEST_DSN` is set.

Round-2 review fixes:
- Reworded the TS bigint→number coercion comment so it is consistent with the OID-23 explanation 17 lines above.
- Tightened `ack_rowcount_test.go` by asserting `nackCalled == 0` on the success path, locking the contract that `Nack` is not called when `Ack` returns `1` or `0`.

Rebased onto current `main` after #200 (Go typed errors) merged; the `clients/go/pgque.go` `Ack` callsite now routes through `wrapSQLError("ack", err)`.

## Test plan

- [x] `cd clients/typescript && bun run check && bun run build && bun run test`
- [x] `cd clients/go && go vet ./... && go build ./...`
- [x] With `PGQUE_TEST_DSN`: `go test ./clients/go/... -run TestAck_DirectCall_ReturnsRowcount` — first ack `1`, second ack `0`
- [x] With `PGQUE_TEST_DSN`: TS live-db ack rowcount tests pass
- [x] Stub-backend tests assert `nackCalled == 0` on success

Closes #148.

## Out of scope

The Python Consumer-layer asymmetry (Python's `client.ack` returns the int but the high-level `Consumer` discards it) is tracked as PR #203 — small follow-up to log a warn on `n == 0` in `clients/python/pgque/consumer.py`.

https://claude.ai/code/session_01TwKyarGpkGKN8LY1CV8dsG