### PR TITLE
docs: expand roadmap table

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,8 +425,20 @@ PgQue keeps PgQ's proven core architecture — snapshot-based batch isolation, t
 | Rust library |  |
 | Java library |  |
 | Ruby library |  |
-| Basic observability views | ✅ |
-| Prometheus exporter |  |
+| Basic queue/consumer info views | ✅ |
+| Advanced observability / health views |  |
+| LISTEN/NOTIFY consumer wakeups on tick |  |
+| Delayed / scheduled delivery (`send_at`) |  |
+| Queue config JSON API |  |
+| Queue pause / resume |  |
+| OpenTelemetry / Prometheus metrics export |  |
+| Admin CLI |  |
+| Cross-database `pg_cron` scheduling |  |
+| Message TTL / expiry |  |
+| Per-tenant isolation / multi-schema installs |  |
+| Transactional receive helpers in clients |  |
+| Ordered / FIFO-key client processing |  |
+| Priority / multi-queue client processing |  |
 | `pg_tle` extension package | ✅ |
 | Migration guides |  |
 

--- a/README.md
+++ b/README.md
@@ -436,8 +436,6 @@ PgQue keeps PgQ's proven core architecture — snapshot-based batch isolation, t
 | Cross-database `pg_cron` scheduling |  |
 | Message TTL / expiry |  |
 | Per-tenant isolation / multi-schema installs |  |
-| Transactional receive helpers in clients |  |
-| Priority / multi-queue client processing |  |
 | `pg_tle` extension package | ✅ |
 | Migration guides |  |
 

--- a/README.md
+++ b/README.md
@@ -437,7 +437,6 @@ PgQue keeps PgQ's proven core architecture — snapshot-based batch isolation, t
 | Message TTL / expiry |  |
 | Per-tenant isolation / multi-schema installs |  |
 | Transactional receive helpers in clients |  |
-| Ordered / FIFO-key client processing |  |
 | Priority / multi-queue client processing |  |
 | `pg_tle` extension package | ✅ |
 | Migration guides |  |


### PR DESCRIPTION
## Summary

Expand the README roadmap table with features that are currently parked in SPECx / `sql/experimental/` or discussed as future direction:

- tick-level LISTEN/NOTIFY consumer wakeups
- delayed delivery
- queue config/pause/resume sugar
- advanced observability and metrics export
- admin CLI, cross-database pg_cron scheduling, TTL, isolation, and client-side helpers

Also splits the vague "Basic observability views" row into basic info views vs advanced observability/health.

## Notes

This is roadmap inventory only — no implementation promises beyond the table.

Related: #201 for LISTEN/NOTIFY semantics/performance verification.
