### PR TITLE
fix: restrict cross-consumer primitives (#106)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -383,40 +383,42 @@ Grant: `pgque_writer`. Source: `sql/pgque.sql`.
 Inserts one event with the four `ev_extra*` columns populated.
 Grant: `pgque_writer`. Source: `sql/pgque.sql`.
 
+> **Trusted-operator-only primitives.** `register_consumer_at`, `get_batch_events`, and both `event_retry` overloads are gated behind `pgque_admin`. They take a consumer name or raw batch id and do **not** validate caller context, so a role with the grant can reposition any consumer's cursor, leak any consumer's active batch payloads, or push any consumer's events into the retry queue. Application code should use `pgque.subscribe`, `pgque.receive`, `pgque.ack`, and `pgque.nack` — those wrappers are `SECURITY DEFINER` and reach the primitives via the function owner, so they keep working under `pgque_reader`.
+
 #### `pgque.register_consumer(queue_name text, consumer_id text) → integer`
 
 Registers `consumer_id` on `queue_name`, starting from the most recent tick. Returns `1` for new, `0` if already registered.
-Grant: `pgque_writer`. Source: `sql/pgque.sql`.
+Grant: `pgque_reader`. Source: `sql/pgque.sql`.
 
 #### `pgque.register_consumer_at(queue_name text, consumer_name text, tick_pos bigint) → integer`
 
-Registers a consumer at a specific historical tick id. Raises if the tick is not found.
-Grant: `pgque_writer`. Source: `sql/pgque.sql`.
+Registers a consumer at a specific historical tick id, or repositions an existing consumer cursor when the consumer is already registered. Raises if the tick is not found.
+Grant: `pgque_admin` only. Source: `sql/pgque.sql`. **Trusted-operator only** — does not validate caller ownership of the consumer.
 
 #### `pgque.unregister_consumer(queue_name text, consumer_name text) → integer`
 
 Removes the subscription and retry-queue entries owned by this consumer on `queue_name`. Returns the number of subscriptions removed.
-Grant: `pgque_writer`. Source: `sql/pgque.sql`.
+Grant: `pgque_reader`. Source: `sql/pgque.sql`.
 
 #### `pgque.next_batch(queue_name text, consumer_name text) → bigint`
 
 Activates the next batch for this consumer and returns its id, or `NULL` if no events are ready.
-Grant: `pgque_writer`. Source: `sql/pgque.sql`.
+Grant: `pgque_reader`. Source: `sql/pgque.sql`.
 
 #### `pgque.next_batch_info(queue_name text, consumer_name text) → record`
 
 Same as `next_batch` but returns tick bounds alongside `batch_id`. Out columns: `batch_id`, `cur_tick_id`, `prev_tick_id`, `cur_tick_time`, `prev_tick_time`, `cur_tick_event_seq`, `prev_tick_event_seq`.
-Grant: `pgque_writer`. Source: `sql/pgque.sql`.
+Grant: `pgque_reader`. Source: `sql/pgque.sql`.
 
 #### `pgque.next_batch_custom(queue_name text, consumer_name text, min_lag interval, min_count int4, min_interval interval) → record`
 
 Activates the next batch with custom size/age constraints. Same out columns as `next_batch_info`.
-Grant: `pgque_writer`. Source: `sql/pgque.sql`.
+Grant: `pgque_reader`. Source: `sql/pgque.sql`.
 
 #### `pgque.get_batch_events(batch_id bigint) → setof record`
 
 Streams the events in a batch. Out columns: `ev_id bigint`, `ev_time timestamptz`, `ev_txid bigint`, `ev_retry int4`, `ev_type text`, `ev_data text`, `ev_extra1..4 text`.
-Grant: `pgque_writer`. Source: `sql/pgque.sql`.
+Grant: `pgque_admin` only. Source: `sql/pgque.sql`. **Trusted-operator only** — returns any active batch's payloads by id without validating caller ownership.
 
 #### `pgque.get_batch_cursor(batch_id bigint, cursor_name text, quick_limit int4) → setof record`
 
@@ -433,17 +435,17 @@ Grant: `pgque_admin` only. Source: `sql/pgque.sql`.
 #### `pgque.finish_batch(batch_id bigint) → integer`
 
 Closes the batch and advances the subscription's `last_tick`. Returns `1` on success, `0` with a warning if the batch was not found.
-Grant: `pgque_writer`. Source: `sql/pgque.sql`.
+Grant: `pgque_reader`. Source: `sql/pgque.sql`.
 
 #### `pgque.event_retry(batch_id bigint, event_id bigint, retry_time timestamptz) → integer`
 
 Puts one event back onto the retry queue with an absolute re-delivery time. Returns `1` on success, `0` if already queued for retry.
-Grant: `pgque_writer`. Source: `sql/pgque.sql`.
+Grant: `pgque_admin` only. Source: `sql/pgque.sql`. **Trusted-operator only** — operates by raw batch id without validating caller ownership.
 
 #### `pgque.event_retry(batch_id bigint, event_id bigint, retry_seconds integer) → integer`
 
 Same as above but takes a relative delay in seconds.
-Grant: `pgque_writer`. Source: `sql/pgque.sql`.
+Grant: `pgque_admin` only. Source: `sql/pgque.sql`. **Trusted-operator only** — operates by raw batch id without validating caller ownership.
 
 #### `pgque.batch_retry(batch_id bigint, retry_seconds integer) → integer`
 
@@ -511,9 +513,9 @@ This is intentional, by design. The batch-ID-based primitives (`ack`, `nack`, `e
 
 | Role           | Functions granted (direct)                                                                                                                                                                                                                                              |
 |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `pgque_reader` | `get_queue_info()`, `get_queue_info(text)`, `get_consumer_info()`, `get_consumer_info(text)`, `get_consumer_info(text, text)`, `get_batch_info(bigint)`, `version()`, `dlq_inspect(text, int)`; `select` on all tables incl. `pgque.dead_letter`; consumer primitives (`register_consumer`, `register_consumer_at`, `unregister_consumer`, `next_batch`, `next_batch_info`, `next_batch_custom`, `get_batch_events`, `finish_batch`, `event_retry` int + timestamptz); modern consume API (`subscribe`, `unsubscribe`, `receive`, `ack`, `nack`)                        |
+| `pgque_reader` | `get_queue_info()`, `get_queue_info(text)`, `get_consumer_info()`, `get_consumer_info(text)`, `get_consumer_info(text, text)`, `get_batch_info(bigint)`, `version()`, `dlq_inspect(text, int)`; `select` on all tables incl. `pgque.dead_letter`; consumer primitives (`register_consumer`, `unregister_consumer`, `next_batch`, `next_batch_info`, `next_batch_custom`, `finish_batch`); modern consume API (`subscribe`, `unsubscribe`, `receive`, `ack`, `nack`)                        |
 | `pgque_writer` | `insert_event` (3, 7), all `send*`, all `send_batch*`, `dlq_replay`, `dlq_replay_all`. **Does not inherit `pgque_reader`** — a producer-only role cannot ack/finish/inspect consumer batches. |
-| `pgque_admin`  | Member of both `pgque_reader` and `pgque_writer`, plus `event_dead`, `dlq_purge`, `all` on `pgque` schema, `all` on all tables and sequences, `execute` on all functions — **except** `uninstall()` and internal `insert_event_bulk()` which are explicitly revoked                                                            |
+| `pgque_admin`  | Member of both `pgque_reader` and `pgque_writer`, plus the trusted-operator primitives (`register_consumer_at`, `get_batch_events`, both `event_retry` overloads, `get_batch_cursor`, `batch_retry`), `event_dead`, `dlq_purge`, `all` on `pgque` schema, `all` on all tables and sequences, `execute` on all functions — **except** `uninstall()` and internal `insert_event_bulk()` which are explicitly revoked                                                            |
 
 `pgque.uninstall()` is revoked from both `pgque_admin` (explicitly) and PUBLIC (via the schema-wide blanket revoke). Internal `pgque.insert_event_bulk()` is also revoked from `pgque_admin`; callers must use `send_batch()` wrappers. Only the schema/install owner (typically a superuser) can run `uninstall()` or the internal primitive directly. All other functions not listed in the table above retain `execute` only for `pgque_admin` (the schema-wide blanket revoke from PUBLIC applies, and `pgque_admin` is granted `execute on all functions`) — notably the lifecycle helpers `start`, `stop`, `status`, `maint`, `maint_retry_events`, `ticker`, `force_tick`, and the queue-management helpers `create_queue`, `drop_queue`, `set_queue_config`. Grant these explicitly to additional roles if your policy demands it.
 

--- a/sql/pgque-additions/roles.sql
+++ b/sql/pgque-additions/roles.sql
@@ -92,19 +92,67 @@ revoke execute on function pgque.event_retry(bigint, bigint, integer) from pgque
 
 -- consumer registration (consumer side: create/move/drop a subscription cursor)
 grant execute on function pgque.register_consumer(text, text) to pgque_reader;
-grant execute on function pgque.register_consumer_at(text, text, bigint) to pgque_reader;
 grant execute on function pgque.unregister_consumer(text, text) to pgque_reader;
 
 -- batch processing
 grant execute on function pgque.next_batch(text, text) to pgque_reader;
 grant execute on function pgque.next_batch_info(text, text) to pgque_reader;
 grant execute on function pgque.next_batch_custom(text, text, interval, int4, interval) to pgque_reader;
-grant execute on function pgque.get_batch_events(bigint) to pgque_reader;
 grant execute on function pgque.finish_batch(bigint) to pgque_reader;
 
--- event retry — timestamptz and integer overloads
-grant execute on function pgque.event_retry(bigint, bigint, timestamptz) to pgque_reader;
-grant execute on function pgque.event_retry(bigint, bigint, integer) to pgque_reader;
+-- ---------------------------------------------------------------------------
+-- Trusted-operator-only primitives (#106)
+--
+-- The PgQ-compatible primitives below operate on (queue, consumer) name pairs
+-- or on raw batch ids and do NOT validate caller context. That means any role
+-- holding the grant can reach into another consumer's active batch / cursor:
+--
+--   - register_consumer_at(queue, victim, tick) repositions any consumer's
+--     cursor (clears sub_batch, rewrites sub_last_tick).
+--   - event_retry(batch_id, ev_id, n) pushes any consumer's events into
+--     the retry queue.
+--   - get_batch_events(batch_id) leaks any consumer's active payloads.
+--
+-- v0.2.0 mitigation: keep these as pgque_admin only. The high-level API
+-- (pgque.receive, pgque.ack, pgque.nack) is SECURITY DEFINER and reaches
+-- the primitives via the function owner, so application code that uses
+-- the modern API is unaffected. Apps that genuinely need the PgQ-compatible
+-- primitive layer must run as pgque_admin (or a role granted pgque_admin).
+--
+-- Per-queue / per-consumer ACLs would close the consumer-vs-consumer
+-- boundary in a finer-grained way; that is a multi-week design exercise
+-- and is tracked separately. For v0.2.0 the smallest-blast-radius fix is
+-- the trusted-operator gate plus an explicit comment on each function.
+-- ---------------------------------------------------------------------------
+
+-- Upgrade path: pre-#106-fix installs granted these to pgque_reader. Postgres
+-- preserves function-level grants across `create or replace function`, so a
+-- re-install silently retains the old grants. Revoke from pgque_reader
+-- explicitly. The earlier revoke from pgque_writer above is also still
+-- needed for installs that pre-date #163.
+revoke execute on function pgque.register_consumer_at(text, text, bigint) from pgque_reader;
+revoke execute on function pgque.get_batch_events(bigint)                 from pgque_reader;
+revoke execute on function pgque.event_retry(bigint, bigint, timestamptz) from pgque_reader;
+revoke execute on function pgque.event_retry(bigint, bigint, integer)     from pgque_reader;
+
+-- Document the trust contract on the functions themselves so anyone
+-- inspecting via \df+ sees it without having to read docs/reference.md.
+comment on function pgque.register_consumer_at(text, text, bigint) is
+    'Trusted-operator only (pgque_admin). Repositions a consumer cursor and '
+    'does not validate caller ownership of the consumer. Apps should use '
+    'pgque.subscribe()/pgque.receive() instead.';
+comment on function pgque.get_batch_events(bigint) is
+    'Trusted-operator only (pgque_admin). Returns the events of any active '
+    'batch by id and does not validate caller ownership of the batch. Apps '
+    'should use pgque.receive() instead.';
+comment on function pgque.event_retry(bigint, bigint, timestamptz) is
+    'Trusted-operator only (pgque_admin). Re-queues an event of any active '
+    'batch by id and does not validate caller ownership. Apps should use '
+    'pgque.nack() instead.';
+comment on function pgque.event_retry(bigint, bigint, integer) is
+    'Trusted-operator only (pgque_admin). Re-queues an event of any active '
+    'batch by id and does not validate caller ownership. Apps should use '
+    'pgque.nack() instead.';
 
 -- ---------------------------------------------------------------------------
 -- Writer: produce events. Strictly producer-side primitives.

--- a/sql/pgque-tle.sql
+++ b/sql/pgque-tle.sql
@@ -4394,19 +4394,67 @@ revoke execute on function pgque.event_retry(bigint, bigint, integer) from pgque
 
 -- consumer registration (consumer side: create/move/drop a subscription cursor)
 grant execute on function pgque.register_consumer(text, text) to pgque_reader;
-grant execute on function pgque.register_consumer_at(text, text, bigint) to pgque_reader;
 grant execute on function pgque.unregister_consumer(text, text) to pgque_reader;
 
 -- batch processing
 grant execute on function pgque.next_batch(text, text) to pgque_reader;
 grant execute on function pgque.next_batch_info(text, text) to pgque_reader;
 grant execute on function pgque.next_batch_custom(text, text, interval, int4, interval) to pgque_reader;
-grant execute on function pgque.get_batch_events(bigint) to pgque_reader;
 grant execute on function pgque.finish_batch(bigint) to pgque_reader;
 
--- event retry — timestamptz and integer overloads
-grant execute on function pgque.event_retry(bigint, bigint, timestamptz) to pgque_reader;
-grant execute on function pgque.event_retry(bigint, bigint, integer) to pgque_reader;
+-- ---------------------------------------------------------------------------
+-- Trusted-operator-only primitives (#106)
+--
+-- The PgQ-compatible primitives below operate on (queue, consumer) name pairs
+-- or on raw batch ids and do NOT validate caller context. That means any role
+-- holding the grant can reach into another consumer's active batch / cursor:
+--
+--   - register_consumer_at(queue, victim, tick) repositions any consumer's
+--     cursor (clears sub_batch, rewrites sub_last_tick).
+--   - event_retry(batch_id, ev_id, n) pushes any consumer's events into
+--     the retry queue.
+--   - get_batch_events(batch_id) leaks any consumer's active payloads.
+--
+-- v0.2.0 mitigation: keep these as pgque_admin only. The high-level API
+-- (pgque.receive, pgque.ack, pgque.nack) is SECURITY DEFINER and reaches
+-- the primitives via the function owner, so application code that uses
+-- the modern API is unaffected. Apps that genuinely need the PgQ-compatible
+-- primitive layer must run as pgque_admin (or a role granted pgque_admin).
+--
+-- Per-queue / per-consumer ACLs would close the consumer-vs-consumer
+-- boundary in a finer-grained way; that is a multi-week design exercise
+-- and is tracked separately. For v0.2.0 the smallest-blast-radius fix is
+-- the trusted-operator gate plus an explicit comment on each function.
+-- ---------------------------------------------------------------------------
+
+-- Upgrade path: pre-#106-fix installs granted these to pgque_reader. Postgres
+-- preserves function-level grants across `create or replace function`, so a
+-- re-install silently retains the old grants. Revoke from pgque_reader
+-- explicitly. The earlier revoke from pgque_writer above is also still
+-- needed for installs that pre-date #163.
+revoke execute on function pgque.register_consumer_at(text, text, bigint) from pgque_reader;
+revoke execute on function pgque.get_batch_events(bigint)                 from pgque_reader;
+revoke execute on function pgque.event_retry(bigint, bigint, timestamptz) from pgque_reader;
+revoke execute on function pgque.event_retry(bigint, bigint, integer)     from pgque_reader;
+
+-- Document the trust contract on the functions themselves so anyone
+-- inspecting via \df+ sees it without having to read docs/reference.md.
+comment on function pgque.register_consumer_at(text, text, bigint) is
+    'Trusted-operator only (pgque_admin). Repositions a consumer cursor and '
+    'does not validate caller ownership of the consumer. Apps should use '
+    'pgque.subscribe()/pgque.receive() instead.';
+comment on function pgque.get_batch_events(bigint) is
+    'Trusted-operator only (pgque_admin). Returns the events of any active '
+    'batch by id and does not validate caller ownership of the batch. Apps '
+    'should use pgque.receive() instead.';
+comment on function pgque.event_retry(bigint, bigint, timestamptz) is
+    'Trusted-operator only (pgque_admin). Re-queues an event of any active '
+    'batch by id and does not validate caller ownership. Apps should use '
+    'pgque.nack() instead.';
+comment on function pgque.event_retry(bigint, bigint, integer) is
+    'Trusted-operator only (pgque_admin). Re-queues an event of any active '
+    'batch by id and does not validate caller ownership. Apps should use '
+    'pgque.nack() instead.';
 
 -- ---------------------------------------------------------------------------
 -- Writer: produce events. Strictly producer-side primitives.

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -4306,19 +4306,67 @@ revoke execute on function pgque.event_retry(bigint, bigint, integer) from pgque
 
 -- consumer registration (consumer side: create/move/drop a subscription cursor)
 grant execute on function pgque.register_consumer(text, text) to pgque_reader;
-grant execute on function pgque.register_consumer_at(text, text, bigint) to pgque_reader;
 grant execute on function pgque.unregister_consumer(text, text) to pgque_reader;
 
 -- batch processing
 grant execute on function pgque.next_batch(text, text) to pgque_reader;
 grant execute on function pgque.next_batch_info(text, text) to pgque_reader;
 grant execute on function pgque.next_batch_custom(text, text, interval, int4, interval) to pgque_reader;
-grant execute on function pgque.get_batch_events(bigint) to pgque_reader;
 grant execute on function pgque.finish_batch(bigint) to pgque_reader;
 
--- event retry — timestamptz and integer overloads
-grant execute on function pgque.event_retry(bigint, bigint, timestamptz) to pgque_reader;
-grant execute on function pgque.event_retry(bigint, bigint, integer) to pgque_reader;
+-- ---------------------------------------------------------------------------
+-- Trusted-operator-only primitives (#106)
+--
+-- The PgQ-compatible primitives below operate on (queue, consumer) name pairs
+-- or on raw batch ids and do NOT validate caller context. That means any role
+-- holding the grant can reach into another consumer's active batch / cursor:
+--
+--   - register_consumer_at(queue, victim, tick) repositions any consumer's
+--     cursor (clears sub_batch, rewrites sub_last_tick).
+--   - event_retry(batch_id, ev_id, n) pushes any consumer's events into
+--     the retry queue.
+--   - get_batch_events(batch_id) leaks any consumer's active payloads.
+--
+-- v0.2.0 mitigation: keep these as pgque_admin only. The high-level API
+-- (pgque.receive, pgque.ack, pgque.nack) is SECURITY DEFINER and reaches
+-- the primitives via the function owner, so application code that uses
+-- the modern API is unaffected. Apps that genuinely need the PgQ-compatible
+-- primitive layer must run as pgque_admin (or a role granted pgque_admin).
+--
+-- Per-queue / per-consumer ACLs would close the consumer-vs-consumer
+-- boundary in a finer-grained way; that is a multi-week design exercise
+-- and is tracked separately. For v0.2.0 the smallest-blast-radius fix is
+-- the trusted-operator gate plus an explicit comment on each function.
+-- ---------------------------------------------------------------------------
+
+-- Upgrade path: pre-#106-fix installs granted these to pgque_reader. Postgres
+-- preserves function-level grants across `create or replace function`, so a
+-- re-install silently retains the old grants. Revoke from pgque_reader
+-- explicitly. The earlier revoke from pgque_writer above is also still
+-- needed for installs that pre-date #163.
+revoke execute on function pgque.register_consumer_at(text, text, bigint) from pgque_reader;
+revoke execute on function pgque.get_batch_events(bigint)                 from pgque_reader;
+revoke execute on function pgque.event_retry(bigint, bigint, timestamptz) from pgque_reader;
+revoke execute on function pgque.event_retry(bigint, bigint, integer)     from pgque_reader;
+
+-- Document the trust contract on the functions themselves so anyone
+-- inspecting via \df+ sees it without having to read docs/reference.md.
+comment on function pgque.register_consumer_at(text, text, bigint) is
+    'Trusted-operator only (pgque_admin). Repositions a consumer cursor and '
+    'does not validate caller ownership of the consumer. Apps should use '
+    'pgque.subscribe()/pgque.receive() instead.';
+comment on function pgque.get_batch_events(bigint) is
+    'Trusted-operator only (pgque_admin). Returns the events of any active '
+    'batch by id and does not validate caller ownership of the batch. Apps '
+    'should use pgque.receive() instead.';
+comment on function pgque.event_retry(bigint, bigint, timestamptz) is
+    'Trusted-operator only (pgque_admin). Re-queues an event of any active '
+    'batch by id and does not validate caller ownership. Apps should use '
+    'pgque.nack() instead.';
+comment on function pgque.event_retry(bigint, bigint, integer) is
+    'Trusted-operator only (pgque_admin). Re-queues an event of any active '
+    'batch by id and does not validate caller ownership. Apps should use '
+    'pgque.nack() instead.';
 
 -- ---------------------------------------------------------------------------
 -- Writer: produce events. Strictly producer-side primitives.

--- a/tests/run_all.sql
+++ b/tests/run_all.sql
@@ -34,6 +34,9 @@
 \echo 'Running: test_security_producer_isolation'
 \i tests/test_security_producer_isolation.sql
 
+\echo 'Running: test_security_cross_consumer'
+\i tests/test_security_cross_consumer.sql
+
 \echo 'Running: test_core_lifecycle'
 \i tests/test_core_lifecycle.sql
 

--- a/tests/test_security_cross_consumer.sql
+++ b/tests/test_security_cross_consumer.sql
@@ -1,0 +1,216 @@
+-- test_security_cross_consumer.sql
+-- Regression test for #106: cross-consumer interference via low-level
+-- PgQ-compatible primitives.
+--
+-- Context: in v0.2.0, register_consumer_at / event_retry / get_batch_events
+-- are granted to pgque_reader so apps can use the PgQ-compatible primitive
+-- layer. But these primitives operate by queue/consumer name or batch id and
+-- do NOT validate caller context. That means a second consumer that already
+-- holds pgque_reader (a perfectly normal grant for any consuming app) can
+-- reach into another consumer's active batch / cursor.
+--
+-- v0.2.0 mitigation: keep these three primitives as trusted-operator-only.
+-- Revoke from pgque_reader and grant to pgque_admin only. The high-level
+-- API (pgque.receive / ack / nack) is SECURITY DEFINER and reaches the
+-- primitives via the function owner, so application code is unaffected.
+--
+-- This test asserts the trusted-operator contract. Two consumer roles A and B
+-- both hold pgque_reader. B must NOT be able to:
+--   A) reposition A's cursor via pgque.register_consumer_at()
+--   B) push A's events into retry via pgque.event_retry()
+--   C) read A's active batch payloads via pgque.get_batch_events()
+--
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+-- Idempotent preamble: clean up leftovers from a prior aborted run.
+do $$
+begin
+    if exists (select 1 from pg_roles where rolname = 'cc_consumer_a') then
+        revoke all privileges on schema pgque from cc_consumer_a;
+        revoke pgque_reader from cc_consumer_a;
+        drop role cc_consumer_a;
+    end if;
+    if exists (select 1 from pg_roles where rolname = 'cc_consumer_b') then
+        revoke all privileges on schema pgque from cc_consumer_b;
+        revoke pgque_reader from cc_consumer_b;
+        drop role cc_consumer_b;
+    end if;
+exception when others then
+    raise notice 'preamble cleanup: % / %', sqlstate, sqlerrm;
+end $$;
+
+do $$
+begin
+    if exists (select 1 from pgque.queue where queue_name = 'q_cc') then
+        perform pgque.drop_queue('q_cc', true);
+    end if;
+exception when others then
+    raise notice 'preamble queue cleanup: % / %', sqlstate, sqlerrm;
+end $$;
+
+-- Setup -----------------------------------------------------------------------
+
+-- Two consumer roles, both holding pgque_reader. NOLOGIN -- we use set role.
+create role cc_consumer_a nologin;
+grant pgque_reader to cc_consumer_a;
+create role cc_consumer_b nologin;
+grant pgque_reader to cc_consumer_b;
+
+-- Queue + two consumers + an event + a tick so consumer_a has an active batch.
+select pgque.create_queue('q_cc');
+select pgque.subscribe('q_cc', 'cons_a');
+select pgque.subscribe('q_cc', 'cons_b');
+select pgque.send('q_cc', 'secret', '{"payload":"top-secret"}'::jsonb);
+select pgque.force_tick('q_cc');
+select pgque.ticker('q_cc');
+
+-- Consumer A opens a batch under pgque_reader privileges and stashes the
+-- (batch_id, ev_id) on a session GUC so the attacker block can read them
+-- back without re-reaching into A's tables.
+set role cc_consumer_a;
+do $$
+declare
+    v_count int;
+    v_bid   bigint;
+    v_eid   bigint;
+begin
+    select count(*) into v_count from pgque.receive('q_cc', 'cons_a', 10);
+    assert v_count = 1, format('cons_a should have received 1 message, got %s', v_count);
+
+    select sub_batch into v_bid
+      from pgque.subscription s
+      join pgque.consumer c on c.co_id = s.sub_consumer
+     where c.co_name = 'cons_a';
+    assert v_bid is not null, 'cons_a should have an active batch_id';
+
+    -- Look up the ev_id while still acting as cons_a (it has the active batch).
+    -- pgque.receive() does not return ev_id directly here, so use the message type.
+    select msg_id into v_eid
+      from pgque.receive('q_cc', 'cons_a', 10)
+     limit 1;
+    -- Note: a second receive returns nothing because the batch is already open.
+    -- Fall back to looking up the event id from the queue data tables, which
+    -- pgque_reader can SELECT from.
+    if v_eid is null then
+        select ev_id into v_eid
+          from pgque.event_1 -- queue data table -- pgque_reader has SELECT
+         where ev_type = 'secret'
+         limit 1;
+    end if;
+    assert v_eid is not null, 'expected to discover an ev_id for the secret event';
+
+    perform set_config('pgque_test.cc_bid', v_bid::text, false);
+    perform set_config('pgque_test.cc_eid', v_eid::text, false);
+end $$;
+reset role;
+
+-- Attacker tests --------------------------------------------------------------
+
+set role cc_consumer_b;
+
+-- Finding A: register_consumer_at(queue, victim_consumer, tick) lets B
+-- reposition cons_a's cursor (clears sub_batch, rewrites sub_last_tick).
+do $$
+begin
+    begin
+        perform pgque.register_consumer_at('q_cc', 'cons_a', 1);
+        raise exception 'FAIL #106-A: cc_consumer_b repositioned cons_a cursor';
+    exception
+        when insufficient_privilege then
+            raise notice 'PASS #106-A (register_consumer_at): denied to pgque_reader';
+        when others then
+            raise exception 'FAIL #106-A: unexpected error: % / %', sqlstate, sqlerrm;
+    end;
+end $$;
+
+-- Finding B: event_retry(batch_id, ev_id, n) lets B push cons_a's events
+-- into the retry queue. Both timestamptz and integer overloads are separate
+-- privilege rows so cover both.
+do $$
+declare
+    v_bid bigint := current_setting('pgque_test.cc_bid')::bigint;
+    v_eid bigint := current_setting('pgque_test.cc_eid')::bigint;
+begin
+    begin
+        perform pgque.event_retry(v_bid, v_eid, 0);
+        raise exception 'FAIL #106-B: cc_consumer_b retried cons_a event (int overload)';
+    exception
+        when insufficient_privilege then
+            raise notice 'PASS #106-B (event_retry int): denied to pgque_reader';
+        when others then
+            raise exception 'FAIL #106-B (int): unexpected error: % / %', sqlstate, sqlerrm;
+    end;
+
+    begin
+        perform pgque.event_retry(v_bid, v_eid, now());
+        raise exception 'FAIL #106-B: cc_consumer_b retried cons_a event (timestamptz overload)';
+    exception
+        when insufficient_privilege then
+            raise notice 'PASS #106-B (event_retry timestamptz): denied to pgque_reader';
+        when others then
+            raise exception 'FAIL #106-B (timestamptz): unexpected error: % / %', sqlstate, sqlerrm;
+    end;
+end $$;
+
+-- Finding C: get_batch_events(batch_id) returns the active payloads of the
+-- batch, including ev_data. B must not be able to inspect cons_a's in-flight
+-- messages.
+do $$
+declare
+    v_bid bigint := current_setting('pgque_test.cc_bid')::bigint;
+begin
+    begin
+        perform * from pgque.get_batch_events(v_bid);
+        raise exception 'FAIL #106-C: cc_consumer_b read cons_a active batch payloads';
+    exception
+        when insufficient_privilege then
+            raise notice 'PASS #106-C (get_batch_events): denied to pgque_reader';
+        when others then
+            raise exception 'FAIL #106-C: unexpected error: % / %', sqlstate, sqlerrm;
+    end;
+end $$;
+
+reset role;
+
+-- Sanity: pgque_admin still has all three primitives via direct grant. --------
+do $$
+begin
+    assert has_function_privilege('pgque_admin',
+        'pgque.register_consumer_at(text, text, bigint)', 'EXECUTE'),
+        'pgque_admin should retain register_consumer_at';
+    assert has_function_privilege('pgque_admin',
+        'pgque.event_retry(bigint, bigint, integer)', 'EXECUTE'),
+        'pgque_admin should retain event_retry(integer)';
+    assert has_function_privilege('pgque_admin',
+        'pgque.event_retry(bigint, bigint, timestamptz)', 'EXECUTE'),
+        'pgque_admin should retain event_retry(timestamptz)';
+    assert has_function_privilege('pgque_admin',
+        'pgque.get_batch_events(bigint)', 'EXECUTE'),
+        'pgque_admin should retain get_batch_events';
+end $$;
+
+-- Sanity: the high-level API (receive/ack/nack) still works for pgque_reader.
+-- These wrappers are SECURITY DEFINER and reach the low-level primitives via
+-- the function owner, so application code that uses the modern API is
+-- unaffected by the revoke.
+set role cc_consumer_a;
+do $$
+declare
+    v_bid bigint := current_setting('pgque_test.cc_bid')::bigint;
+begin
+    perform pgque.ack(v_bid);
+end $$;
+reset role;
+
+-- Cleanup ---------------------------------------------------------------------
+
+select pgque.unsubscribe('q_cc', 'cons_a');
+select pgque.unsubscribe('q_cc', 'cons_b');
+select pgque.drop_queue('q_cc', true);
+
+revoke pgque_reader from cc_consumer_a;
+revoke pgque_reader from cc_consumer_b;
+drop role cc_consumer_a;
+drop role cc_consumer_b;
+
+\echo 'PASS: cross-consumer primitive isolation (#106)'


### PR DESCRIPTION
## Summary

Closes #106. Fix the cross-consumer interference paths in the low-level
PgQ-compatible primitive surface.

The three primitives flagged in #106 operate by `(queue, consumer)` name
pair or by raw batch id and do **not** validate caller context. Before
this PR, any role with the grant could reach into another consumer's
active batch / cursor. Each finding is an independent attack vector; in
v0.2.0 they all collapse onto whichever role is granted execute on these
functions.

### Findings (verbatim from #106) and the surface that exposes each

- **A — `register_consumer_at(queue, victim, tick)`** repositions any
  consumer's cursor. Clears `sub_batch`, clears `sub_next_tick`, rewrites
  `sub_last_tick`. Drops the victim's active batch state and can cause
  message loss or duplicate delivery.
- **B — `event_retry(batch_id, ev_id, n)`** pushes any consumer's events
  into the retry queue, causing duplicate processing after the victim
  acks and retry-count pollution. Both `(timestamptz)` and `(integer)`
  overloads are separate privilege rows.
- **C — `get_batch_events(batch_id)`** leaks any consumer's active
  batch payloads (full `ev_data`).

## Design choice

The issue lists two end-states. **Option 1** (treat the primitives as
trusted-operator surface and document loudly) is shipped here because
**option 2** (per-queue/per-consumer ACLs) is a multi-week design
exercise that touches the "sacred" PgQ engine and changes function
signatures. Option 1 closes the immediate exposure with a one-line
grant change per primitive.

### Mitigation

Revoke from `pgque_reader`, grant only to `pgque_admin` for:

- `pgque.register_consumer_at(text, text, bigint)`
- `pgque.get_batch_events(bigint)`
- `pgque.event_retry(bigint, bigint, timestamptz)`
- `pgque.event_retry(bigint, bigint, integer)`

The high-level API (`pgque.receive`, `pgque.ack`, `pgque.nack`,
`pgque.subscribe`) is `SECURITY DEFINER` and reaches the primitives via
the function owner, so application code that uses the modern API is
**unaffected**. Apps that genuinely need the PgQ-compatible primitive
layer must run as `pgque_admin` (or as a role granted `pgque_admin`).

A `comment on function` is added to each affected primitive so anyone
inspecting via `\df+` sees the trust contract without having to read
`docs/reference.md`. `docs/reference.md` itself gets a callout box at
the top of the consumer-primitives section and per-function "Trusted
operator only" notes. The role grants table is updated to reflect the
new shape.

The source `sql/pgque-additions/roles.sql`, the assembled
`sql/pgque.sql`, and the pg_tle wrapper `sql/pgque-tle.sql` are all
kept consistent.

## Why not also fix `next_batch` / `finish_batch`

These two primitives are also batch-id / consumer-name-keyed and have
the same shape, but they are reachable through the `pgque.receive` /
`pgque.ack` modern API path that application code already uses. Pushing
them to admin-only would force every consumer to either run as
`pgque_admin` or rewrite via `receive` + `ack` (the recommended path
anyway). Driver tests exercise `receive` + `ack`, not `next_batch` /
`finish_batch` directly, so we keep them on `pgque_reader` for v0.2.0.
The narrower "writer cannot call them" boundary is already locked by
`tests/test_security_producer_isolation.sql`. A follow-up can revisit
this once finer-grained ACLs land.

## Test plan

- [x] `tests/test_security_cross_consumer.sql`: red on `origin/main`,
  green after the fix. Two `pgque_reader` roles A and B; B cannot
  `register_consumer_at` cons_a, `event_retry` cons_a's batch (both
  overloads), or `get_batch_events` cons_a's batch.
- [x] `psql -f tests/run_all.sql`: ALL TESTS PASSED on PG16.
- [x] `psql -f tests/acceptance/run_acceptance.sql`: ALL ACCEPTANCE
  TESTS PASSED on PG16.
- [x] Install + reinstall + `tests/test_install_idempotency.sql`: green.
- [x] Python driver suite (54 tests): all passed.
- [x] Go driver suite: all passed.
- [x] TypeScript driver suite (37 tests): all passed.

Evidence is posted as a PR comment.

https://claude.ai/code/session_01TwKyarGpkGKN8LY1CV8dsG

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwKyarGpkGKN8LY1CV8dsG)_