### PR TITLE
fix(clients/go): typed errors for cross-driver parity (#140)

### DIFF
--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -120,7 +120,7 @@ case errors.Is(err, pgque.ErrConnection):
     // pool closed, network drop, bad DSN
 case err != nil:
     // generic SQL error — extract SQLSTATE if needed
-    var sqlErr *pgque.SqlError
+    var sqlErr *pgque.SQLError
     if errors.As(err, &sqlErr) {
         log.Printf("pgque %s failed: %s [SQLSTATE %s]",
             sqlErr.Op, sqlErr.Err, sqlErr.SQLSTATE)
@@ -128,13 +128,14 @@ case err != nil:
 }
 ```
 
-`context.Canceled` and `context.DeadlineExceeded` pass through unwrapped,
-so `errors.Is(err, context.Canceled)` continues to work.
+`context.Canceled` and `context.DeadlineExceeded` are preserved through
+the chain, so `errors.Is(err, context.Canceled)` continues to work.
 
 The same typed surface is exposed by the Python client (`PgqueQueueNotFound`,
 `PgqueConsumerNotFound`, `PgqueBatchNotFound`, `PgqueConnectionError`) and
 TypeScript client (`PgqueQueueNotFoundError`, `PgqueConsumerNotFoundError`,
-`PgqueSqlError`).
+`PgqueSqlError`). Go uses the standard acronym-uppercase convention
+(`SQLError` rather than `SqlError`).
 
 ## Tests
 

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -102,6 +102,40 @@ so PgQue redelivers it on the next Receive. Acking a batch whose Nack
 failed would silently drop the failure information — the Go consumer
 prefers redelivery and lets the at-least-once retry path do its job.
 
+## Typed errors
+
+Client methods wrap PostgreSQL-side failures so callers can route on
+recoverable conditions with `errors.Is`:
+
+```go
+_, err := client.Send(ctx, "orders", pgque.Event{Type: "x", Payload: nil})
+switch {
+case errors.Is(err, pgque.ErrQueueNotFound):
+    // create the queue, retry
+case errors.Is(err, pgque.ErrConsumerNotFound):
+    // re-register the consumer
+case errors.Is(err, pgque.ErrBatchNotFound):
+    // batch already finished — usually safe to ignore
+case errors.Is(err, pgque.ErrConnection):
+    // pool closed, network drop, bad DSN
+case err != nil:
+    // generic SQL error — extract SQLSTATE if needed
+    var sqlErr *pgque.SqlError
+    if errors.As(err, &sqlErr) {
+        log.Printf("pgque %s failed: %s [SQLSTATE %s]",
+            sqlErr.Op, sqlErr.Err, sqlErr.SQLSTATE)
+    }
+}
+```
+
+`context.Canceled` and `context.DeadlineExceeded` pass through unwrapped,
+so `errors.Is(err, context.Canceled)` continues to work.
+
+The same typed surface is exposed by the Python client (`PgqueQueueNotFound`,
+`PgqueConsumerNotFound`, `PgqueBatchNotFound`, `PgqueConnectionError`) and
+TypeScript client (`PgqueQueueNotFoundError`, `PgqueConsumerNotFoundError`,
+`PgqueSqlError`).
+
 ## Tests
 
 The integration tests require a running PostgreSQL with the PgQue schema

--- a/clients/go/errors.go
+++ b/clients/go/errors.go
@@ -36,10 +36,10 @@ var (
 	ErrBatchNotFound = errors.New("pgque: batch not found")
 )
 
-// SqlError wraps a PostgreSQL-side failure with the SQLSTATE code and the
+// SQLError wraps a PostgreSQL-side failure with the SQLSTATE code and the
 // op label that produced it. It is returned for SQL errors that do not
 // match any of the typed sentinels above. Use errors.As to extract.
-type SqlError struct {
+type SQLError struct {
 	// Op identifies the client-side operation that produced the error
 	// (e.g. "send", "receive", "ack", "nack", "send batch", "connect").
 	Op string
@@ -52,16 +52,16 @@ type SqlError struct {
 	Err error
 }
 
-func (e *SqlError) Error() string {
+func (e *SQLError) Error() string {
 	if e.SQLSTATE != "" {
 		return fmt.Sprintf("pgque: %s: %s [SQLSTATE %s]", e.Op, e.Err, e.SQLSTATE)
 	}
 	return fmt.Sprintf("pgque: %s: %s", e.Op, e.Err)
 }
 
-func (e *SqlError) Unwrap() error { return e.Err }
+func (e *SQLError) Unwrap() error { return e.Err }
 
-// wrapSqlError maps a raw error from pgx into a typed pgque error.
+// wrapSQLError maps a raw error from pgx into a typed pgque error.
 //
 // The caller passes the operation label (e.g. "send", "receive") and the
 // underlying error. The returned error is suitable for errors.Is /
@@ -73,12 +73,12 @@ func (e *SqlError) Unwrap() error { return e.Err }
 //  2. context.Canceled / context.DeadlineExceeded → returned as-is wrapped
 //     with the op label so context-aware callers can still match.
 //  3. *pgconn.PgError with a recognized message fragment → wrapped with
-//     the matching sentinel and a *SqlError that carries SQLSTATE.
+//     the matching sentinel and a *SQLError that carries SQLSTATE.
 //  4. *pgconn.PgError without a recognized fragment → wrapped in
-//     *SqlError with SQLSTATE.
+//     *SQLError with SQLSTATE.
 //  5. Anything else (typically connection-level pgx failures) → wrapped
 //     with ErrConnection so errors.Is(err, ErrConnection) matches.
-func wrapSqlError(op string, err error) error {
+func wrapSQLError(op string, err error) error {
 	if err == nil {
 		return nil
 	}
@@ -92,7 +92,7 @@ func wrapSqlError(op string, err error) error {
 
 	var pgErr *pgconn.PgError
 	if errors.As(err, &pgErr) {
-		sqlErr := &SqlError{Op: op, SQLSTATE: pgErr.Code, Err: err}
+		sqlErr := &SQLError{Op: op, SQLSTATE: pgErr.Code, Err: err}
 		if sentinel := classifyPgMessage(pgErr.Message); sentinel != nil {
 			return fmt.Errorf("%w: %w", sentinel, sqlErr)
 		}
@@ -102,6 +102,25 @@ func wrapSqlError(op string, err error) error {
 	// Non-PgError: typically a pgx connection-level failure (pool closed,
 	// network drop, bad DSN). Tag as ErrConnection.
 	return fmt.Errorf("pgque: %s: %w: %w", op, ErrConnection, err)
+}
+
+// wrapConnectError wraps a connect-time error so callers can match
+// ErrConnection AND extract *SQLError if the underlying failure is a
+// *pgconn.PgError (e.g. wrong password 28P01, missing database 3D000,
+// pg_hba rejection 28000). Without this helper, wrapSQLError would expose
+// SQLSTATE for *pgconn.PgError but skip the ErrConnection tag, while
+// non-PgError failures would get ErrConnection but no SQLSTATE — the two
+// kinds of connect failure would be inconsistent.
+func wrapConnectError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		sqlErr := &SQLError{Op: "connect", SQLSTATE: pgErr.Code, Err: err}
+		return fmt.Errorf("pgque: connect: %w: %w", ErrConnection, sqlErr)
+	}
+	return fmt.Errorf("pgque: connect: %w: %w", ErrConnection, err)
 }
 
 // classifyPgMessage maps the message text of a PgError to one of the typed

--- a/clients/go/errors.go
+++ b/clients/go/errors.go
@@ -1,0 +1,132 @@
+// pgque-go -- Go client for PgQue
+// Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+package pgque
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// Sentinel errors. Use errors.Is to match.
+//
+// These mirror the typed exceptions exposed by the Python and TypeScript
+// clients (PgqueQueueNotFound, PgqueConsumerNotFound, PgqueBatchNotFound,
+// PgqueConnectionError) so application code can write equivalent
+// recovery logic across the three drivers.
+var (
+	// ErrConnection is returned when the underlying PostgreSQL connection
+	// cannot be established or has dropped.
+	ErrConnection = errors.New("pgque: connection error")
+
+	// ErrQueueNotFound is returned when a SQL call references a queue
+	// that does not exist.
+	ErrQueueNotFound = errors.New("pgque: queue not found")
+
+	// ErrConsumerNotFound is returned when a SQL call references a
+	// consumer that is not registered on the queue.
+	ErrConsumerNotFound = errors.New("pgque: consumer not registered")
+
+	// ErrBatchNotFound is returned when a SQL call references a batch ID
+	// that does not exist or has already been finished.
+	ErrBatchNotFound = errors.New("pgque: batch not found")
+)
+
+// SqlError wraps a PostgreSQL-side failure with the SQLSTATE code and the
+// op label that produced it. It is returned for SQL errors that do not
+// match any of the typed sentinels above. Use errors.As to extract.
+type SqlError struct {
+	// Op identifies the client-side operation that produced the error
+	// (e.g. "send", "receive", "ack", "nack", "send batch", "connect").
+	Op string
+
+	// SQLSTATE is the 5-character PostgreSQL error code if the underlying
+	// error is a *pgconn.PgError; otherwise empty.
+	SQLSTATE string
+
+	// Err is the underlying error (typically *pgconn.PgError).
+	Err error
+}
+
+func (e *SqlError) Error() string {
+	if e.SQLSTATE != "" {
+		return fmt.Sprintf("pgque: %s: %s [SQLSTATE %s]", e.Op, e.Err, e.SQLSTATE)
+	}
+	return fmt.Sprintf("pgque: %s: %s", e.Op, e.Err)
+}
+
+func (e *SqlError) Unwrap() error { return e.Err }
+
+// wrapSqlError maps a raw error from pgx into a typed pgque error.
+//
+// The caller passes the operation label (e.g. "send", "receive") and the
+// underlying error. The returned error is suitable for errors.Is /
+// errors.As: callers can match the typed sentinels above, the underlying
+// pgconn.PgError, or context.Canceled / context.DeadlineExceeded.
+//
+// Mapping precedence:
+//  1. nil → nil.
+//  2. context.Canceled / context.DeadlineExceeded → returned as-is wrapped
+//     with the op label so context-aware callers can still match.
+//  3. *pgconn.PgError with a recognized message fragment → wrapped with
+//     the matching sentinel and a *SqlError that carries SQLSTATE.
+//  4. *pgconn.PgError without a recognized fragment → wrapped in
+//     *SqlError with SQLSTATE.
+//  5. Anything else (typically connection-level pgx failures) → wrapped
+//     with ErrConnection so errors.Is(err, ErrConnection) matches.
+func wrapSqlError(op string, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// Preserve context-cancellation and deadline-exceeded so callers can
+	// still match them with errors.Is(err, context.Canceled) /
+	// errors.Is(err, context.DeadlineExceeded).
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("pgque: %s: %w", op, err)
+	}
+
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		sqlErr := &SqlError{Op: op, SQLSTATE: pgErr.Code, Err: err}
+		if sentinel := classifyPgMessage(pgErr.Message); sentinel != nil {
+			return fmt.Errorf("%w: %w", sentinel, sqlErr)
+		}
+		return sqlErr
+	}
+
+	// Non-PgError: typically a pgx connection-level failure (pool closed,
+	// network drop, bad DSN). Tag as ErrConnection.
+	return fmt.Errorf("pgque: %s: %w: %w", op, ErrConnection, err)
+}
+
+// classifyPgMessage maps the message text of a PgError to one of the typed
+// sentinels, or nil if no fragment matches.
+//
+// PgQue raises these conditions via plpgsql `raise exception '...'` which
+// produces SQLSTATE P0001 — the message text is the only signal, so the
+// match is by recognizable substrings drawn from sql/pgque.sql. Matching
+// is case-insensitive.
+func classifyPgMessage(msg string) error {
+	low := strings.ToLower(msg)
+	switch {
+	case strings.Contains(low, "queue not found"),
+		strings.Contains(low, "no such queue"),
+		strings.Contains(low, "no such event queue"),
+		strings.Contains(low, "event queue not found"),
+		strings.Contains(low, "event queue not created"):
+		return ErrQueueNotFound
+	case strings.Contains(low, "consumer not registered"),
+		strings.Contains(low, "consumer not found"),
+		strings.Contains(low, "not subscriber to queue"):
+		return ErrConsumerNotFound
+	case strings.Contains(low, "batch not found"),
+		strings.Contains(low, "cannot find data for batch"):
+		return ErrBatchNotFound
+	}
+	return nil
+}

--- a/clients/go/errors_internal_test.go
+++ b/clients/go/errors_internal_test.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+// White-box tests for the typed-error layer. Lives in package pgque so
+// it can drive classifyPgMessage and wrapSQLError directly without a
+// running PostgreSQL.
+
+package pgque
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// TestClassifyPgMessage_AllFragments ensures every message fragment we
+// match against sql/pgque.sql maps to the expected sentinel. Locks the
+// classifier against silent drift if a typo is introduced.
+func TestClassifyPgMessage_AllFragments(t *testing.T) {
+	cases := []struct {
+		msg  string
+		want error
+	}{
+		// ErrQueueNotFound fragments
+		{"queue not found", ErrQueueNotFound},
+		{"queue not found: orders", ErrQueueNotFound},
+		{"Queue not found", ErrQueueNotFound},
+		{"no such queue", ErrQueueNotFound},
+		{"No such event queue", ErrQueueNotFound},
+		{"Event queue not found", ErrQueueNotFound},
+		{"Event queue not created yet", ErrQueueNotFound},
+
+		// ErrConsumerNotFound fragments
+		{"consumer not registered", ErrConsumerNotFound},
+		{"consumer not found", ErrConsumerNotFound},
+		{"Not subscriber to queue: orders/worker", ErrConsumerNotFound},
+
+		// ErrBatchNotFound fragments
+		{"batch not found", ErrBatchNotFound},
+		{"Cannot find data for batch 42", ErrBatchNotFound},
+
+		// No-match cases
+		{"some unrelated error", nil},
+		{"", nil},
+	}
+
+	for _, tc := range cases {
+		got := classifyPgMessage(tc.msg)
+		if got != tc.want {
+			t.Errorf("classifyPgMessage(%q) = %v, want %v", tc.msg, got, tc.want)
+		}
+	}
+}
+
+// TestWrapSQLError_NoSentinelMatch covers the *pgconn.PgError-without-
+// recognized-fragment branch: the result must be a plain *SQLError that
+// errors.As can extract, with SQLSTATE preserved and no sentinel chain.
+func TestWrapSQLError_NoSentinelMatch(t *testing.T) {
+	pgErr := &pgconn.PgError{
+		Code:    "42601", // syntax_error
+		Message: "syntax error at or near \"frob\"",
+	}
+	wrapped := wrapSQLError("send", pgErr)
+
+	var sqlErr *SQLError
+	if !errors.As(wrapped, &sqlErr) {
+		t.Fatalf("expected errors.As to extract *SQLError, got: %v", wrapped)
+	}
+	if sqlErr.SQLSTATE != "42601" {
+		t.Errorf("expected SQLSTATE=42601, got %q", sqlErr.SQLSTATE)
+	}
+	if sqlErr.Op != "send" {
+		t.Errorf("expected Op=send, got %q", sqlErr.Op)
+	}
+	for _, sentinel := range []error{ErrQueueNotFound, ErrConsumerNotFound, ErrBatchNotFound, ErrConnection} {
+		if errors.Is(wrapped, sentinel) {
+			t.Errorf("expected wrapped error to NOT match %v, but it did", sentinel)
+		}
+	}
+}
+
+// TestWrapSQLError_SentinelChain covers the recognized-fragment branch:
+// the result must satisfy BOTH errors.Is(err, ErrXxx) AND
+// errors.As(err, &sqlErr) — the dual-match guarantee documented on the
+// wrapping helper.
+func TestWrapSQLError_SentinelChain(t *testing.T) {
+	pgErr := &pgconn.PgError{
+		Code:    "P0001",
+		Message: "queue not found: orders",
+	}
+	wrapped := wrapSQLError("send", pgErr)
+
+	if !errors.Is(wrapped, ErrQueueNotFound) {
+		t.Errorf("expected errors.Is(err, ErrQueueNotFound) to be true, got: %v", wrapped)
+	}
+	var sqlErr *SQLError
+	if !errors.As(wrapped, &sqlErr) {
+		t.Errorf("expected errors.As to also extract *SQLError, got: %v", wrapped)
+	}
+	if sqlErr != nil && sqlErr.SQLSTATE != "P0001" {
+		t.Errorf("expected SQLSTATE=P0001, got %q", sqlErr.SQLSTATE)
+	}
+}
+
+// TestWrapConnectError_PgError covers connect-time *pgconn.PgError such
+// as 28P01 (wrong password) or 3D000 (missing database): the chain must
+// match ErrConnection AND extract *SQLError with SQLSTATE.
+func TestWrapConnectError_PgError(t *testing.T) {
+	pgErr := &pgconn.PgError{
+		Code:    "28P01",
+		Message: "password authentication failed for user \"alice\"",
+	}
+	wrapped := wrapConnectError(pgErr)
+
+	if !errors.Is(wrapped, ErrConnection) {
+		t.Errorf("expected errors.Is(err, ErrConnection) to be true, got: %v", wrapped)
+	}
+	var sqlErr *SQLError
+	if !errors.As(wrapped, &sqlErr) {
+		t.Errorf("expected errors.As to extract *SQLError, got: %v", wrapped)
+	}
+	if sqlErr != nil {
+		if sqlErr.SQLSTATE != "28P01" {
+			t.Errorf("expected SQLSTATE=28P01, got %q", sqlErr.SQLSTATE)
+		}
+		if sqlErr.Op != "connect" {
+			t.Errorf("expected Op=connect, got %q", sqlErr.Op)
+		}
+	}
+}
+
+// TestWrapConnectError_NonPgError covers connect-time non-PgError such
+// as a parse error or network drop: the chain must match ErrConnection
+// without exposing a *SQLError (no SQLSTATE to extract).
+func TestWrapConnectError_NonPgError(t *testing.T) {
+	wrapped := wrapConnectError(errors.New("dial tcp: connection refused"))
+
+	if !errors.Is(wrapped, ErrConnection) {
+		t.Errorf("expected errors.Is(err, ErrConnection) to be true, got: %v", wrapped)
+	}
+	var sqlErr *SQLError
+	if errors.As(wrapped, &sqlErr) {
+		t.Errorf("expected errors.As to NOT extract *SQLError for non-PgError, got: %+v", sqlErr)
+	}
+}

--- a/clients/go/pgque.go
+++ b/clients/go/pgque.go
@@ -28,11 +28,11 @@ type Client struct {
 func Connect(ctx context.Context, dsn string) (*Client, error) {
 	pool, err := pgxpool.New(ctx, dsn)
 	if err != nil {
-		return nil, fmt.Errorf("pgque: connect: %w: %w", ErrConnection, err)
+		return nil, wrapConnectError(err)
 	}
 	if err := pool.Ping(ctx); err != nil {
 		pool.Close()
-		return nil, fmt.Errorf("pgque: connect: %w: %w", ErrConnection, err)
+		return nil, wrapConnectError(err)
 	}
 	return &Client{pool: pool}, nil
 }
@@ -63,7 +63,7 @@ func (c *Client) Send(ctx context.Context, queue string, ev Event) (int64, error
 		"SELECT pgque.send($1, $2, $3::jsonb)", queue, typ, string(payload),
 	).Scan(&eid)
 	if err != nil {
-		return 0, wrapSqlError("send", err)
+		return 0, wrapSQLError("send", err)
 	}
 	return eid, nil
 }
@@ -90,7 +90,7 @@ func (c *Client) SendBatch(ctx context.Context, queue, typ string, payloads []an
 		"select pgque.send_batch($1, $2, $3::jsonb[])", queue, typ, jsonPayloads,
 	).Scan(&ids)
 	if err != nil {
-		return nil, wrapSqlError("send batch", err)
+		return nil, wrapSQLError("send batch", err)
 	}
 	return ids, nil
 }
@@ -104,7 +104,7 @@ func (c *Client) Receive(ctx context.Context, queue, consumer string, maxMessage
 	rows, err := c.pool.Query(ctx,
 		"SELECT * FROM pgque.receive($1, $2, $3)", queue, consumer, maxMessages)
 	if err != nil {
-		return nil, wrapSqlError("receive", err)
+		return nil, wrapSQLError("receive", err)
 	}
 	defer rows.Close()
 
@@ -124,7 +124,7 @@ func (c *Client) Receive(ctx context.Context, queue, consumer string, maxMessage
 		msgs = append(msgs, m)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, wrapSqlError("receive", err)
+		return nil, wrapSQLError("receive rows", err)
 	}
 	return msgs, nil
 }
@@ -135,7 +135,7 @@ func (c *Client) Receive(ctx context.Context, queue, consumer string, maxMessage
 func (c *Client) Ack(ctx context.Context, batchID int64) error {
 	_, err := c.pool.Exec(ctx, "SELECT pgque.ack($1)", batchID)
 	if err != nil {
-		return wrapSqlError("ack", err)
+		return wrapSQLError("ack", err)
 	}
 	return nil
 }
@@ -173,7 +173,7 @@ func (c *Client) Nack(ctx context.Context, batchID int64, msg Message, opts ...N
 		msg.Extra1, msg.Extra2, msg.Extra3, msg.Extra4,
 		interval, reason)
 	if err != nil {
-		return wrapSqlError("nack", err)
+		return wrapSQLError("nack", err)
 	}
 	return nil
 }

--- a/clients/go/pgque.go
+++ b/clients/go/pgque.go
@@ -28,11 +28,11 @@ type Client struct {
 func Connect(ctx context.Context, dsn string) (*Client, error) {
 	pool, err := pgxpool.New(ctx, dsn)
 	if err != nil {
-		return nil, fmt.Errorf("pgque: connect: %w", err)
+		return nil, fmt.Errorf("pgque: connect: %w: %w", ErrConnection, err)
 	}
 	if err := pool.Ping(ctx); err != nil {
 		pool.Close()
-		return nil, fmt.Errorf("pgque: connect: %w", err)
+		return nil, fmt.Errorf("pgque: connect: %w: %w", ErrConnection, err)
 	}
 	return &Client{pool: pool}, nil
 }
@@ -63,7 +63,7 @@ func (c *Client) Send(ctx context.Context, queue string, ev Event) (int64, error
 		"SELECT pgque.send($1, $2, $3::jsonb)", queue, typ, string(payload),
 	).Scan(&eid)
 	if err != nil {
-		return 0, fmt.Errorf("pgque: send: %w", err)
+		return 0, wrapSqlError("send", err)
 	}
 	return eid, nil
 }
@@ -90,7 +90,7 @@ func (c *Client) SendBatch(ctx context.Context, queue, typ string, payloads []an
 		"select pgque.send_batch($1, $2, $3::jsonb[])", queue, typ, jsonPayloads,
 	).Scan(&ids)
 	if err != nil {
-		return nil, fmt.Errorf("pgque: send batch: %w", err)
+		return nil, wrapSqlError("send batch", err)
 	}
 	return ids, nil
 }
@@ -104,7 +104,7 @@ func (c *Client) Receive(ctx context.Context, queue, consumer string, maxMessage
 	rows, err := c.pool.Query(ctx,
 		"SELECT * FROM pgque.receive($1, $2, $3)", queue, consumer, maxMessages)
 	if err != nil {
-		return nil, fmt.Errorf("pgque: receive: %w", err)
+		return nil, wrapSqlError("receive", err)
 	}
 	defer rows.Close()
 
@@ -124,7 +124,7 @@ func (c *Client) Receive(ctx context.Context, queue, consumer string, maxMessage
 		msgs = append(msgs, m)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("pgque: receive rows: %w", err)
+		return nil, wrapSqlError("receive", err)
 	}
 	return msgs, nil
 }
@@ -135,7 +135,7 @@ func (c *Client) Receive(ctx context.Context, queue, consumer string, maxMessage
 func (c *Client) Ack(ctx context.Context, batchID int64) error {
 	_, err := c.pool.Exec(ctx, "SELECT pgque.ack($1)", batchID)
 	if err != nil {
-		return fmt.Errorf("pgque: ack: %w", err)
+		return wrapSqlError("ack", err)
 	}
 	return nil
 }
@@ -173,7 +173,7 @@ func (c *Client) Nack(ctx context.Context, batchID int64, msg Message, opts ...N
 		msg.Extra1, msg.Extra2, msg.Extra3, msg.Extra4,
 		interval, reason)
 	if err != nil {
-		return fmt.Errorf("pgque: nack: %w", err)
+		return wrapSqlError("nack", err)
 	}
 	return nil
 }

--- a/clients/go/typed_errors_test.go
+++ b/clients/go/typed_errors_test.go
@@ -58,10 +58,10 @@ func TestTypedError_ConnectionError(t *testing.T) {
 	}
 }
 
-// TestTypedError_SqlErrorCarriesSqlstate: a generic SQL error (e.g. unknown
+// TestTypedError_SQLErrorCarriesSqlstate: a generic SQL error (e.g. unknown
 // queue raised by PgQ as a P0001 raise_exception) must be unwrappable to a
-// *pgque.SqlError that exposes the SQLSTATE.
-func TestTypedError_SqlErrorCarriesSqlstate(t *testing.T) {
+// *pgque.SQLError that exposes the SQLSTATE.
+func TestTypedError_SQLErrorCarriesSqlstate(t *testing.T) {
 	client := connectOrSkip(t)
 	defer client.Close()
 	ctx := context.Background()
@@ -72,11 +72,11 @@ func TestTypedError_SqlErrorCarriesSqlstate(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error sending to missing queue")
 	}
-	var sqlErr *pgque.SqlError
+	var sqlErr *pgque.SQLError
 	if !errors.As(err, &sqlErr) {
-		t.Fatalf("expected errors.As to extract *SqlError, got: %v", err)
+		t.Fatalf("expected errors.As to extract *SQLError, got: %v", err)
 	}
 	if sqlErr.SQLSTATE == "" {
-		t.Errorf("expected non-empty SQLSTATE on SqlError, got empty")
+		t.Errorf("expected non-empty SQLSTATE on SQLError, got empty")
 	}
 }

--- a/clients/go/typed_errors_test.go
+++ b/clients/go/typed_errors_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+package pgque_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	pgque "github.com/NikolayS/pgque-go"
+)
+
+// TestTypedError_QueueNotFound: sending to a queue that does not exist must
+// surface an error matched by errors.Is(err, pgque.ErrQueueNotFound).
+func TestTypedError_QueueNotFound(t *testing.T) {
+	client := connectOrSkip(t)
+	defer client.Close()
+	ctx := context.Background()
+
+	_, err := client.Send(ctx, "queue_typed_err_missing_"+randSuffix(t), pgque.Event{
+		Type: "x", Payload: map[string]any{"y": 1},
+	})
+	if err == nil {
+		t.Fatal("expected error sending to missing queue")
+	}
+	if !errors.Is(err, pgque.ErrQueueNotFound) {
+		t.Errorf("expected errors.Is(err, ErrQueueNotFound) to be true, got: %v", err)
+	}
+}
+
+// TestTypedError_ConsumerNotFound: receiving from a non-registered consumer
+// must surface an error matched by errors.Is(err, pgque.ErrConsumerNotFound).
+func TestTypedError_ConsumerNotFound(t *testing.T) {
+	client := connectOrSkip(t)
+	defer client.Close()
+	queue, _ := setupFreshQueue(t, client)
+	ctx := context.Background()
+
+	_, err := client.Receive(ctx, queue, "no_such_consumer_"+randSuffix(t), 10)
+	if err == nil {
+		t.Fatal("expected error from Receive with missing consumer")
+	}
+	if !errors.Is(err, pgque.ErrConsumerNotFound) {
+		t.Errorf("expected errors.Is(err, ErrConsumerNotFound) to be true, got: %v", err)
+	}
+}
+
+// TestTypedError_ConnectionError: a syntactically invalid DSN must surface an
+// error matched by errors.Is(err, pgque.ErrConnection).
+func TestTypedError_ConnectionError(t *testing.T) {
+	ctx := context.Background()
+	_, err := pgque.Connect(ctx, "not a real dsn :: garbage")
+	if err == nil {
+		t.Fatal("expected error from invalid DSN, got nil")
+	}
+	if !errors.Is(err, pgque.ErrConnection) {
+		t.Errorf("expected errors.Is(err, ErrConnection) to be true, got: %v", err)
+	}
+}
+
+// TestTypedError_SqlErrorCarriesSqlstate: a generic SQL error (e.g. unknown
+// queue raised by PgQ as a P0001 raise_exception) must be unwrappable to a
+// *pgque.SqlError that exposes the SQLSTATE.
+func TestTypedError_SqlErrorCarriesSqlstate(t *testing.T) {
+	client := connectOrSkip(t)
+	defer client.Close()
+	ctx := context.Background()
+
+	_, err := client.Send(ctx, "queue_typed_err_sqlstate_"+randSuffix(t), pgque.Event{
+		Type: "x", Payload: map[string]any{"y": 1},
+	})
+	if err == nil {
+		t.Fatal("expected error sending to missing queue")
+	}
+	var sqlErr *pgque.SqlError
+	if !errors.As(err, &sqlErr) {
+		t.Fatalf("expected errors.As to extract *SqlError, got: %v", err)
+	}
+	if sqlErr.SQLSTATE == "" {
+		t.Errorf("expected non-empty SQLSTATE on SqlError, got empty")
+	}
+}


### PR DESCRIPTION
Closes the Go portion of #140. Python and TypeScript already expose typed error hierarchies; the Go client only had `fmt.Errorf("pgque: …: %w", err)` wrapping. Application code that wants to recover from "queue does not exist" or "consumer not registered" had to substring-match — exactly the pattern #140 calls out as fragile.

## Cross-driver shape

| Concept | Python | TypeScript | Go (this PR) |
|---|---|---|---|
| connection | `PgqueConnectionError` | `PgqueConnectionError` | `ErrConnection` |
| queue missing | `PgqueQueueNotFound` | `PgqueQueueNotFoundError` | `ErrQueueNotFound` |
| consumer missing | `PgqueConsumerNotFound` | `PgqueConsumerNotFoundError` | `ErrConsumerNotFound` |
| batch missing | `PgqueBatchNotFound` | — (no analogue) | `ErrBatchNotFound` |
| generic SQL | `PgqueError` | `PgqueSqlError` | `*SqlError` (Op, SQLSTATE, Err) |

Go matches Python's coverage and adds `*SqlError` so unmatched conditions still expose SQLSTATE.

## Files

- **`clients/go/errors.go`** (new) — sentinels + `*SqlError` + `wrapSqlError(op, err)`. Maps `*pgconn.PgError.Message` against fragments drawn from `sql/pgque.sql`: `queue not found`, `no such queue`, `event queue not found`, `event queue not created`, `consumer not registered`, `not subscriber to queue` (PgQ wording), `batch not found`, `cannot find data for batch`. Non-`PgError` failures (pool closed, DSN garbage, network) tag `ErrConnection`.
- **`clients/go/pgque.go`** — Send/SendBatch/Receive/Ack/Nack callsites now delegate to `wrapSqlError`; `Connect` wraps both `pgxpool.New` and `pool.Ping` with `ErrConnection`.
- **`clients/go/README.md`** — typed-errors section with `errors.Is` / `errors.As` pattern.
- **`clients/go/typed_errors_test.go`** (new) — red/green TDD coverage for the four sentinels and `*SqlError`.

## TDD

```
$ # RED: test references undefined symbols on origin/main
$ go vet ./...
vet: ./typed_errors_test.go:26:27: undefined: pgque.ErrQueueNotFound
```

```
$ # GREEN: same tests on this branch
$ PGQUE_TEST_DSN=postgres://pgque_test:pgque_test@localhost:5432/pgque_test_140 \
  go test -run TestTypedError -v ./...
=== RUN   TestTypedError_QueueNotFound
--- PASS: TestTypedError_QueueNotFound (0.01s)
=== RUN   TestTypedError_ConsumerNotFound
--- PASS: TestTypedError_ConsumerNotFound (0.03s)
=== RUN   TestTypedError_ConnectionError
--- PASS: TestTypedError_ConnectionError (0.00s)
=== RUN   TestTypedError_SqlErrorCarriesSqlstate
--- PASS: TestTypedError_SqlErrorCarriesSqlstate (0.01s)
PASS
```

## Full suite

```
$ PGQUE_TEST_DSN=… go test -count=1 ./...
ok  github.com/NikolayS/pgque-go  12.110s
```

`gofmt -l` clean, `go vet ./...` clean.

## Backward compatibility

Existing tests in `errors_test.go` use `strings.Contains` against the error message. Those continue to pass — the wrapping preserves the underlying `*pgconn.PgError` text under the sentinel chain, and the sentinel messages themselves contain the same words ("queue not found", "consumer not registered", "batch not found"). No callers have to migrate; the new `errors.Is` path is additive.

## Out of scope

- `ErrPermissionDenied` / `ErrInvalidInput` from #140's "at minimum" list — PgQue surfaces those as standard SQLSTATEs (`42501`, `22xxx`); routing them needs a small extra branch on `pgErr.Code` rather than message text. Easy follow-up; left out to keep this PR's diff minimal.
- Migrating the existing `errors_test.go` substring assertions to `errors.Is` — the new `typed_errors_test.go` covers the same scenarios with the typed assertions; the older tests are kept as-is for now.

Refs #140.

https://claude.ai/code/session_01TwKyarGpkGKN8LY1CV8dsG

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwKyarGpkGKN8LY1CV8dsG)_