### PR TITLE
docs(clients/go): correct Consumer handler contract (#142)

### DIFF
--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -95,12 +95,25 @@ err := client.Nack(ctx, batchID, msg,
 Calls without options preserve the historical defaults: 60-second retry
 delay, NULL reason.
 
-## At-least-once contract
+## Handler contract
 
-If a per-message Nack call fails, the Consumer leaves the batch unacked
-so PgQue redelivers it on the next Receive. Acking a batch whose Nack
-failed would silently drop the failure information — the Go consumer
-prefers redelivery and lets the at-least-once retry path do its job.
+The Consumer dispatches each message to its registered handler and
+acts on the outcome individually before acking the batch:
+
+| Handler outcome                         | Action on the message                                            |
+| --------------------------------------- | ---------------------------------------------------------------- |
+| returns `nil`                           | nothing (succeeds quietly)                                       |
+| returns a non-nil `error`               | `Nack` the message (retry, then DLQ)                             |
+| panics                                  | recovered, treated identically to a returned error               |
+| no handler registered, `NackUnknown`    | log + `Nack` the message                                         |
+| no handler registered, `AckUnknown`     | log + skip                                                       |
+
+After every message has been processed, the batch is `Ack`'d. The one
+exception is when a per-message `Nack` call itself fails: in that case
+the Consumer leaves the batch unacked so PgQue redelivers it on the
+next `Receive`. Acking a batch whose `Nack` failed would silently drop
+the failure information — the Go consumer prefers redelivery and lets
+the at-least-once retry path do its job.
 
 ## Tests
 

--- a/clients/go/consumer.go
+++ b/clients/go/consumer.go
@@ -14,8 +14,10 @@ import (
 // causes the Consumer to issue a per-message Nack for that message
 // (routing it to retry_queue or, once max_retries is exceeded, to the
 // dead_letter table). Other messages in the same batch are still
-// dispatched to their handlers; the batch as a whole is acked only if
-// every required Nack succeeded.
+// dispatched to their own handlers; the batch as a whole is Ack'd
+// only if every per-message Nack call returned without error. A
+// panic raised inside the handler is recovered and routed identically
+// to a returned error.
 type HandlerFunc func(ctx context.Context, msg Message) error
 
 // consumerBackend is the subset of Client used by Consumer. Defining
@@ -40,11 +42,12 @@ type Consumer struct {
 }
 
 // Handle registers fn as the handler for messages whose Type matches
-// eventType. Messages with no registered handler are dispatched per
-// the consumer's UnknownHandlerPolicy: by default each is Nack'd
-// individually (routing it to retry_queue or eventually the DLQ);
-// with WithUnknownHandlerPolicy(AckUnknown) they are logged and
-// silently skipped instead.
+// eventType. Messages with no registered handler are dispatched
+// according to the Consumer's UnknownHandlerPolicy: by default
+// (NackUnknown) each is logged and Nack'd individually, routing it to
+// retry_queue or eventually the DLQ; with
+// WithUnknownHandlerPolicy(AckUnknown) each is logged and silently
+// skipped (the surrounding batch is still Ack'd).
 func (c *Consumer) Handle(eventType string, fn HandlerFunc) {
 	c.handlers[eventType] = fn
 }
@@ -61,21 +64,25 @@ func (c *Consumer) dispatchWithRecover(ctx context.Context, fn HandlerFunc, msg 
 }
 
 // Start begins the poll loop and blocks until ctx is cancelled. On
-// receive errors it logs and retries after the configured poll
+// Receive errors it logs and retries after the configured poll
 // interval.
 //
-// Per-batch dispatch semantics:
+// Per-batch dispatch semantics (the runtime contract of this loop):
 //
-//   - Each message is delivered to its registered handler. If the
-//     handler returns a non-nil error or panics, the message is
+//   - Each message is delivered to its registered handler. A handler
+//     that returns a non-nil error, or panics, has its message
 //     individually Nack'd (routed to retry_queue, eventually the DLQ).
-//   - Messages with no registered handler are Nack'd or skipped
-//     depending on the configured UnknownHandlerPolicy (default: Nack).
-//   - If every required Nack call succeeded (or none were needed), the
-//     batch is Ack'd. If any Nack fails, the batch is left unacked so
-//     that PgQue redelivers it on the next Receive — losing the Nack
-//     would otherwise mean losing the failure information for that
-//     message.
+//     The handler error is logged and dispatch continues to the next
+//     message in the batch.
+//   - Messages with no registered handler follow the configured
+//     UnknownHandlerPolicy: NackUnknown (default) logs and Nacks each;
+//     AckUnknown logs and skips each, leaving the batch Ack to handle
+//     them.
+//   - After every message has been processed, the batch is Ack'd —
+//     unless one of the per-message Nack calls returned an error, in
+//     which case the batch is left unacked so PgQue redelivers it on
+//     the next Receive. Acking a batch whose Nack failed would silently
+//     drop the failure information.
 func (c *Consumer) Start(ctx context.Context) error {
 	for {
 		select {

--- a/clients/go/consumer_contract_test.go
+++ b/clients/go/consumer_contract_test.go
@@ -1,0 +1,217 @@
+// Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+package pgque_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	pgque "github.com/NikolayS/pgque-go"
+)
+
+// contractBackend is a minimal Consumer backend that delivers one batch
+// of messages on the first Receive and nothing afterwards. Ack and Nack
+// are recorded with configurable error returns so a test can lock a
+// specific runtime contract.
+//
+// It is intentionally separate from stubBackend in
+// consumer_nackfail_test.go: the contract tests assert across multi-
+// message batches and across all four handler outcomes (success, error,
+// missing handler, panic), which the single-message stubBackend does
+// not cover.
+type contractBackend struct {
+	mu sync.Mutex
+
+	delivered bool
+	msgs      []pgque.Message
+
+	nackErr error
+
+	nackCount int32
+	ackCount  int32
+
+	nackedMsgIDs []int64
+	ackedBatches []int64
+}
+
+func (b *contractBackend) Receive(_ context.Context, _, _ string, _ int) ([]pgque.Message, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.delivered {
+		return nil, nil
+	}
+	b.delivered = true
+	out := make([]pgque.Message, len(b.msgs))
+	copy(out, b.msgs)
+	return out, nil
+}
+
+func (b *contractBackend) Ack(_ context.Context, batchID int64) error {
+	b.mu.Lock()
+	b.ackedBatches = append(b.ackedBatches, batchID)
+	b.mu.Unlock()
+	atomic.AddInt32(&b.ackCount, 1)
+	return nil
+}
+
+func (b *contractBackend) Nack(_ context.Context, _ int64, msg pgque.Message, _ ...pgque.NackOption) error {
+	b.mu.Lock()
+	b.nackedMsgIDs = append(b.nackedMsgIDs, msg.MsgID)
+	b.mu.Unlock()
+	atomic.AddInt32(&b.nackCount, 1)
+	return b.nackErr
+}
+
+// runConsumer wires the stub backend into a fresh Consumer, runs Start
+// long enough for the single delivered batch to be processed, and
+// returns once the consumer has cancelled.
+func runConsumer(t *testing.T, stub *contractBackend, opts ...pgque.ConsumerOption) *pgque.Consumer {
+	t.Helper()
+	var client *pgque.Client
+	defaultOpts := []pgque.ConsumerOption{pgque.WithPollInterval(20 * time.Millisecond)}
+	c := client.NewConsumer("dummy_queue", "dummy_consumer", append(defaultOpts, opts...)...)
+	pgque.SetConsumerBackend(c, stub)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	_ = c.Start(ctx)
+	return c
+}
+
+// TestConsumerContract_HandlerSuccess_AcksBatch locks the documented
+// contract: when every message in a batch is dispatched to a registered
+// handler that returns nil, the batch is Ack'd exactly once and no Nack
+// is issued.
+func TestConsumerContract_HandlerSuccess_AcksBatch(t *testing.T) {
+	stub := &contractBackend{
+		msgs: []pgque.Message{
+			{MsgID: 1, BatchID: 100, Type: "ok", Payload: `{}`},
+			{MsgID: 2, BatchID: 100, Type: "ok", Payload: `{}`},
+		},
+	}
+
+	var client *pgque.Client
+	c := client.NewConsumer("q", "c",
+		pgque.WithPollInterval(20*time.Millisecond))
+	c.Handle("ok", func(ctx context.Context, m pgque.Message) error { return nil })
+	pgque.SetConsumerBackend(c, stub)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	_ = c.Start(ctx)
+
+	if got := atomic.LoadInt32(&stub.nackCount); got != 0 {
+		t.Fatalf("handler success must not Nack, got %d", got)
+	}
+	if got := atomic.LoadInt32(&stub.ackCount); got == 0 {
+		t.Fatal("handler success must Ack the batch")
+	}
+}
+
+// TestConsumerContract_HandlerError_NacksMessageThenAcksBatch locks the
+// documented contract: when a handler returns a non-nil error, the
+// individual message is Nack'd; the batch is Ack'd because the Nack
+// succeeded. Other messages in the same batch still reach their
+// handlers.
+//
+// Note: the related question of what should happen when Nack itself
+// fails is covered by TestConsumer_NackFailure_DoesNotAck in
+// consumer_nackfail_test.go and is intentionally not re-asserted here.
+func TestConsumerContract_HandlerError_NacksMessageThenAcksBatch(t *testing.T) {
+	stub := &contractBackend{
+		msgs: []pgque.Message{
+			{MsgID: 10, BatchID: 200, Type: "fail", Payload: `{}`},
+			{MsgID: 11, BatchID: 200, Type: "ok", Payload: `{}`},
+		},
+	}
+
+	var client *pgque.Client
+	c := client.NewConsumer("q", "c",
+		pgque.WithPollInterval(20*time.Millisecond))
+
+	var okSeen int32
+	c.Handle("fail", func(ctx context.Context, m pgque.Message) error {
+		return errors.New("boom")
+	})
+	c.Handle("ok", func(ctx context.Context, m pgque.Message) error {
+		atomic.AddInt32(&okSeen, 1)
+		return nil
+	})
+	pgque.SetConsumerBackend(c, stub)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	_ = c.Start(ctx)
+
+	if got := atomic.LoadInt32(&stub.nackCount); got != 1 {
+		t.Fatalf("handler error must Nack exactly once, got %d", got)
+	}
+	if got := atomic.LoadInt32(&stub.ackCount); got != 1 {
+		t.Fatalf("batch must be Ack'd after successful per-message Nack, got %d", got)
+	}
+	if got := atomic.LoadInt32(&okSeen); got != 1 {
+		t.Fatalf("handler error must not stop dispatch of remaining messages; got okSeen = %d, want 1", got)
+	}
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	if len(stub.nackedMsgIDs) != 1 || stub.nackedMsgIDs[0] != 10 {
+		t.Fatalf("Nack must target the failed message (id 10), got %v", stub.nackedMsgIDs)
+	}
+}
+
+// TestConsumerContract_MissingHandler_DefaultPolicyNacks locks the
+// documented default UnknownHandlerPolicy contract: a message whose
+// Type has no registered handler is Nack'd, and the batch is Ack'd
+// because the Nack succeeded.
+func TestConsumerContract_MissingHandler_DefaultPolicyNacks(t *testing.T) {
+	stub := &contractBackend{
+		msgs: []pgque.Message{
+			{MsgID: 20, BatchID: 300, Type: "no.handler", Payload: `{}`},
+		},
+	}
+
+	c := runConsumer(t, stub)
+	_ = c
+
+	if got := atomic.LoadInt32(&stub.nackCount); got != 1 {
+		t.Fatalf("default policy must Nack unknown types exactly once, got %d", got)
+	}
+	if got := atomic.LoadInt32(&stub.ackCount); got != 1 {
+		t.Fatalf("default policy must Ack the batch after successful Nack, got %d", got)
+	}
+}
+
+// TestConsumerContract_HandlerPanic_NacksMessageThenAcksBatch locks the
+// documented panic contract: a handler panic is caught by
+// dispatchWithRecover and treated identically to a handler error —
+// per-message Nack, then batch Ack.
+func TestConsumerContract_HandlerPanic_NacksMessageThenAcksBatch(t *testing.T) {
+	stub := &contractBackend{
+		msgs: []pgque.Message{
+			{MsgID: 30, BatchID: 400, Type: "panic", Payload: `{}`},
+		},
+	}
+
+	var client *pgque.Client
+	c := client.NewConsumer("q", "c",
+		pgque.WithPollInterval(20*time.Millisecond))
+	c.Handle("panic", func(ctx context.Context, m pgque.Message) error {
+		panic("kaboom")
+	})
+	pgque.SetConsumerBackend(c, stub)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	_ = c.Start(ctx)
+
+	if got := atomic.LoadInt32(&stub.nackCount); got != 1 {
+		t.Fatalf("handler panic must Nack exactly once (same as handler error), got %d", got)
+	}
+	if got := atomic.LoadInt32(&stub.ackCount); got != 1 {
+		t.Fatalf("batch must be Ack'd after successful per-message Nack, got %d", got)
+	}
+}


### PR DESCRIPTION
Closes #142.

## Summary

Issue #142 reported that the Go Consumer's public doc comments in
`clients/go/consumer.go` described whole-batch redelivery on handler
error, while the runtime actually issues a per-message `Nack` and
still `Ack`s the batch. The runtime contract is the one users want;
the docs were the lie. This PR keeps scope strictly to making the
docs match the code, and locks the contract with stub-backend tests
so a future refactor cannot quietly drift back.

Out of scope (called out in #142 but addressed elsewhere):

- Whether `Ack` should still run after a failed `Nack` — already
  fixed; the consumer leaves the batch unacked. See
  `TestConsumer_NackFailure_DoesNotAck` in
  `clients/go/consumer_nackfail_test.go`.
- Cross-driver unknown-handler / Nack-failure policy redesign.
- Parity matrix work.

## Commits

1. `test: encode Go Consumer handler contract (#142)` — adds
   `clients/go/consumer_contract_test.go` with one test per scenario
   from the issue's "Suggested fix": handler success → `Ack`; handler
   error → per-message `Nack` + batch `Ack`; missing handler under
   default policy → per-message `Nack` + batch `Ack`; handler panic →
   identical to handler error. Tests pass against the current
   implementation and would fail if someone reverted the dispatcher to
   the old whole-batch-redelivery semantics.
2. `docs(clients/go): correct Consumer handler contract (#142)` —
   tightens the doc comments and the README to spell out the runtime
   contract precisely.

## Doc changes (before → after)

### `clients/go/consumer.go` — `HandlerFunc`

Before:

> Other messages in the same batch are still dispatched to their
> handlers; the batch as a whole is acked only if every required Nack
> succeeded.

After:

> Other messages in the same batch are still dispatched to their own
> handlers; the batch as a whole is Ack'd only if every per-message
> Nack call returned without error. A panic raised inside the handler
> is recovered and routed identically to a returned error.

Why this is correct: the dispatch loop in `Consumer.Start`
(`clients/go/consumer.go:114-139`) iterates every message regardless
of prior failures, calls `Nack` on the individual `msg`, and tracks
`nackFailed` to gate the final `Ack`. The panic path is
`dispatchWithRecover` (`clients/go/consumer.go:55-64`), which converts
a panic into a non-nil error so the same `Nack`-then-continue branch
runs.

### `clients/go/consumer.go` — `Handle`

Before:

> Messages with no registered handler are dispatched per the
> consumer's UnknownHandlerPolicy: by default each is Nack'd
> individually (routing it to retry_queue or eventually the DLQ); with
> WithUnknownHandlerPolicy(AckUnknown) they are logged and silently
> skipped instead.

After:

> Messages with no registered handler are dispatched according to the
> Consumer's UnknownHandlerPolicy: by default (NackUnknown) each is
> logged and Nack'd individually, routing it to retry_queue or
> eventually the DLQ; with WithUnknownHandlerPolicy(AckUnknown) each
> is logged and silently skipped (the surrounding batch is still
> Ack'd).

Why this is correct: the unknown-handler branch
(`clients/go/consumer.go:118-130`) logs in both cases; on
`AckUnknown` it `continue`s without touching the per-batch `Ack`
logic, so the batch is Ack'd at the end.

### `clients/go/consumer.go` — `Start`

Before (per-batch dispatch bullets):

> - If the handler returns a non-nil error or panics, the message is
>   individually Nack'd
> - Messages with no registered handler are Nack'd or skipped
>   depending on the configured UnknownHandlerPolicy (default: Nack).
> - If every required Nack call succeeded (or none were needed), the
>   batch is Ack'd. If any Nack fails, the batch is left unacked

After:

> - Each message is delivered to its registered handler. A handler
>   that returns a non-nil error, or panics, has its message
>   individually Nack'd ... The handler error is logged and dispatch
>   continues to the next message in the batch.
> - Messages with no registered handler follow the configured
>   UnknownHandlerPolicy: NackUnknown (default) logs and Nacks each;
>   AckUnknown logs and skips each, leaving the batch Ack to handle
>   them.
> - After every message has been processed, the batch is Ack'd —
>   unless one of the per-message Nack calls returned an error, in
>   which case the batch is left unacked so PgQue redelivers it on the
>   next Receive.

Why this is correct: the bullets now read in the same order as the
loop body (`clients/go/consumer.go:114-149`), including the
"continue dispatching" detail and the explicit final-Ack step.

### `clients/go/README.md`

Replaces the prose-only "At-least-once contract" section with a
"Handler contract" table that mirrors the consumer.go bullets, so the
two surfaces cannot drift independently. Same five outcomes (success,
error, panic, missing handler under each policy) plus the same
Nack-failed-leaves-batch-unacked rule.

## Testing evidence

DSN: `postgres://postgres:pgque_test@localhost/pgque_test`

```
$ cd clients/go && PGQUE_TEST_DSN="postgres://postgres:pgque_test@localhost/pgque_test" go test -count=1 ./...
ok  	github.com/NikolayS/pgque-go	13.561s
```

Verbose output of just the new contract tests:

```
=== RUN   TestConsumerContract_HandlerSuccess_AcksBatch
--- PASS: TestConsumerContract_HandlerSuccess_AcksBatch (0.30s)
=== RUN   TestConsumerContract_HandlerError_NacksMessageThenAcksBatch
2026/05/04 07:21:17 pgque: handler error for fail: boom
--- PASS: TestConsumerContract_HandlerError_NacksMessageThenAcksBatch (0.30s)
=== RUN   TestConsumerContract_MissingHandler_DefaultPolicyNacks
2026/05/04 07:21:17 pgque: no handler registered for event type "no.handler", nacking message 20
--- PASS: TestConsumerContract_MissingHandler_DefaultPolicyNacks (0.30s)
=== RUN   TestConsumerContract_HandlerPanic_NacksMessageThenAcksBatch
2026/05/04 07:21:17 pgque: handler error for panic: handler panic: kaboom
--- PASS: TestConsumerContract_HandlerPanic_NacksMessageThenAcksBatch (0.30s)
PASS
ok  	github.com/NikolayS/pgque-go	1.207s
```

Static checks:

```
$ gofmt -l clients/go/
$ go vet ./...
$ go build ./...
```

(all silent / no errors).

## Test plan

- [x] `go test -count=1 ./...` against PG 17 with PgQue 0.2.0-dev
  schema installed
- [x] `gofmt -l`, `go vet`, `go build` clean
- [ ] CI green on all supported PostgreSQL versions
- [ ] REV review (SOC2 findings ignored per repo policy)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TwKyarGpkGKN8LY1CV8dsG)_