### PR TITLE
fix(clients): handle NULL ev_type/ev_data per driver (#143)

### DIFF
--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -64,7 +64,11 @@ func main() {
         pgque.WithUnknownHandlerPolicy(pgque.NackUnknown), // also the default
     )
     consumer.Handle("order.created", func(ctx context.Context, msg pgque.Message) error {
-        log.Printf("got %s: %s", msg.Type, msg.Payload)
+        // msg.Type and msg.Payload are *string: events enqueued via
+        // pgque.insert_event(queue, null, null) carry SQL-NULL fields.
+        // Code that only consumes pgque.Send-produced events sees
+        // non-nil values and can deref directly.
+        log.Printf("got %s: %s", *msg.Type, *msg.Payload)
         return nil
     })
     if err := consumer.Start(ctx); err != nil {

--- a/clients/go/consumer.go
+++ b/clients/go/consumer.go
@@ -108,23 +108,31 @@ func (c *Consumer) Start(ctx context.Context) error {
 		nackFailed := false
 		for _, msg := range msgs {
 			batchID = msg.BatchID
-			handler, ok := c.handlers[msg.Type]
+			// Messages enqueued via the low-level pgque.insert_event(...,
+			// null, null) primitive carry a nil Type. Look up the empty
+			// string handler for those rows so callers can register a
+			// fallback explicitly via consumer.Handle("", fn).
+			typeKey := ""
+			if msg.Type != nil {
+				typeKey = *msg.Type
+			}
+			handler, ok := c.handlers[typeKey]
 			if !ok {
 				if c.unknownPolicy == AckUnknown {
-					log.Printf("pgque: no handler registered for event type %q, skipping message %d (AckUnknown policy)", msg.Type, msg.MsgID)
+					log.Printf("pgque: no handler registered for event type %q, skipping message %d (AckUnknown policy)", typeKey, msg.MsgID)
 					continue
 				}
-				log.Printf("pgque: no handler registered for event type %q, nacking message %d", msg.Type, msg.MsgID)
+				log.Printf("pgque: no handler registered for event type %q, nacking message %d", typeKey, msg.MsgID)
 				if nackErr := c.backend.Nack(ctx, batchID, msg); nackErr != nil {
-					log.Printf("pgque: nack error for unhandled type %s: %v", msg.Type, nackErr)
+					log.Printf("pgque: nack error for unhandled type %s: %v", typeKey, nackErr)
 					nackFailed = true
 				}
 				continue
 			}
 			if handlerErr := c.dispatchWithRecover(ctx, handler, msg); handlerErr != nil {
-				log.Printf("pgque: handler error for %s: %v", msg.Type, handlerErr)
+				log.Printf("pgque: handler error for %s: %v", typeKey, handlerErr)
 				if nackErr := c.backend.Nack(ctx, batchID, msg); nackErr != nil {
-					log.Printf("pgque: nack error for %s: %v", msg.Type, nackErr)
+					log.Printf("pgque: nack error for %s: %v", typeKey, nackErr)
 					nackFailed = true
 				}
 				continue

--- a/clients/go/consumer_nackfail_test.go
+++ b/clients/go/consumer_nackfail_test.go
@@ -60,12 +60,14 @@ func (s *stubBackend) Nack(_ context.Context, _ int64, _ pgque.Message, _ ...pgq
 func TestConsumer_NackFailure_DoesNotAck(t *testing.T) {
 	var client *pgque.Client
 
+	typ := "no.handler.registered"
+	payload := `{"x":1}`
 	stub := &stubBackend{
 		msg: pgque.Message{
 			MsgID:   1,
 			BatchID: 42,
-			Type:    "no.handler.registered",
-			Payload: `{"x":1}`,
+			Type:    &typ,
+			Payload: &payload,
 		},
 		nackErr: errors.New("simulated nack failure"),
 	}
@@ -93,12 +95,14 @@ func TestConsumer_NackFailure_DoesNotAck(t *testing.T) {
 func TestConsumer_NackSuccess_StillAcks(t *testing.T) {
 	var client *pgque.Client
 
+	typ := "still.unknown"
+	payload := `{}`
 	stub := &stubBackend{
 		msg: pgque.Message{
 			MsgID:   1,
 			BatchID: 7,
-			Type:    "still.unknown",
-			Payload: `{}`,
+			Type:    &typ,
+			Payload: &payload,
 		},
 		nackErr: nil,
 	}
@@ -126,12 +130,14 @@ func TestConsumer_NackSuccess_StillAcks(t *testing.T) {
 func TestConsumer_AckUnknownPolicy_SkipsNack(t *testing.T) {
 	var client *pgque.Client
 
+	typ := "ignored.type"
+	payload := `{}`
 	stub := &stubBackend{
 		msg: pgque.Message{
 			MsgID:   1,
 			BatchID: 99,
-			Type:    "ignored.type",
-			Payload: `{}`,
+			Type:    &typ,
+			Payload: &payload,
 		},
 	}
 

--- a/clients/go/edge_test.go
+++ b/clients/go/edge_test.go
@@ -30,8 +30,8 @@ func TestEvent_EmptyPayload(t *testing.T) {
 	if len(msgs) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(msgs))
 	}
-	if !strings.Contains(msgs[0].Payload, "null") {
-		t.Logf("payload for nil Payload is %q (acceptable as long as Receive does not panic)", msgs[0].Payload)
+	if msgs[0].Payload == nil || !strings.Contains(*msgs[0].Payload, "null") {
+		t.Logf("payload for nil Payload is %v (acceptable as long as Receive does not panic)", msgs[0].Payload)
 	}
 	client.Ack(ctx, msgs[0].BatchID)
 }
@@ -59,8 +59,12 @@ func TestEvent_LargePayload(t *testing.T) {
 	if len(msgs) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(msgs))
 	}
-	if !strings.Contains(msgs[0].Payload, big) {
-		t.Fatalf("large payload truncated: received %d bytes, expected ≥ %d", len(msgs[0].Payload), size)
+	if msgs[0].Payload == nil || !strings.Contains(*msgs[0].Payload, big) {
+		got := 0
+		if msgs[0].Payload != nil {
+			got = len(*msgs[0].Payload)
+		}
+		t.Fatalf("large payload truncated: received %d bytes, expected ≥ %d", got, size)
 	}
 	client.Ack(ctx, msgs[0].BatchID)
 }
@@ -87,11 +91,13 @@ func TestEvent_UnicodeEverything(t *testing.T) {
 	if len(msgs) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(msgs))
 	}
-	if msgs[0].Type != "事件.test.🚀" {
-		t.Fatalf("type unicode mangled: %q", msgs[0].Type)
+	if msgs[0].Type == nil || *msgs[0].Type != "事件.test.🚀" {
+		t.Fatalf("type unicode mangled: %v", msgs[0].Type)
 	}
-	if !strings.Contains(msgs[0].Payload, "中文") || !strings.Contains(msgs[0].Payload, "🎉") {
-		t.Fatalf("payload unicode mangled: %s", msgs[0].Payload)
+	if msgs[0].Payload == nil ||
+		!strings.Contains(*msgs[0].Payload, "中文") ||
+		!strings.Contains(*msgs[0].Payload, "🎉") {
+		t.Fatalf("payload unicode mangled: %v", msgs[0].Payload)
 	}
 	client.Ack(ctx, msgs[0].BatchID)
 }
@@ -128,7 +134,9 @@ func TestEvent_TypeWithSpecialChars(t *testing.T) {
 	}
 	got := map[string]bool{}
 	for _, m := range msgs {
-		got[m.Type] = true
+		if m.Type != nil {
+			got[*m.Type] = true
+		}
 	}
 	for _, want := range cases {
 		if !got[want] {
@@ -223,8 +231,8 @@ func TestEvent_PayloadIsString(t *testing.T) {
 	if len(msgs) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(msgs))
 	}
-	if msgs[0].Payload != `"just a string"` {
-		t.Fatalf("expected JSON-quoted string payload, got %q", msgs[0].Payload)
+	if msgs[0].Payload == nil || *msgs[0].Payload != `"just a string"` {
+		t.Fatalf("expected JSON-quoted string payload, got %v", msgs[0].Payload)
 	}
 	client.Ack(ctx, msgs[0].BatchID)
 }
@@ -250,8 +258,8 @@ func TestEvent_PayloadIsArray(t *testing.T) {
 	if len(msgs) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(msgs))
 	}
-	if msgs[0].Payload != "[1, 2, 3]" {
-		t.Fatalf("expected [1, 2, 3], got %q", msgs[0].Payload)
+	if msgs[0].Payload == nil || *msgs[0].Payload != "[1, 2, 3]" {
+		t.Fatalf("expected [1, 2, 3], got %v", msgs[0].Payload)
 	}
 	client.Ack(ctx, msgs[0].BatchID)
 }

--- a/clients/go/errors_test.go
+++ b/clients/go/errors_test.go
@@ -184,7 +184,8 @@ func TestNack_AfterClose(t *testing.T) {
 			t.Fatalf("Nack after Close panicked: %v", r)
 		}
 	}()
-	msg := pgque.Message{MsgID: 1, BatchID: 1, Type: "x"}
+	typ := "x"
+	msg := pgque.Message{MsgID: 1, BatchID: 1, Type: &typ}
 	if err := client.Nack(context.Background(), 1, msg); err == nil {
 		t.Fatal("expected error from Nack after Close")
 	}

--- a/clients/go/examples_test.go
+++ b/clients/go/examples_test.go
@@ -35,7 +35,11 @@ func Example_sendReceiveAck() {
 		log.Fatal(err)
 	}
 	for _, msg := range msgs {
-		log.Printf("got %s: %s", msg.Type, msg.Payload)
+		// msg.Type and msg.Payload are *string: rows produced by the
+		// low-level pgque.insert_event(queue, null, null) primitive
+		// arrive with nil values. Pure pgque.Send producers always
+		// see non-nil pointers.
+		log.Printf("got %v: %v", msg.Type, msg.Payload)
 	}
 	if len(msgs) > 0 {
 		if err := client.Ack(ctx, msgs[0].BatchID); err != nil {
@@ -57,7 +61,7 @@ func ExampleClient_NewConsumer() {
 
 	consumer := client.NewConsumer("orders", "order_worker")
 	consumer.Handle("order.created", func(ctx context.Context, msg pgque.Message) error {
-		log.Printf("processing %s", msg.Type)
+		log.Printf("processing %v", msg.Type)
 		return nil
 	})
 

--- a/clients/go/integration_test.go
+++ b/clients/go/integration_test.go
@@ -31,8 +31,8 @@ func TestSend_DefaultEventType(t *testing.T) {
 	if len(msgs) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(msgs))
 	}
-	if msgs[0].Type != "default" {
-		t.Fatalf("expected default type, got %q", msgs[0].Type)
+	if msgs[0].Type == nil || *msgs[0].Type != "default" {
+		t.Fatalf("expected default type, got %v", msgs[0].Type)
 	}
 	if err := client.Ack(ctx, msgs[0].BatchID); err != nil {
 		t.Fatal(err)
@@ -240,8 +240,10 @@ func TestSendReceive_PayloadRoundTrip(t *testing.T) {
 	if len(msgs) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(msgs))
 	}
-	if !strings.Contains(msgs[0].Payload, `"string"`) || !strings.Contains(msgs[0].Payload, `"hello"`) {
-		t.Fatalf("payload missing expected fields: %s", msgs[0].Payload)
+	if msgs[0].Payload == nil ||
+		!strings.Contains(*msgs[0].Payload, `"string"`) ||
+		!strings.Contains(*msgs[0].Payload, `"hello"`) {
+		t.Fatalf("payload missing expected fields: %v", msgs[0].Payload)
 	}
 	client.Ack(ctx, msgs[0].BatchID)
 }
@@ -281,8 +283,8 @@ func TestSendBatch_RoundTrip(t *testing.T) {
 		t.Fatalf("expected %d messages, got %d", len(payloads), len(msgs))
 	}
 	for _, m := range msgs {
-		if m.Type != "batch.type" {
-			t.Fatalf("expected batch.type, got %q", m.Type)
+		if m.Type == nil || *m.Type != "batch.type" {
+			t.Fatalf("expected batch.type, got %v", m.Type)
 		}
 	}
 	if err := client.Ack(ctx, msgs[0].BatchID); err != nil {

--- a/clients/go/message.go
+++ b/clients/go/message.go
@@ -8,11 +8,17 @@ import "time"
 // Message is a single event delivered as part of a batch. The BatchID
 // must be passed to Client.Ack once every message in the batch has
 // been processed.
+//
+// Type and Payload are *string (not string) because the low-level PgQ
+// primitive pgque.insert_event(queue, null, null) can enqueue rows
+// whose ev_type / ev_data are SQL-NULL. Code that produced messages
+// via Client.Send always sees non-nil values; consumers reading from
+// queues that may be fed by raw insert_event calls must nil-check.
 type Message struct {
 	MsgID      int64     `json:"msg_id"`
 	BatchID    int64     `json:"batch_id"`
-	Type       string    `json:"type"`
-	Payload    string    `json:"payload"`
+	Type       *string   `json:"type"`
+	Payload    *string   `json:"payload"`
 	RetryCount *int      `json:"retry_count"`
 	CreatedAt  time.Time `json:"created_at"`
 	Extra1     *string   `json:"extra1"`

--- a/clients/go/null_event_test.go
+++ b/clients/go/null_event_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+package pgque_test
+
+import (
+	"context"
+	"testing"
+)
+
+// TestReceive_NullEvTypeAndData covers the corner case where a message
+// is enqueued via the low-level pgque.insert_event(queue, null, null)
+// primitive: the resulting row has SQL-NULL ev_type and ev_data. The
+// driver's Receive path must scan the row without errors and surface
+// the NULLs in the Message.Type and Message.Payload fields.
+//
+// Regression for NikolayS/pgque#143.
+func TestReceive_NullEvTypeAndData(t *testing.T) {
+	client := connectOrSkip(t)
+	defer client.Close()
+	queue, consumer := setupFreshQueue(t, client)
+	ctx := context.Background()
+
+	// Bypass pgque.send() and call the low-level PgQ primitive that can
+	// produce SQL-NULL ev_type / ev_data. This is the shape every driver
+	// must tolerate even though pgque.send() itself never emits it.
+	if _, err := client.Pool().Exec(ctx,
+		"select pgque.insert_event($1, null::text, null::text)", queue); err != nil {
+		t.Fatal(err)
+	}
+	tick(t, client, queue)
+
+	msgs, err := client.Receive(ctx, queue, consumer, 10)
+	if err != nil {
+		t.Fatalf("Receive returned error for NULL ev_type/ev_data: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	m := msgs[0]
+	if m.Type != nil {
+		t.Errorf("expected Type to be nil for NULL ev_type, got %q", *m.Type)
+	}
+	if m.Payload != nil {
+		t.Errorf("expected Payload to be nil for NULL ev_data, got %q", *m.Payload)
+	}
+	if err := client.Ack(ctx, m.BatchID); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/clients/go/pgque_test.go
+++ b/clients/go/pgque_test.go
@@ -127,11 +127,14 @@ func TestSendBatch(t *testing.T) {
 	}
 	sort.Slice(msgs, func(i, j int) bool { return msgs[i].MsgID < msgs[j].MsgID })
 	for i, msg := range msgs {
-		if msg.Type != "batch.test" {
-			t.Fatalf("expected type batch.test, got %s", msg.Type)
+		if msg.Type == nil || *msg.Type != "batch.test" {
+			t.Fatalf("expected type batch.test, got %v", msg.Type)
+		}
+		if msg.Payload == nil {
+			t.Fatalf("expected non-nil payload, got nil")
 		}
 		var payload map[string]int
-		if err := json.Unmarshal([]byte(msg.Payload), &payload); err != nil {
+		if err := json.Unmarshal([]byte(*msg.Payload), &payload); err != nil {
 			t.Fatal(err)
 		}
 		if payload["n"] != i+1 {
@@ -173,7 +176,7 @@ func TestSendBatchEmptyTypeDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(msgs) != 1 || msgs[0].Type != "default" {
+	if len(msgs) != 1 || msgs[0].Type == nil || *msgs[0].Type != "default" {
 		t.Fatalf("expected one default message, got %#v", msgs)
 	}
 }
@@ -190,7 +193,7 @@ func TestSendBatchNilPayloadProducesJSONNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(msgs) != 1 || msgs[0].Payload != "null" {
+	if len(msgs) != 1 || msgs[0].Payload == nil || *msgs[0].Payload != "null" {
 		t.Fatalf("expected JSON null payload, got %#v", msgs)
 	}
 }
@@ -246,8 +249,8 @@ func TestSendAndReceive(t *testing.T) {
 	if len(msgs) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(msgs))
 	}
-	if msgs[0].Type != "test.type" {
-		t.Fatalf("expected type test.type, got %s", msgs[0].Type)
+	if msgs[0].Type == nil || *msgs[0].Type != "test.type" {
+		t.Fatalf("expected type test.type, got %v", msgs[0].Type)
 	}
 
 	// Ack
@@ -567,8 +570,8 @@ func TestConsumerHandlerDispatch(t *testing.T) {
 
 	select {
 	case msg := <-received:
-		if msg.Type != "dispatch.test" {
-			t.Fatalf("expected dispatch.test, got %s", msg.Type)
+		if msg.Type == nil || *msg.Type != "dispatch.test" {
+			t.Fatalf("expected dispatch.test, got %v", msg.Type)
 		}
 	case <-ctx.Done():
 		t.Fatal("timeout waiting for message")

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -44,6 +44,10 @@ consumer = pgque.Consumer(
 
 @consumer.on("order.created")
 def handle_order(msg: pgque.Message) -> None:
+    # msg.type and msg.payload are Optional: events enqueued via the
+    # low-level pgque.insert_event(queue, null, null) primitive carry
+    # type=None / payload=None. Pure Client.send producers always see
+    # non-None values.
     print(f"got {msg.type}: {msg.payload}")
 
 # Optional: catch-all handler for types with no specific handler.

--- a/clients/python/pgque/consumer.py
+++ b/clients/python/pgque/consumer.py
@@ -241,7 +241,13 @@ class Consumer:
             nack_failed = False
 
             for msg in msgs:
-                handler = self._handlers.get(msg.type, self._default_handler)
+                # msg.type is Optional[str]: rows enqueued via the
+                # low-level pgque.insert_event(queue, null, null)
+                # primitive arrive with type=None. Look up handlers
+                # using the empty string for those rows so callers
+                # can register a fallback explicitly.
+                lookup_type = msg.type if msg.type is not None else ""
+                handler = self._handlers.get(lookup_type, self._default_handler)
                 if handler is None:
                     if self._unknown_handler == "ack":
                         self._log.warning(

--- a/clients/python/pgque/types.py
+++ b/clients/python/pgque/types.py
@@ -16,17 +16,26 @@ class Message:
     Maps to the ``pgque.message`` composite type:
         msg_id      -- ev_id
         batch_id    -- batch containing this message
-        type        -- ev_type
-        payload     -- ev_data (jsonb auto-decoded by psycopg, otherwise text)
+        type        -- ev_type (``None`` if enqueued via raw
+                       ``pgque.insert_event(queue, null, null)``)
+        payload     -- ev_data (jsonb auto-decoded by psycopg, otherwise
+                       text; ``None`` if raw insert_event passed null)
         retry_count -- ev_retry (None for first delivery)
         created_at  -- ev_time
         extra1..4   -- ev_extra1..ev_extra4
+
+    ``type`` and ``payload`` are ``Optional`` because the low-level PgQ
+    primitive ``pgque.insert_event(queue, null, null)`` can produce rows
+    whose ``ev_type`` and ``ev_data`` are SQL-NULL. ``Client.send`` and
+    ``Client.send_batch`` always emit non-NULL values, so most consumers
+    will never observe ``None`` here -- but consumers that read from
+    queues fed by raw ``insert_event`` calls must handle it.
     """
 
     msg_id: int
     batch_id: int
-    type: str
-    payload: Any
+    type: Optional[str]
+    payload: Optional[Any]
     retry_count: Optional[int]
     created_at: datetime
     extra1: Optional[str] = None

--- a/clients/python/tests/test_null_event.py
+++ b/clients/python/tests/test_null_event.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+"""Regression: NULL ev_type / ev_data round-trip cleanly through receive.
+
+The low-level PgQ primitive ``pgque.insert_event(queue, null, null)`` can
+produce a row with SQL-NULL ``ev_type`` and ``ev_data``. The driver's
+``Message`` type and row mapper must tolerate that shape -- the row must
+be returned with ``type`` and ``payload`` set to ``None``, the type
+annotations must declare those fields nullable, and ``ack`` / ``nack``
+must still work on the surrounding batch.
+
+Regression for NikolayS/pgque#143.
+"""
+
+import typing
+
+import pgque
+from pgque.types import Message
+
+
+def test_message_type_and_payload_are_optional():
+    """The Message dataclass must declare ``type`` and ``payload`` as Optional."""
+    hints = typing.get_type_hints(Message)
+    type_args = typing.get_args(hints["type"])
+    payload_args = typing.get_args(hints["payload"])
+    assert type(None) in type_args, (
+        f"Message.type must be Optional, got {hints['type']!r}"
+    )
+    assert type(None) in payload_args, (
+        f"Message.payload must be Optional, got {hints['payload']!r}"
+    )
+
+
+def test_receive_null_ev_type_and_data(conn, setup_queue):
+    queue, consumer = setup_queue
+    client = pgque.PgqueClient(conn)
+
+    # Bypass pgque.send(): call the low-level primitive directly so the
+    # row has SQL-NULL ev_type and ev_data.
+    conn.execute(
+        "select pgque.insert_event(%s, null::text, null::text)", (queue,)
+    )
+    conn.commit()
+    conn.execute("select pgque.force_tick(%s)", (queue,))
+    conn.execute("select pgque.ticker(%s)", (queue,))
+    conn.commit()
+
+    msgs = client.receive(queue, consumer, max_messages=10)
+    assert len(msgs) == 1
+    m = msgs[0]
+    assert m.type is None, f"expected None type, got {m.type!r}"
+    assert m.payload is None, f"expected None payload, got {m.payload!r}"
+
+    # ack must still work on the batch.
+    client.ack(m.batch_id)
+    conn.commit()

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -43,9 +43,14 @@ try {
   console.log('published', eventId, batchIds);
 
   // High-level consumer with per-event-type dispatch.
-  // msg.payload is raw JSON text — call JSON.parse() to get the object back.
+  // msg.type and msg.payload are `string | null`: rows enqueued via the
+  // low-level pgque.insert_event(queue, null, null) primitive arrive
+  // with both fields set to null. Pure Client.send producers always
+  // see non-null strings, so a single null check before JSON.parse is
+  // enough for typical apps.
   const consumer = client.newConsumer('orders', 'order_worker');
   consumer.handle('order.created', async (msg) => {
+    if (msg.payload === null) return;
     const data = JSON.parse(msg.payload) as { id: number };
     console.log('got', msg.type, data);
   });

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -32,12 +32,17 @@ function isPgError(e: unknown): e is PgError {
   return e instanceof Error && typeof (e as PgError).code === 'string';
 }
 
-/** Internal: row shape returned by `pgque.receive` after type parsers run. */
+/** Internal: row shape returned by `pgque.receive` after type parsers run.
+ *
+ * `type` and `payload` are nullable because the low-level
+ * `pgque.insert_event(queue, null, null)` primitive can produce rows
+ * whose `ev_type` / `ev_data` are SQL-NULL.
+ */
 interface RawMessageRow {
   msg_id: bigint;
   batch_id: bigint;
-  type: string;
-  payload: string;
+  type: string | null;
+  payload: string | null;
   retry_count: number | null;
   created_at: Date;
   extra1: string | null;

--- a/clients/typescript/src/consumer.ts
+++ b/clients/typescript/src/consumer.ts
@@ -76,17 +76,22 @@ export class Consumer {
       let anyNackFailed = false;
       for (const msg of msgs) {
         batchId = msg.batchId;
-        const handler = this.handlers.get(msg.type);
+        // msg.type is `string | null`: rows enqueued via the low-level
+        // pgque.insert_event(queue, null, null) primitive arrive with
+        // type=null. Look up handlers using the empty string for those
+        // rows so callers can register a fallback explicitly.
+        const lookupType = msg.type ?? '';
+        const handler = this.handlers.get(lookupType);
         if (!handler) {
           if (this.unknownHandlerPolicy === 'ack') {
             this.logger.warn(
-              `pgque: no handler registered for event type "${msg.type}", acking msg ${msg.msgId} (unknownHandlerPolicy='ack')`,
+              `pgque: no handler registered for event type "${lookupType}", acking msg ${msg.msgId} (unknownHandlerPolicy='ack')`,
             );
             // Fall through; the batch ack at the end of the loop covers it.
             continue;
           }
           this.logger.warn(
-            `pgque: no handler registered for event type "${msg.type}", nacking msg ${msg.msgId}`,
+            `pgque: no handler registered for event type "${lookupType}", nacking msg ${msg.msgId}`,
           );
           if (!(await this.tryNack(batchId, msg, 'unknown event type'))) {
             anyNackFailed = true;
@@ -96,7 +101,7 @@ export class Consumer {
         try {
           await handler(msg);
         } catch (err) {
-          this.logger.error(`pgque: handler error for "${msg.type}": ${formatErr(err)}`);
+          this.logger.error(`pgque: handler error for "${lookupType}": ${formatErr(err)}`);
           if (!(await this.tryNack(batchId, msg, 'handler error'))) {
             anyNackFailed = true;
           }

--- a/clients/typescript/src/smoke.ts
+++ b/clients/typescript/src/smoke.ts
@@ -44,6 +44,9 @@ async function run(): Promise<void> {
       throw new Error(`expected 1 message, got ${msgs.length}`);
     }
     const msg = msgs[0]!;
+    if (msg.payload === null) {
+      throw new Error('unexpected null payload from Client.send');
+    }
     const parsed = JSON.parse(msg.payload) as { ok: boolean };
     if (!parsed.ok) {
       throw new Error(`unexpected payload: ${msg.payload}`);

--- a/clients/typescript/src/types.ts
+++ b/clients/typescript/src/types.ts
@@ -7,13 +7,19 @@
  *
  * `msgId` and `batchId` are `bigint` (JavaScript native) because the
  * underlying PostgreSQL `bigint` columns can exceed `Number.MAX_SAFE_INTEGER`.
+ *
+ * `type` and `payload` are nullable because PgQ's low-level
+ * `pgque.insert_event(queue, null, null)` primitive can enqueue rows
+ * whose `ev_type` / `ev_data` are SQL-NULL. Code that produced events
+ * via `Client.send` always sees non-null strings; consumers reading
+ * from queues fed by raw `insert_event` calls must null-check.
  */
 export interface Message {
   msgId: bigint;
   batchId: bigint;
-  type: string;
+  type: string | null;
   /** Raw `ev_data` text. Caller may `JSON.parse()` if the producer used `Event.payload`. */
-  payload: string;
+  payload: string | null;
   /** Number of prior retry attempts. `null` on the first delivery. */
   retryCount: number | null;
   createdAt: Date;

--- a/clients/typescript/test/client.test.ts
+++ b/clients/typescript/test/client.test.ts
@@ -53,7 +53,7 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
     expect(msgs).toHaveLength(1);
     const m = msgs[0]!;
     expect(m.type).toBe('created');
-    expect(JSON.parse(m.payload)).toEqual({ id: 42, hello: 'world' });
+    expect(JSON.parse(m.payload!)).toEqual({ id: 42, hello: 'world' });
     expect(typeof m.msgId).toBe('bigint');
     expect(typeof m.batchId).toBe('bigint');
     expect(m.createdAt).toBeInstanceOf(Date);
@@ -81,7 +81,7 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
     const msgs = await env.client.receive(env.queue, env.consumer, 10);
     expect(msgs).toHaveLength(3);
     expect(msgs.map((m) => m.type)).toEqual(['batch.test', 'batch.test', 'batch.test']);
-    expect(msgs.map((m) => JSON.parse(m.payload))).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
+    expect(msgs.map((m) => JSON.parse(m.payload!))).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
     await env.client.ack(msgs[0]!.batchId);
   });
 
@@ -195,7 +195,7 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
     for (const [type, payload] of cases) {
       const m = byType.get(type);
       expect(m, `missing message of type ${type}`).toBeDefined();
-      expect(JSON.parse(m!.payload)).toEqual(payload);
+      expect(JSON.parse(m!.payload!)).toEqual(payload);
     }
     await env.client.ack(msgs[0]!.batchId);
   });
@@ -211,7 +211,7 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
     expect(m!.type).toBe('undef.explicit');
     // Strong assertion: the stored value is the JSON literal `null`.
     expect(m!.payload).toBe('null');
-    expect(JSON.parse(m!.payload)).toBeNull();
+    expect(JSON.parse(m!.payload!)).toBeNull();
     await env.client.ack(m!.batchId);
   });
 
@@ -223,7 +223,7 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
     expect(m).toBeDefined();
     expect(m!.type).toBe('undef.omitted');
     expect(m!.payload).toBe('null');
-    expect(JSON.parse(m!.payload)).toBeNull();
+    expect(JSON.parse(m!.payload!)).toBeNull();
     await env.client.ack(m!.batchId);
   });
 
@@ -236,7 +236,7 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
     const [m] = await env.client.receive(env.queue, env.consumer, 10);
     expect(m).toBeDefined();
     expect(m!.type).toBe('undef.nested');
-    expect(JSON.parse(m!.payload)).toEqual({ a: 1 });
+    expect(JSON.parse(m!.payload!)).toEqual({ a: 1 });
     await env.client.ack(m!.batchId);
   });
 

--- a/clients/typescript/test/consumer.test.ts
+++ b/clients/typescript/test/consumer.test.ts
@@ -33,11 +33,11 @@ describe('Consumer (env-gated)', () => {
     });
     const seen: Array<{ type: string; v: number }> = [];
     consumer.handle('a', async (msg) => {
-      const p = JSON.parse(msg.payload) as { v: number };
+      const p = JSON.parse(msg.payload!) as { v: number };
       seen.push({ type: 'a', v: p.v });
     });
     consumer.handle('b', async (msg) => {
-      const p = JSON.parse(msg.payload) as { v: number };
+      const p = JSON.parse(msg.payload!) as { v: number };
       seen.push({ type: 'b', v: p.v });
     });
 

--- a/clients/typescript/test/null_event.test.ts
+++ b/clients/typescript/test/null_event.test.ts
@@ -1,0 +1,66 @@
+// pgque -- TypeScript client for PgQue
+// Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { Message } from '../src/types.js';
+import { TEST_DSN, advanceQueue, setupTestQueue, teardownTestQueue, type TestEnv } from './helpers.js';
+
+const skipIfNoDb = TEST_DSN ? it : it.skip;
+
+// Type-level guard: Message.type and Message.payload must accept null.
+// If either field is `string` (non-nullable), assigning null below is a
+// TypeScript error and `tsc --noEmit` fails -- this is the failing test
+// that drives the type-shape change.
+//
+// Regression for NikolayS/pgque#143.
+type _AssertNullableType = Message extends { type: infer T }
+  ? null extends T
+    ? true
+    : never
+  : never;
+type _AssertNullablePayload = Message extends { payload: infer P }
+  ? null extends P
+    ? true
+    : never
+  : never;
+const _typeNullable: _AssertNullableType = true;
+const _payloadNullable: _AssertNullablePayload = true;
+void _typeNullable;
+void _payloadNullable;
+
+// Regression for NikolayS/pgque#143: the low-level PgQ primitive
+// pgque.insert_event(queue, null, null) can produce a row with
+// SQL-NULL ev_type and ev_data. The driver's Message type and row
+// mapper must tolerate that shape: type and payload come back as
+// null, and ack/nack still work on the surrounding batch.
+describe('Receive: NULL ev_type / ev_data (#143)', () => {
+  let env: TestEnv;
+
+  beforeEach(async () => {
+    if (!TEST_DSN) return;
+    env = await setupTestQueue();
+  });
+
+  afterEach(async () => {
+    if (!TEST_DSN) return;
+    await teardownTestQueue(env);
+  });
+
+  skipIfNoDb('returns null type and payload without throwing', async () => {
+    // Bypass send() and call the low-level primitive that yields
+    // SQL-NULL ev_type / ev_data.
+    await env.client.rawPool.query(
+      'select pgque.insert_event($1, null::text, null::text)',
+      [env.queue],
+    );
+    await advanceQueue(env.client, env.queue);
+
+    const msgs = await env.client.receive(env.queue, env.consumer, 10);
+    expect(msgs).toHaveLength(1);
+    const m = msgs[0]!;
+    expect(m.type).toBeNull();
+    expect(m.payload).toBeNull();
+
+    await env.client.ack(m.batchId);
+  });
+});


### PR DESCRIPTION
Closes #143.

## Chosen policy

**Option 2 — robust PgQ-compatible.** Each driver's `Message` type now models `type` and `payload` as nullable to match the `pgque.message` SQL composite. PgQue is explicitly a thin wrapper over PgQ primitives (`SPECx.md` §1.3, `CLAUDE.md` Key Design Rule #3); silently rejecting rows produced by `pgque.insert_event(queue, null, null)` would contradict that stance and pessimize the consumer side for queues fed by raw inserts (LISTEN/NOTIFY routers, foreign-data triggers, ad-hoc admin tooling).

Pure `Client.send` / `client.send_batch` producers are unaffected — they always emit non-null type/payload, so existing happy-path code only needs a one-line null guard before `JSON.parse`. README quickstarts updated accordingly.

## Breaking change

This changes the type-shape of `Message.type` / `Message.payload` across all three drivers. v0.2.0 has not shipped, so the unreleased shape is still in flux — but downstream consumers that already adopted the v0.2.0 client previews will need to nil-check before deref / `JSON.parse`.

## Before / after type signatures

| Driver | Before | After |
|---|---|---|
| Go | `Type string` / `Payload string` | `Type *string` / `Payload *string` |
| Python | `type: str` / `payload: Any` | `type: Optional[str]` / `payload: Optional[Any]` |
| TypeScript | `type: string` / `payload: string` | `type: string \| null` / `payload: string \| null` |

Each driver's Consumer dispatch loop additionally routes null-typed rows through the empty-string handler key (`consumer.Handle("", fn)` in Go, `@consumer.on("")` in Python, `consumer.handle("", fn)` in TS) so applications can opt in to handling raw `insert_event` events explicitly.

## Testing evidence

All test runs against a live Postgres 16 with `PGQUE_TEST_DSN` set.

### Go (`go test -count=1 ./...`)

```
=== RUN   TestReceive_NullEvTypeAndData
--- PASS: TestReceive_NullEvTypeAndData (0.03s)
... 35 other tests ...
PASS
ok  	github.com/NikolayS/pgque-go	12.510s
```

### Python (`pytest`)

```
tests/test_null_event.py::test_message_type_and_payload_are_optional PASSED
tests/test_null_event.py::test_receive_null_ev_type_and_data PASSED
... 54 other tests ...
============================= 56 passed in 28.31s ==============================
```

### TypeScript (`npx vitest --run` + `tsc --noEmit -p tsconfig.test.json`)

```
 ✓ test/client.test.ts (25 tests) 1028ms
 ✓ test/consumer.test.ts (9 tests) 1260ms
 ✓ test/nack.test.ts (3 tests) 177ms
 ✓ test/null_event.test.ts (1 test) 78ms

 Test Files  4 passed (4)
      Tests  38 passed (38)
```

`npm run check` (full type-check) also passes.

## Coordination

Stayed off the produce path (`clients/typescript/src/client.ts` `send()`) per the issue note — that's the territory of the parallel #149 work. All edits here are on the receive path: `Message` type, row mapper, consumer dispatch.

## Manual verification

```sh
psql -c "select pgque.insert_event('q', null::text, null::text)"
# then call client.Receive / client.receive / client.receive
# rows arrive with type=null and payload=null; ack still works.
```

DO NOT MERGE — draft for maintainer review.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TwKyarGpkGKN8LY1CV8dsG)_