### PR TITLE
fix(clients/python): warn on stale ack (#148)

### DIFF
--- a/clients/python/pgque/consumer.py
+++ b/clients/python/pgque/consumer.py
@@ -296,4 +296,13 @@ class Consumer:
                 # Do NOT ack -- redeliver on next poll.
                 return
 
-            client.ack(batch_id)
+            # pgque.ack returns 1 on success, 0 if the batch was already
+            # finished or not found (stale/double ack, cross-consumer
+            # race). Mirror the TS+Go consumers and log warn on 0; do
+            # not treat it as an error.
+            if client.ack(batch_id) == 0:
+                logger.warning(
+                    "pgque: ack batch %d returned 0 -- stale or double ack "
+                    "(batch already finished or not found)",
+                    batch_id,
+                )

--- a/clients/python/tests/test_consumer.py
+++ b/clients/python/tests/test_consumer.py
@@ -407,6 +407,59 @@ def test_consumer_does_not_ack_when_handler_error_nack_fails(
         conn.commit()
 
 
+def test_consumer_warns_on_stale_ack(dsn, conn, setup_queue, caplog):
+    """If ``client.ack(batch_id)`` returns 0 (stale/double ack), the
+    Consumer must log a WARNING -- matching the TS+Go consumers, which
+    log a warn on ``n == 0`` from the new ack-rowcount surface.
+
+    Simulated by monkey-patching the per-poll ``PgqueClient`` so its
+    ``ack`` returns 0 instead of delegating to the SQL function. The
+    test does not exercise the real stale path (which requires a race
+    between two consumers); it locks the warn-log behavior.
+    """
+    queue, consumer_name = setup_queue
+    client = pgque.PgqueClient(conn)
+    client.send(queue, {"x": 1}, type="order.created")
+    conn.commit()
+    conn.execute("select pgque.force_tick(%s)", (queue,))
+    conn.execute("select pgque.ticker()")
+    conn.commit()
+
+    cons = pgque.Consumer(
+        dsn=dsn, queue=queue, name=consumer_name, poll_interval=1
+    )
+
+    @cons.on("order.created")
+    def _ok(msg):
+        return None
+
+    real_client_init = pgque.PgqueClient.__init__
+    ack_returns: list[int] = []
+
+    def fake_init(self, c):
+        real_client_init(self, c)
+
+        def fake_ack(batch_id):
+            ack_returns.append(0)
+            return 0
+
+        self.ack = fake_ack  # type: ignore[method-assign]
+
+    with mock.patch.object(pgque.PgqueClient, "__init__", fake_init):
+        with caplog.at_level(logging.WARNING, logger="pgque"):
+            t = _run_consumer_for(cons, 3.0)
+            t.join(timeout=5.0)
+
+    assert ack_returns, "ack was never called by the consumer"
+
+    warning_lines = [
+        r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+    ]
+    assert any("stale" in m.lower() or "double" in m.lower() for m in warning_lines), (
+        f"expected a WARNING mentioning stale or double ack; got {warning_lines}"
+    )
+
+
 def test_consumer_stop_returns_within_2s_while_waiting(dsn, setup_queue):
     """``stop()`` must unblock the LISTEN/NOTIFY wait promptly, even when
     no notifications arrive and ``poll_interval`` is large.


### PR DESCRIPTION
Closes the cross-driver Consumer asymmetry that #192 (TS+Go ack rowcount surfacing) left behind in Python.

## Background

PR #192 made TS and Go `client.ack(batchId)` return the integer rowcount from `pgque.finish_batch` (1 success / 0 stale-or-double-ack), and the high-level Consumers in those languages log a `warn` on `0`. Python's `client.ack()` already returned the int, but the high-level `Consumer` at `clients/python/pgque/consumer.py:299` discarded it:

```python
client.ack(batch_id)
```

So a stale/double ack — the same condition TS+Go now log — was silently swallowed by Python's Consumer.

## Fix

Capture the rowcount and log a `WARNING` on `0`, mirroring the wording used in `clients/typescript/src/consumer.ts` and `clients/go/consumer.go`.

```python
if client.ack(batch_id) == 0:
    logger.warning(
        "pgque: ack batch %d returned 0 -- stale or double ack "
        "(batch already finished or not found)",
        batch_id,
    )
```

The 1-line behavior change is additive — successful acks (`n == 1`) are unchanged. Errors (raised from `client.ack`) still propagate as before.

## Test

`tests/test_consumer.py::test_consumer_warns_on_stale_ack` — monkey-patches the per-poll `PgqueClient.ack` to return `0` and asserts a `WARNING` containing "stale" / "double" appears in `caplog`.

## TDD

```
$ # RED on origin/main:
$ python -m pytest tests/test_consumer.py::test_consumer_warns_on_stale_ack -x -v
AssertionError: expected a WARNING mentioning stale or double ack; got []

$ # GREEN on this branch:
PASSED

$ # Full suite:
$ python -m pytest -q
55 passed in 31.88s
```

## Out of scope

- The actual stale-ack scenario (race between two consumers ackking the same batch) is not exercised here — that requires a 2-session live test. The unit test locks the warn-log behavior; integration coverage can come later.

Refs #148.

https://claude.ai/code/session_01TwKyarGpkGKN8LY1CV8dsG

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwKyarGpkGKN8LY1CV8dsG)_