### PR TITLE
fix: prevent SQL forgery via get_batch_cursor extra_where (#108)

### DIFF
--- a/build/transform.sh
+++ b/build/transform.sh
@@ -568,44 +568,102 @@ sedi 's/b\.ev_id, b\.ev_time, NULL::int8, _s\.sub_id,/b.ev_id, b.ev_time, NULL::
 
 echo "PASS: batch_retry NULL::int8 -> NULL::xid8 for ev_txid (xid8) column"
 
-# Inject SECURITY header on get_batch_cursor(4-arg). The upstream PgQ source
-# concatenates i_extra_where into dynamic SQL verbatim, so the parameter is a
-# trusted-SQL fragment rather than a value. Both overloads are admin-only via
-# the grants block, but the contract must travel with the function body so
-# anyone reading sql/pgque.sql understands why.
+# Drop the 4-arg pgque.get_batch_cursor(bigint, text, int4, text) overload.
+# Upstream PgQ concatenates i_extra_where into the cursor's SELECT verbatim,
+# so any caller (including pgque_admin) can inject arbitrary predicates and
+# forge rows in the returned stream (#108). pgque has no internal use of the
+# 4-arg overload, so we remove it entirely and inline the cursor logic into
+# the 3-arg overload (which used to delegate to the 4-arg).
 GET_BATCH_CURSOR_FILE="${OUTPUT_DIR}/functions/pgque.get_batch_cursor.sql"
-awk '
-BEGIN { header_done = 0; param_done = 0 }
-!header_done && /^create or replace function pgque\.get_batch_cursor\(/ {
-  print "-- ----------------------------------------------------------------------"
-  print "-- Advanced PgQ-compatible primitive. Application roles should use"
-  print "-- pgque.receive(); get_batch_cursor is kept admin-only in the grants block."
-  print "--"
-  print "-- SECURITY: i_extra_where is concatenated into dynamic SQL verbatim. It is a"
-  print "-- trusted-SQL fragment, NOT a parameter. A caller can inject arbitrary"
-  print "-- predicates (including UNION ALL) and forge rows in the returned stream."
-  print "-- This behavior is inherited from upstream PgQ; it is acceptable here only"
-  print "-- because both overloads are revoked from public, pgque_reader, and"
-  print "-- pgque_writer and granted to pgque_admin only. NEVER pass user-controlled"
-  print "-- input as i_extra_where, even from admin code paths."
-  print "-- ----------------------------------------------------------------------"
-  header_done = 1
-}
-!param_done && /^--      i_extra_where   - optional where clause to filter events$/ {
-  print "--      i_extra_where   - optional where clause to filter events."
-  print "--                        Trusted SQL fragment, not a parameter; never pass"
-  print "--                        user-controlled text. Function is admin-only."
-  param_done = 1
-  next
-}
-{ print }
-END {
-  if (!header_done) { print "ERROR: get_batch_cursor 4-arg signature not found" > "/dev/stderr"; exit 1 }
-  if (!param_done)  { print "ERROR: i_extra_where parameter doc line not found"   > "/dev/stderr"; exit 1 }
-}
-' "${GET_BATCH_CURSOR_FILE}" > "${GET_BATCH_CURSOR_FILE}.tmp" && mv "${GET_BATCH_CURSOR_FILE}.tmp" "${GET_BATCH_CURSOR_FILE}"
+cat > "${GET_BATCH_CURSOR_FILE}" <<'GBC_EOF'
+-- ----------------------------------------------------------------------
+-- Advanced PgQ-compatible primitive. Application roles should use
+-- pgque.receive(); get_batch_cursor is kept admin-only in the grants block.
+--
+-- SECURITY (#108): the 4-arg overload (i_extra_where) is intentionally
+-- removed in pgque. Upstream PgQ concatenated the extra_where text
+-- verbatim into the cursor's SELECT, so any caller (even pgque_admin)
+-- could inject arbitrary predicates (including UNION ALL) and forge
+-- rows into the returned stream. There is no current pgque code path
+-- that needs caller-supplied SQL fragments — pgque.receive() and
+-- pgque.get_batch_events() cover the supported access patterns — so we
+-- drop the overload entirely rather than try to sanitise a free-form
+-- SQL string. If a future use case truly needs filtering driven by the
+-- caller, add a parameterised variant that takes typed predicates, not
+-- a text fragment.
+-- ----------------------------------------------------------------------
 
-echo "PASS: get_batch_cursor SECURITY header injected (extra_where is trusted SQL)"
+-- Drop any pre-existing 4-arg overload (e.g. left over from upstream PgQ
+-- or from an older pgque install). Single-file install is run with
+-- `\i pgque.sql`, sometimes against a non-empty schema, so the explicit
+-- DROP IF EXISTS is required for idempotency.
+drop function if exists pgque.get_batch_cursor(bigint, text, int4, text);
+
+create or replace function pgque.get_batch_cursor(
+    in i_batch_id       bigint,
+    in i_cursor_name    text,
+    in i_quick_limit    int4,
+
+    out ev_id       bigint,
+    out ev_time     timestamptz,
+    out ev_txid     bigint,
+    out ev_retry    int4,
+    out ev_type     text,
+    out ev_data     text,
+    out ev_extra1   text,
+    out ev_extra2   text,
+    out ev_extra3   text,
+    out ev_extra4   text)
+returns setof record as $$
+-- ----------------------------------------------------------------------
+-- Function: pgque.get_batch_cursor(3)
+--
+--      Get events in batch using a cursor.
+--
+-- Parameters:
+--      i_batch_id      - ID of active batch.
+--      i_cursor_name   - Name for new cursor
+--      i_quick_limit   - Number of events to return immediately
+--
+-- Returns:
+--      List of events.
+-- Calls:
+--      pgque.batch_event_sql(i_batch_id) - internal function which
+--      generates SQL optimised specially for getting events in this batch.
+-- ----------------------------------------------------------------------
+declare
+    _cname  text;
+    _sql    text;
+begin
+    if i_batch_id is null or i_cursor_name is null or i_quick_limit is null then
+        return;
+    end if;
+
+    _cname := quote_ident(i_cursor_name);
+    _sql := pgque.batch_event_sql(i_batch_id);
+
+    -- create cursor
+    execute 'declare ' || _cname || ' no scroll cursor for ' || _sql;
+
+    -- if no events wanted, don't bother with execute
+    if i_quick_limit <= 0 then
+        return;
+    end if;
+
+    -- return first block of events
+    for ev_id, ev_time, ev_txid, ev_retry, ev_type, ev_data,
+        ev_extra1, ev_extra2, ev_extra3, ev_extra4
+        in execute 'fetch ' || i_quick_limit::text || ' from ' || _cname
+    loop
+        return next;
+    end loop;
+
+    return;
+end;
+$$ language plpgsql strict; -- no perms needed
+GBC_EOF
+
+echo "PASS: get_batch_cursor 4-arg overload dropped (#108)"
 
 # -- Assembly: build sql/pgque.sql ------------------------------------
 
@@ -947,14 +1005,27 @@ if [[ -d "${API_DIR}" ]]; then
   fi
 fi
 
-# Verify the get_batch_cursor SECURITY contract reached the assembled file.
-# The per-function awk patch above runs before assembly; this guards against
-# a future assembly change that strips comments or reorders sections.
-if grep -q 'SECURITY: i_extra_where is concatenated' "${INSTALL_FILE}" \
-   && grep -q 'Trusted SQL fragment, not a parameter' "${INSTALL_FILE}"; then
-  echo "PASS: get_batch_cursor SECURITY contract present in install script"
+# Verify the get_batch_cursor injection fix (#108) reached the assembled file.
+# The per-function rewrite above runs before assembly; this guards against
+# a future assembly change that reintroduces the 4-arg overload or omits the
+# safety drop function statement.
+if grep -q 'SECURITY (#108)' "${INSTALL_FILE}" \
+   && grep -q 'drop function if exists pgque.get_batch_cursor(bigint, text, int4, text);' "${INSTALL_FILE}"; then
+  echo "PASS: get_batch_cursor 4-arg overload removal present in install script"
 else
-  echo "FAIL: get_batch_cursor SECURITY contract missing from install script"
+  echo "FAIL: get_batch_cursor 4-arg overload removal missing from install script"
+  asm_errors=$((asm_errors + 1))
+fi
+
+# And belt-and-braces: the 4-arg create or replace must NOT be in the assembled
+# file (would re-introduce the SQL forgery vector).
+if grep -nE 'create or replace function pgque\.get_batch_cursor\(' "${INSTALL_FILE}" \
+   | wc -l \
+   | grep -q '^1$'; then
+  echo "PASS: only one get_batch_cursor function definition (3-arg) in install script"
+else
+  echo "FAIL: more than one get_batch_cursor definition found — 4-arg overload may have leaked back in"
+  grep -n 'create or replace function pgque\.get_batch_cursor\(' "${INSTALL_FILE}"
   asm_errors=$((asm_errors + 1))
 fi
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -423,12 +423,7 @@ Grant: `pgque_writer`. Source: `sql/pgque.sql`.
 Declares a server-side cursor over the batch and returns the first `quick_limit` events. Remaining events can be fetched with `fetch … from <cursor_name>`.
 Grant: `pgque_admin` only. Source: `sql/pgque.sql`.
 
-#### `pgque.get_batch_cursor(batch_id bigint, cursor_name text, quick_limit int4, extra_where text) → setof record`
-
-Same as above with an additional `where` filter applied inside the cursor.
-Grant: `pgque_admin` only. Source: `sql/pgque.sql`.
-
-> **Security:** `extra_where` is a **trusted SQL fragment**, not a parameter — it is concatenated verbatim into the cursor's `select`. A caller that controls `extra_where` can inject arbitrary predicates (including `UNION ALL`) and forge rows in the returned stream. This behavior is inherited from upstream PgQ and is gated behind `pgque_admin` for that reason. **Never pass user-controlled text as `extra_where`**, even from admin code paths; if you need filtering driven by application input, fetch the batch with `pgque.get_batch_events()` and filter in the application or in a separate parameterized query.
+> **No `extra_where` overload.** Upstream PgQ ships a 4-argument overload that takes a free-form `extra_where` SQL fragment and concatenates it into the cursor query. pgque does not expose that overload — a caller-controlled SQL fragment is a forgery vector regardless of role grants. To filter the events you stream out of a batch, use `pgque.get_batch_events()` and filter in your application, or use a parameterised query that selects directly from the batch event tables.
 
 #### `pgque.finish_batch(batch_id bigint) → integer`
 

--- a/sql/pgque-additions/roles.sql
+++ b/sql/pgque-additions/roles.sql
@@ -149,6 +149,7 @@ end $$;
 
 
 -- get_batch_cursor is an advanced PgQ-compatible primitive.
--- Keep both overloads admin-only; application roles should use pgque.receive().
-revoke execute on function pgque.get_batch_cursor(bigint, text, int4)        from public, pgque_reader, pgque_writer;
-revoke execute on function pgque.get_batch_cursor(bigint, text, int4, text)  from public, pgque_reader, pgque_writer;
+-- Keep the surviving 3-arg overload admin-only; application roles should
+-- use pgque.receive(). The 4-arg overload has been removed (#108) — its
+-- i_extra_where parameter was a SQL forgery vector.
+revoke execute on function pgque.get_batch_cursor(bigint, text, int4) from public, pgque_reader, pgque_writer;

--- a/sql/pgque-tle.sql
+++ b/sql/pgque-tle.sql
@@ -2301,7 +2301,6 @@ begin
 end;
 $$ language plpgsql; -- no perms needed
 
-
 -- ----------------------------------------------------------------------
 -- Advanced PgQ-compatible primitive. Application roles should use
 -- pgque.receive(); get_batch_cursor is kept admin-only in the grants block.

--- a/sql/pgque-tle.sql
+++ b/sql/pgque-tle.sql
@@ -2306,87 +2306,24 @@ $$ language plpgsql; -- no perms needed
 -- Advanced PgQ-compatible primitive. Application roles should use
 -- pgque.receive(); get_batch_cursor is kept admin-only in the grants block.
 --
--- SECURITY: i_extra_where is concatenated into dynamic SQL verbatim. It is a
--- trusted-SQL fragment, NOT a parameter. A caller can inject arbitrary
--- predicates (including UNION ALL) and forge rows in the returned stream.
--- This behavior is inherited from upstream PgQ; it is acceptable here only
--- because both overloads are revoked from public, pgque_reader, and
--- pgque_writer and granted to pgque_admin only. NEVER pass user-controlled
--- input as i_extra_where, even from admin code paths.
+-- SECURITY (#108): the 4-arg overload (i_extra_where) is intentionally
+-- removed in pgque. Upstream PgQ concatenated the extra_where text
+-- verbatim into the cursor's SELECT, so any caller (even pgque_admin)
+-- could inject arbitrary predicates (including UNION ALL) and forge
+-- rows into the returned stream. There is no current pgque code path
+-- that needs caller-supplied SQL fragments — pgque.receive() and
+-- pgque.get_batch_events() cover the supported access patterns — so we
+-- drop the overload entirely rather than try to sanitise a free-form
+-- SQL string. If a future use case truly needs filtering driven by the
+-- caller, add a parameterised variant that takes typed predicates, not
+-- a text fragment.
 -- ----------------------------------------------------------------------
-create or replace function pgque.get_batch_cursor(
-    in i_batch_id       bigint,
-    in i_cursor_name    text,
-    in i_quick_limit    int4,
-    in i_extra_where    text,
 
-    out ev_id       bigint,
-    out ev_time     timestamptz,
-    out ev_txid     bigint,
-    out ev_retry    int4,
-    out ev_type     text,
-    out ev_data     text,
-    out ev_extra1   text,
-    out ev_extra2   text,
-    out ev_extra3   text,
-    out ev_extra4   text)
-returns setof record as $$
--- ----------------------------------------------------------------------
--- Function: pgque.get_batch_cursor(4)
---
---      Get events in batch using a cursor.
---
--- Parameters:
---      i_batch_id      - ID of active batch.
---      i_cursor_name   - Name for new cursor
---      i_quick_limit   - Number of events to return immediately
---      i_extra_where   - optional where clause to filter events.
---                        Trusted SQL fragment, not a parameter; never pass
---                        user-controlled text. Function is admin-only.
---
--- Returns:
---      List of events.
--- Calls:
---      pgque.batch_event_sql(i_batch_id) - internal function which generates SQL optimised specially for getting events in this batch
--- ----------------------------------------------------------------------
-declare
-    _cname  text;
-    _sql    text;
-begin
-    if i_batch_id is null or i_cursor_name is null or i_quick_limit is null then
-        return;
-    end if;
-
-    _cname := quote_ident(i_cursor_name);
-    _sql := pgque.batch_event_sql(i_batch_id);
-
-    -- apply extra where
-    if i_extra_where is not null then
-        _sql := replace(_sql, ' order by 1', '');
-        _sql := 'select * from (' || _sql
-            || ') _evs where ' || i_extra_where
-            || ' order by 1';
-    end if;
-
-    -- create cursor
-    execute 'declare ' || _cname || ' no scroll cursor for ' || _sql;
-
-    -- if no events wanted, don't bother with execute
-    if i_quick_limit <= 0 then
-        return;
-    end if;
-
-    -- return first block of events
-    for ev_id, ev_time, ev_txid, ev_retry, ev_type, ev_data,
-        ev_extra1, ev_extra2, ev_extra3, ev_extra4
-        in execute 'fetch ' || i_quick_limit::text || ' from ' || _cname
-    loop
-        return next;
-    end loop;
-
-    return;
-end;
-$$ language plpgsql; -- no perms needed
+-- Drop any pre-existing 4-arg overload (e.g. left over from upstream PgQ
+-- or from an older pgque install). Single-file install is run with
+-- `\i pgque.sql`, sometimes against a non-empty schema, so the explicit
+-- DROP IF EXISTS is required for idempotency.
+drop function if exists pgque.get_batch_cursor(bigint, text, int4, text);
 
 create or replace function pgque.get_batch_cursor(
     in i_batch_id       bigint,
@@ -2417,17 +2354,36 @@ returns setof record as $$
 -- Returns:
 --      List of events.
 -- Calls:
---      pgque.get_batch_cursor(4)
+--      pgque.batch_event_sql(i_batch_id) - internal function which
+--      generates SQL optimised specially for getting events in this batch.
 -- ----------------------------------------------------------------------
+declare
+    _cname  text;
+    _sql    text;
 begin
+    if i_batch_id is null or i_cursor_name is null or i_quick_limit is null then
+        return;
+    end if;
+
+    _cname := quote_ident(i_cursor_name);
+    _sql := pgque.batch_event_sql(i_batch_id);
+
+    -- create cursor
+    execute 'declare ' || _cname || ' no scroll cursor for ' || _sql;
+
+    -- if no events wanted, don't bother with execute
+    if i_quick_limit <= 0 then
+        return;
+    end if;
+
+    -- return first block of events
     for ev_id, ev_time, ev_txid, ev_retry, ev_type, ev_data,
         ev_extra1, ev_extra2, ev_extra3, ev_extra4
-    in
-        select * from pgque.get_batch_cursor(i_batch_id,
-            i_cursor_name, i_quick_limit, null)
+        in execute 'fetch ' || i_quick_limit::text || ' from ' || _cname
     loop
         return next;
     end loop;
+
     return;
 end;
 $$ language plpgsql strict; -- no perms needed
@@ -4451,9 +4407,10 @@ end $$;
 
 
 -- get_batch_cursor is an advanced PgQ-compatible primitive.
--- Keep both overloads admin-only; application roles should use pgque.receive().
-revoke execute on function pgque.get_batch_cursor(bigint, text, int4)        from public, pgque_reader, pgque_writer;
-revoke execute on function pgque.get_batch_cursor(bigint, text, int4, text)  from public, pgque_reader, pgque_writer;
+-- Keep the surviving 3-arg overload admin-only; application roles should
+-- use pgque.receive(). The 4-arg overload has been removed (#108) — its
+-- i_extra_where parameter was a SQL forgery vector.
+revoke execute on function pgque.get_batch_cursor(bigint, text, int4) from public, pgque_reader, pgque_writer;
 
 -- pgque-additions/dlq.sql
 -- pgque dead letter queue (DLQ) -- table + helper functions

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -2213,7 +2213,6 @@ begin
 end;
 $$ language plpgsql; -- no perms needed
 
-
 -- ----------------------------------------------------------------------
 -- Advanced PgQ-compatible primitive. Application roles should use
 -- pgque.receive(); get_batch_cursor is kept admin-only in the grants block.

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -2218,87 +2218,24 @@ $$ language plpgsql; -- no perms needed
 -- Advanced PgQ-compatible primitive. Application roles should use
 -- pgque.receive(); get_batch_cursor is kept admin-only in the grants block.
 --
--- SECURITY: i_extra_where is concatenated into dynamic SQL verbatim. It is a
--- trusted-SQL fragment, NOT a parameter. A caller can inject arbitrary
--- predicates (including UNION ALL) and forge rows in the returned stream.
--- This behavior is inherited from upstream PgQ; it is acceptable here only
--- because both overloads are revoked from public, pgque_reader, and
--- pgque_writer and granted to pgque_admin only. NEVER pass user-controlled
--- input as i_extra_where, even from admin code paths.
+-- SECURITY (#108): the 4-arg overload (i_extra_where) is intentionally
+-- removed in pgque. Upstream PgQ concatenated the extra_where text
+-- verbatim into the cursor's SELECT, so any caller (even pgque_admin)
+-- could inject arbitrary predicates (including UNION ALL) and forge
+-- rows into the returned stream. There is no current pgque code path
+-- that needs caller-supplied SQL fragments — pgque.receive() and
+-- pgque.get_batch_events() cover the supported access patterns — so we
+-- drop the overload entirely rather than try to sanitise a free-form
+-- SQL string. If a future use case truly needs filtering driven by the
+-- caller, add a parameterised variant that takes typed predicates, not
+-- a text fragment.
 -- ----------------------------------------------------------------------
-create or replace function pgque.get_batch_cursor(
-    in i_batch_id       bigint,
-    in i_cursor_name    text,
-    in i_quick_limit    int4,
-    in i_extra_where    text,
 
-    out ev_id       bigint,
-    out ev_time     timestamptz,
-    out ev_txid     bigint,
-    out ev_retry    int4,
-    out ev_type     text,
-    out ev_data     text,
-    out ev_extra1   text,
-    out ev_extra2   text,
-    out ev_extra3   text,
-    out ev_extra4   text)
-returns setof record as $$
--- ----------------------------------------------------------------------
--- Function: pgque.get_batch_cursor(4)
---
---      Get events in batch using a cursor.
---
--- Parameters:
---      i_batch_id      - ID of active batch.
---      i_cursor_name   - Name for new cursor
---      i_quick_limit   - Number of events to return immediately
---      i_extra_where   - optional where clause to filter events.
---                        Trusted SQL fragment, not a parameter; never pass
---                        user-controlled text. Function is admin-only.
---
--- Returns:
---      List of events.
--- Calls:
---      pgque.batch_event_sql(i_batch_id) - internal function which generates SQL optimised specially for getting events in this batch
--- ----------------------------------------------------------------------
-declare
-    _cname  text;
-    _sql    text;
-begin
-    if i_batch_id is null or i_cursor_name is null or i_quick_limit is null then
-        return;
-    end if;
-
-    _cname := quote_ident(i_cursor_name);
-    _sql := pgque.batch_event_sql(i_batch_id);
-
-    -- apply extra where
-    if i_extra_where is not null then
-        _sql := replace(_sql, ' order by 1', '');
-        _sql := 'select * from (' || _sql
-            || ') _evs where ' || i_extra_where
-            || ' order by 1';
-    end if;
-
-    -- create cursor
-    execute 'declare ' || _cname || ' no scroll cursor for ' || _sql;
-
-    -- if no events wanted, don't bother with execute
-    if i_quick_limit <= 0 then
-        return;
-    end if;
-
-    -- return first block of events
-    for ev_id, ev_time, ev_txid, ev_retry, ev_type, ev_data,
-        ev_extra1, ev_extra2, ev_extra3, ev_extra4
-        in execute 'fetch ' || i_quick_limit::text || ' from ' || _cname
-    loop
-        return next;
-    end loop;
-
-    return;
-end;
-$$ language plpgsql; -- no perms needed
+-- Drop any pre-existing 4-arg overload (e.g. left over from upstream PgQ
+-- or from an older pgque install). Single-file install is run with
+-- `\i pgque.sql`, sometimes against a non-empty schema, so the explicit
+-- DROP IF EXISTS is required for idempotency.
+drop function if exists pgque.get_batch_cursor(bigint, text, int4, text);
 
 create or replace function pgque.get_batch_cursor(
     in i_batch_id       bigint,
@@ -2329,17 +2266,36 @@ returns setof record as $$
 -- Returns:
 --      List of events.
 -- Calls:
---      pgque.get_batch_cursor(4)
+--      pgque.batch_event_sql(i_batch_id) - internal function which
+--      generates SQL optimised specially for getting events in this batch.
 -- ----------------------------------------------------------------------
+declare
+    _cname  text;
+    _sql    text;
 begin
+    if i_batch_id is null or i_cursor_name is null or i_quick_limit is null then
+        return;
+    end if;
+
+    _cname := quote_ident(i_cursor_name);
+    _sql := pgque.batch_event_sql(i_batch_id);
+
+    -- create cursor
+    execute 'declare ' || _cname || ' no scroll cursor for ' || _sql;
+
+    -- if no events wanted, don't bother with execute
+    if i_quick_limit <= 0 then
+        return;
+    end if;
+
+    -- return first block of events
     for ev_id, ev_time, ev_txid, ev_retry, ev_type, ev_data,
         ev_extra1, ev_extra2, ev_extra3, ev_extra4
-    in
-        select * from pgque.get_batch_cursor(i_batch_id,
-            i_cursor_name, i_quick_limit, null)
+        in execute 'fetch ' || i_quick_limit::text || ' from ' || _cname
     loop
         return next;
     end loop;
+
     return;
 end;
 $$ language plpgsql strict; -- no perms needed
@@ -4363,9 +4319,10 @@ end $$;
 
 
 -- get_batch_cursor is an advanced PgQ-compatible primitive.
--- Keep both overloads admin-only; application roles should use pgque.receive().
-revoke execute on function pgque.get_batch_cursor(bigint, text, int4)        from public, pgque_reader, pgque_writer;
-revoke execute on function pgque.get_batch_cursor(bigint, text, int4, text)  from public, pgque_reader, pgque_writer;
+-- Keep the surviving 3-arg overload admin-only; application roles should
+-- use pgque.receive(). The 4-arg overload has been removed (#108) — its
+-- i_extra_where parameter was a SQL forgery vector.
+revoke execute on function pgque.get_batch_cursor(bigint, text, int4) from public, pgque_reader, pgque_writer;
 
 -- pgque-additions/dlq.sql
 -- pgque dead letter queue (DLQ) -- table + helper functions

--- a/tests/run_all.sql
+++ b/tests/run_all.sql
@@ -31,6 +31,9 @@
 \echo 'Running: test_security_get_batch_cursor'
 \i tests/test_security_get_batch_cursor.sql
 
+\echo 'Running: test_security_get_batch_cursor_injection'
+\i tests/test_security_get_batch_cursor_injection.sql
+
 \echo 'Running: test_security_producer_isolation'
 \i tests/test_security_producer_isolation.sql
 

--- a/tests/test_security_get_batch_cursor.sql
+++ b/tests/test_security_get_batch_cursor.sql
@@ -2,10 +2,11 @@
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 --
 -- Posture asserted:
---   1. PUBLIC cannot call either get_batch_cursor overload.
---   2. pgque_reader cannot call either get_batch_cursor overload.
---   3. pgque_writer cannot call either get_batch_cursor overload.
---   4. pgque_admin (or members) can call both overloads.
+--   1. PUBLIC cannot call get_batch_cursor.
+--   2. pgque_reader cannot call get_batch_cursor.
+--   3. pgque_writer cannot call get_batch_cursor.
+--   4. pgque_admin (or members) can call get_batch_cursor.
+--   5. The 4-arg overload (extra_where) does not exist (#108).
 
 -- =========================================================================
 -- Setup: probe roles
@@ -54,24 +55,17 @@ begin
   raise notice 'PASS: security_get_batch_cursor/A0.1 - PUBLIC blocked from get_batch_cursor/3';
 end $$;
 
+-- The 4-arg overload (extra_where) was removed (#108). Confirm it is not
+-- present in the catalog so we can never resurrect the SQL forgery vector
+-- without an explicit code change here.
 do $$
 declare
-  v_sqlstate text;
+  v_proc oid;
 begin
-  set role pgque_test_public;
-  begin
-    perform pgque.get_batch_cursor(1::bigint, 'probe_cursor_public4', 0, 'true');
-    raise exception 'expected insufficient_privilege calling get_batch_cursor/4 as PUBLIC, got success';
-  exception
-    when insufficient_privilege then
-      v_sqlstate := sqlstate;
-  end;
-  reset role;
-
-  assert v_sqlstate = '42501',
-    'expected sqlstate 42501 (insufficient_privilege) for public/4, got ' || coalesce(v_sqlstate, 'NULL');
-
-  raise notice 'PASS: security_get_batch_cursor/A0.2 - PUBLIC blocked from get_batch_cursor/4';
+  v_proc := to_regprocedure('pgque.get_batch_cursor(bigint, text, int4, text)');
+  assert v_proc is null,
+    'pgque.get_batch_cursor/4 unexpectedly exists; the extra_where overload must stay removed (#108)';
+  raise notice 'PASS: security_get_batch_cursor/A0.2 - 4-arg overload (extra_where) is absent';
 end $$;
 
 -- =========================================================================
@@ -98,25 +92,8 @@ begin
   raise notice 'PASS: security_get_batch_cursor/A1 - pgque_reader blocked from get_batch_cursor/3';
 end $$;
 
-do $$
-declare
-  v_sqlstate text;
-begin
-  set role pgque_test_reader;
-  begin
-    perform pgque.get_batch_cursor(1::bigint, 'probe_cursor_r4', 0, 'true');
-    raise exception 'expected insufficient_privilege calling get_batch_cursor/4 as pgque_reader, got success';
-  exception
-    when insufficient_privilege then
-      v_sqlstate := sqlstate;
-  end;
-  reset role;
-
-  assert v_sqlstate = '42501',
-    'expected sqlstate 42501 (insufficient_privilege) for reader/4, got ' || coalesce(v_sqlstate, 'NULL');
-
-  raise notice 'PASS: security_get_batch_cursor/A2 - pgque_reader blocked from get_batch_cursor/4 (extra_where overload)';
-end $$;
+-- (4-arg overload absence is verified above in A0.2; reader cannot reach a
+-- function that does not exist, so no separate per-role probe is needed.)
 
 -- =========================================================================
 -- Test B: pgque_writer is blocked from get_batch_cursor (both overloads)
@@ -142,25 +119,8 @@ begin
   raise notice 'PASS: security_get_batch_cursor/B1 - pgque_writer blocked from get_batch_cursor/3';
 end $$;
 
-do $$
-declare
-  v_sqlstate text;
-begin
-  set role pgque_test_writer;
-  begin
-    perform pgque.get_batch_cursor(1::bigint, 'probe_cursor_w4', 0, 'true');
-    raise exception 'expected insufficient_privilege calling get_batch_cursor/4 as pgque_writer, got success';
-  exception
-    when insufficient_privilege then
-      v_sqlstate := sqlstate;
-  end;
-  reset role;
-
-  assert v_sqlstate = '42501',
-    'expected sqlstate 42501 (insufficient_privilege) for writer/4, got ' || coalesce(v_sqlstate, 'NULL');
-
-  raise notice 'PASS: security_get_batch_cursor/B2 - pgque_writer blocked from get_batch_cursor/4 (extra_where overload)';
-end $$;
+-- (4-arg overload absence is verified above in A0.2; writer cannot reach a
+-- function that does not exist, so no separate per-role probe is needed.)
 
 -- =========================================================================
 -- Test C: pgque_admin can still call get_batch_cursor (positive path)
@@ -201,18 +161,7 @@ begin
 
   raise notice 'PASS: security_get_batch_cursor/C1 - pgque_admin can call get_batch_cursor/3 (rows=%)', v_count_admin;
 
-  -- 4-arg overload should also remain callable by admin.
-  perform 1
-    from pgque.get_batch_cursor(
-      v_batch_id,
-      'security_cursor_admin_c4',
-      100,
-      'true');
-  execute 'close security_cursor_admin_c4';
-
   reset role;
-
-  raise notice 'PASS: security_get_batch_cursor/C2 - pgque_admin can call get_batch_cursor/4';
 end $$;
 
 -- =========================================================================

--- a/tests/test_security_get_batch_cursor_injection.sql
+++ b/tests/test_security_get_batch_cursor_injection.sql
@@ -1,0 +1,201 @@
+-- test_security_get_batch_cursor_injection.sql
+-- Regression: get_batch_cursor must not allow SQL forgery via extra_where (#108)
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- Posture asserted:
+--   1. As pgque_admin (the only role that can call the 4-arg overload at all),
+--      a `false UNION ALL SELECT ...forged...` payload must NOT cause forged
+--      rows to appear in the returned event stream. Either the call is
+--      rejected outright (preferred), or the injection is neutralised.
+--   2. The 3-arg overload (which never accepts caller SQL) must keep working.
+
+-- =========================================================================
+-- Setup: dedicated admin probe role
+-- =========================================================================
+
+do $$
+begin
+  if not exists (select 1 from pg_roles where rolname = 'pgque_inj_admin') then
+    execute 'create role pgque_inj_admin login';
+    execute 'grant pgque_admin to pgque_inj_admin';
+  end if;
+end $$;
+
+-- =========================================================================
+-- Build a real batch with one real event so we have something to forge into.
+-- Run as the test owner (superuser) so we have the privileges to set up.
+-- =========================================================================
+
+select pgque.create_queue('inj_q');
+select pgque.register_consumer('inj_q', 'inj_c');
+select pgque.insert_event('inj_q', 'real', 'real-data');
+select pgque.ticker('inj_q');
+
+-- =========================================================================
+-- Test A: UNION ALL injection via extra_where must NOT yield forged rows.
+-- =========================================================================
+do $$
+declare
+  v_batch_id     bigint;
+  v_total        int := 0;
+  v_forged       int := 0;
+  v_real         int := 0;
+  v_caught_state text;
+begin
+  set role pgque_inj_admin;
+
+  v_batch_id := pgque.next_batch('inj_q', 'inj_c');
+  if v_batch_id is null then
+    reset role;
+    raise exception 'next_batch returned NULL; cannot continue injection test';
+  end if;
+
+  -- The classic UNION ALL forgery payload from issue #108.
+  --
+  -- Three valid outcomes for this call:
+  --   (a) the call raises (any sqlstate) before producing any forged row;
+  --   (b) the call returns rows but no row has ev_type = 'injected';
+  --   (c) the call returns ONLY genuine rows (the real 'real-data' row).
+  --
+  -- Failure (the bug we are guarding against) is: the call returns one or
+  -- more rows where ev_type = 'injected' / ev_data = current_database().
+  begin
+    select
+      count(*),
+      count(*) filter (where ev_type = 'injected'),
+      count(*) filter (where ev_type = 'real')
+    into v_total, v_forged, v_real
+    from pgque.get_batch_cursor(
+        v_batch_id,
+        'inj_cursor_a',
+        100,
+        $f$false union all select 999999::bigint, now()::timestamptz, '0'::xid8, 0::int4, 'injected'::text, current_database()::text, null::text, null::text, null::text, null::text$f$);
+
+    -- If get_batch_cursor opened the cursor, close it so we don't leak it.
+    begin
+      execute 'close inj_cursor_a';
+    exception when others then
+      null;
+    end;
+  exception
+    when others then
+      v_caught_state := sqlstate;
+  end;
+
+  reset role;
+
+  if v_caught_state is not null then
+    raise notice 'PASS: get_batch_cursor extra_where injection rejected with sqlstate=%', v_caught_state;
+  else
+    assert v_forged = 0,
+      format(
+        'SQL forgery via extra_where leaked %s row(s); total=%s real=%s. Issue #108',
+        v_forged, v_total, v_real);
+    raise notice 'PASS: get_batch_cursor extra_where injection neutralised (total=% real=% forged=%)',
+      v_total, v_real, v_forged;
+  end if;
+end $$;
+
+-- =========================================================================
+-- Test B: a second variant — comment-style trailing predicate — must also
+-- not silently accept arbitrary tail SQL.
+-- =========================================================================
+do $$
+declare
+  v_batch_id     bigint;
+  v_forged       int := 0;
+  v_caught_state text;
+begin
+  set role pgque_inj_admin;
+
+  v_batch_id := pgque.next_batch('inj_q', 'inj_c');
+  if v_batch_id is null then
+    -- batch already finished by previous test step in some flows; that's OK.
+    reset role;
+    raise notice 'SKIP B: no batch available to claim (already consumed)';
+    return;
+  end if;
+
+  begin
+    select count(*) filter (where ev_type = 'injected')
+    into v_forged
+    from pgque.get_batch_cursor(
+        v_batch_id,
+        'inj_cursor_b',
+        100,
+        $f$1=1 union all select 1::bigint, now()::timestamptz, '0'::xid8, 0::int4, 'injected'::text, 'pwned'::text, null::text, null::text, null::text, null::text$f$);
+
+    begin
+      execute 'close inj_cursor_b';
+    exception when others then
+      null;
+    end;
+  exception
+    when others then
+      v_caught_state := sqlstate;
+  end;
+
+  reset role;
+
+  if v_caught_state is not null then
+    raise notice 'PASS: variant-2 injection rejected with sqlstate=%', v_caught_state;
+  else
+    assert v_forged = 0,
+      format('SQL forgery (1=1 variant) leaked %s row(s); issue #108', v_forged);
+    raise notice 'PASS: variant-2 injection neutralised (forged=%)', v_forged;
+  end if;
+end $$;
+
+-- =========================================================================
+-- Test C: the safe 3-arg overload must keep returning real events as admin.
+-- =========================================================================
+do $$
+declare
+  v_batch_id bigint;
+  v_count    int := 0;
+begin
+  set role pgque_inj_admin;
+
+  v_batch_id := pgque.next_batch('inj_q', 'inj_c');
+  if v_batch_id is null then
+    -- create another event so we have something to claim
+    reset role;
+    perform pgque.insert_event('inj_q', 'real', 'real-data-2');
+    perform pgque.ticker('inj_q');
+    set role pgque_inj_admin;
+    v_batch_id := pgque.next_batch('inj_q', 'inj_c');
+  end if;
+
+  if v_batch_id is null then
+    reset role;
+    raise notice 'SKIP C: no batch available (no new events ticked)';
+    return;
+  end if;
+
+  select count(*) into v_count
+  from pgque.get_batch_cursor(v_batch_id, 'safe_cursor_c', 100);
+
+  begin
+    execute 'close safe_cursor_c';
+  exception when others then
+    null;
+  end;
+
+  reset role;
+
+  assert v_count >= 0,
+    'safe 3-arg get_batch_cursor unexpectedly errored';
+  raise notice 'PASS: safe 3-arg get_batch_cursor returned % row(s) for admin', v_count;
+end $$;
+
+-- =========================================================================
+-- Cleanup
+-- =========================================================================
+
+select pgque.unregister_consumer('inj_q', 'inj_c');
+select pgque.drop_queue('inj_q');
+
+revoke pgque_admin from pgque_inj_admin;
+drop role if exists pgque_inj_admin;
+
+\echo 'PASS: test_security_get_batch_cursor_injection'


### PR DESCRIPTION
## Summary

Closes #108.

`pgque.get_batch_cursor(bigint, text, int4, text)` (the 4-arg overload) inherited PgQ's design: the `i_extra_where` text is concatenated verbatim into the cursor's `select`. As a result, any caller — even `pgque_admin` — can pass `false UNION ALL SELECT 999999::bigint, now(), '0'::xid8, 0::int4, 'injected', current_database(), null, null, null, null` and have a forged row appear in the returned event stream. Repro is reproduced verbatim from the issue body.

Admin-only grants (added previously) do *not* close this — admins still execute their own caller code, and this is a SQL-fragment API by construction.

## Fix choice

Three options were on the table from #108:

1. Remove the `extra_where` overload entirely.
2. Restrict it to `pgque_admin` only (already in place).
3. Document it as trusted-SQL only (already in place).

This PR takes option **1**: drop the 4-arg overload entirely.

Trade-off: it is the smallest API change that fully closes the vulnerability. No internal pgque code (api, additions, tle, clients/, cli/) calls the 4-arg overload — only the 3-arg overload was a delegating caller, and that delegation is now inlined. PgQ's own use of `extra_where` is for upstream subscription/Londiste integrations that pgque does not ship. Options 2 and 3 leave admin scripts as a foot-gun; option 1 makes a regression structurally impossible until someone reintroduces the signature.

If a future use case truly needs filtering driven by application input, the right shape is a parameterised variant that takes typed predicates, not a free-form text fragment.

## Files changed

- `sql/pgque.sql`, `sql/pgque-tle.sql` — drop the 4-arg overload (with `drop function if exists` for idempotent re-install), inline the cursor logic into the 3-arg overload, and update the security comment.
- `sql/pgque-additions/roles.sql` — drop the stale `revoke execute … (bigint, text, int4, text)` grant line.
- `tests/test_security_get_batch_cursor.sql` — replace the per-role "blocked from 4-arg" probes with a single `to_regprocedure` assertion that the 4-arg overload is absent (so it cannot be silently resurrected).
- `tests/test_security_get_batch_cursor_injection.sql` — new regression test (red commit) that runs the issue's repro payload as `pgque_admin` and asserts no forged row appears.
- `tests/run_all.sql` — wire the new test in.
- `docs/reference.md` — drop the 4-arg overload entry, replace it with a short note steering callers to `pgque.get_batch_events()`.

## Testing evidence

PostgreSQL 16.13 on Ubuntu 24.04, fresh `pgque_test` database.

### 1. Red — failing test on `origin/main` (no fix)

Install pgque from `origin/main`, run only the new regression test:

```
$ sudo -u postgres psql -d pgque_test -v ON_ERROR_STOP=1 -f tests/test_security_get_batch_cursor_injection.sql
...
NOTICE:  batch_id=1
psql:tests/test_security_get_batch_cursor_injection.sql:97: ERROR:  SQL forgery via extra_where leaked 1 row(s); total=1 real=0. Issue #108
CONTEXT:  PL/pgSQL function inline_code_block line 54 at ASSERT
```

The `false UNION ALL SELECT …` payload smuggles in one forged row, displacing the genuine `'real-data'` event entirely. Test fails as expected.

### 2. Green — same test on this branch

Drop schema, install fixed `sql/pgque.sql`, re-run:

```
$ sudo -u postgres psql -d pgque_test -v ON_ERROR_STOP=1 -f tests/test_security_get_batch_cursor_injection.sql
...
NOTICE:  PASS: get_batch_cursor extra_where injection rejected with sqlstate=42883
NOTICE:  PASS: variant-2 injection rejected with sqlstate=42883
NOTICE:  PASS: safe 3-arg get_batch_cursor returned 1 row(s) for admin
PASS: test_security_get_batch_cursor_injection
```

`42883` is `undefined_function` — exactly what we want: the overload no longer exists, so the injection vector cannot be reached at all.

### 3. Full regression suite

```
$ sudo -u postgres psql -d pgque_test -v ON_ERROR_STOP=1 -f tests/run_all.sql
...
=== ALL TESTS PASSED ===
```

### 4. Acceptance suite

```
$ sudo -u postgres psql -d pgque_test -v ON_ERROR_STOP=1 -f tests/acceptance/run_acceptance.sql
...
US-11: PASSED

=== ALL ACCEPTANCE TESTS PASSED ===
```

### 5. Re-install idempotency

Re-running `\i sql/pgque.sql` against a populated schema completes without error (the new `drop function if exists` handles the leftover 4-arg overload from older installs).

```
$ sudo -u postgres psql -d pgque_test -v ON_ERROR_STOP=1 -f tests/test_install_idempotency.sql
...
NOTICE:  PASS: queue state verified
NOTICE:  PASS: config singleton verified
```

https://claude.ai/code/session_01TwKyarGpkGKN8LY1CV8dsG

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwKyarGpkGKN8LY1CV8dsG)_