### PR TITLE
test: add SQL contract + e2e coverage for last ~20 merged PRs

### DIFF
--- a/tests/run_all.sql
+++ b/tests/run_all.sql
@@ -97,5 +97,23 @@
 \echo 'Running: test_config_hardening'
 \i tests/test_config_hardening.sql
 
+\echo 'Running: test_ack_rowcount_contract'
+\i tests/test_ack_rowcount_contract.sql
+
+\echo 'Running: test_ticker_returns_contract'
+\i tests/test_ticker_returns_contract.sql
+
+\echo 'Running: test_redelivery_contract'
+\i tests/test_redelivery_contract.sql
+
+\echo 'Running: test_dlq_edge_cases'
+\i tests/test_dlq_edge_cases.sql
+
+\echo 'Running: test_snapshot_visibility_contract'
+\i tests/test_snapshot_visibility_contract.sql
+
+\echo 'Running: test_e2e_role_split'
+\i tests/test_e2e_role_split.sql
+
 \echo ''
 \echo '=== ALL TESTS PASSED ==='

--- a/tests/test_ack_rowcount_contract.sql
+++ b/tests/test_ack_rowcount_contract.sql
@@ -1,0 +1,233 @@
+-- test_ack_rowcount_contract.sql
+-- SQL-level contract tests for pgque.ack() / pgque.finish_batch() / pgque.nack()
+-- rowcount semantics. Cross-driver clients (Python, Go, TypeScript) surface
+-- the integer return so callers can detect stale / double acks; this test
+-- pins the SQL-side contract those drivers depend on.
+--
+-- Contract:
+--   pgque.ack(batch_id)          returns 1 on success (batch finished)
+--   pgque.ack(batch_id)          returns 0 on stale / double / unknown id
+--   pgque.finish_batch(batch_id) returns 1 / 0 with the same semantics
+--   pgque.nack(...)              returns 1 on success (retry or DLQ branch)
+--   pgque.nack(...)              raises 'batch not found' on unknown batch id
+--   pgque.nack(...)              raises 'msg_id % not found' on forged msg
+--
+-- A regression that turns ack() into raise-on-not-found, or that returns 1
+-- for a stale batch, would silently break the driver contract: stale acks
+-- would either crash apps or be invisible. This test catches both.
+--
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+\set ON_ERROR_STOP on
+
+-- =========================================================================
+-- Setup
+-- =========================================================================
+do $$ begin
+  perform pgque.create_queue('test_ack_rowcount');
+  perform pgque.subscribe('test_ack_rowcount', 'rc1');
+end $$;
+
+do $$ begin
+  perform pgque.send('test_ack_rowcount', 'rc.test', '{"n":1}'::jsonb);
+end $$;
+
+do $$ begin
+  perform pgque.force_tick('test_ack_rowcount');
+  perform pgque.ticker();
+end $$;
+
+-- =========================================================================
+-- Test 1: pgque.ack() returns 1 on first call, 0 on second (double-ack)
+-- =========================================================================
+do $$
+declare
+  v_msg     pgque.message;
+  v_batch   bigint;
+  v_first   integer;
+  v_second  integer;
+begin
+  select * into v_msg from pgque.receive('test_ack_rowcount', 'rc1', 10) limit 1;
+  assert v_msg.msg_id is not null, 'should receive 1 message';
+  v_batch := v_msg.batch_id;
+
+  v_first := pgque.ack(v_batch);
+  assert v_first = 1,
+    format('first ack on a held batch must return 1, got %s', v_first);
+
+  -- Double ack: same batch_id, no longer active. Must return 0, not raise,
+  -- not succeed silently. This is the contract Go/TS drivers depend on for
+  -- "stale ack" detection.
+  v_second := pgque.ack(v_batch);
+  assert v_second = 0,
+    format('second ack on already-finished batch must return 0, got %s', v_second);
+
+  raise notice 'PASS: pgque.ack() returns 1 then 0 (double-ack detected)';
+end $$;
+
+-- =========================================================================
+-- Test 2: pgque.ack() on unknown batch_id returns 0 (no exception)
+-- =========================================================================
+do $$
+declare
+  v_rc integer;
+begin
+  -- Pick a batch_id we know does not exist.
+  v_rc := pgque.ack(9999999999::bigint);
+  assert v_rc = 0,
+    format('ack on unknown batch_id must return 0, got %s', v_rc);
+
+  raise notice 'PASS: pgque.ack(unknown) returns 0 without raising';
+end $$;
+
+-- =========================================================================
+-- Test 3: pgque.finish_batch() mirrors ack() rowcount semantics
+-- (ack is a thin SECURITY DEFINER wrapper around finish_batch but the
+-- contract is asserted independently so a future inlining/refactor doesn't
+-- silently change behavior on either function.)
+-- =========================================================================
+
+-- Send + tick a fresh message for finish_batch test.
+do $$ begin
+  perform pgque.send('test_ack_rowcount', 'rc.test2', '{"n":2}'::jsonb);
+end $$;
+
+do $$ begin
+  perform pgque.force_tick('test_ack_rowcount');
+  perform pgque.ticker();
+end $$;
+
+do $$
+declare
+  v_msg     pgque.message;
+  v_batch   bigint;
+  v_first   integer;
+  v_second  integer;
+  v_unknown integer;
+begin
+  select * into v_msg from pgque.receive('test_ack_rowcount', 'rc1', 10) limit 1;
+  assert v_msg.msg_id is not null, 'should receive the second message';
+  v_batch := v_msg.batch_id;
+
+  v_first := pgque.finish_batch(v_batch);
+  assert v_first = 1,
+    format('finish_batch on a held batch must return 1, got %s', v_first);
+
+  v_second := pgque.finish_batch(v_batch);
+  assert v_second = 0,
+    format('finish_batch on already-finished batch must return 0, got %s', v_second);
+
+  v_unknown := pgque.finish_batch(9999999998::bigint);
+  assert v_unknown = 0,
+    format('finish_batch(unknown) must return 0, got %s', v_unknown);
+
+  raise notice 'PASS: pgque.finish_batch() rowcount mirrors ack()';
+end $$;
+
+-- =========================================================================
+-- Test 4: pgque.nack() returns 1 on success (retry branch)
+-- =========================================================================
+do $$ begin
+  perform pgque.send('test_ack_rowcount', 'rc.retry', '{"n":3}'::jsonb);
+end $$;
+
+do $$ begin
+  perform pgque.force_tick('test_ack_rowcount');
+  perform pgque.ticker();
+end $$;
+
+do $$
+declare
+  v_msg pgque.message;
+  v_rc  integer;
+begin
+  select * into v_msg from pgque.receive('test_ack_rowcount', 'rc1', 10) limit 1;
+  assert v_msg.msg_id is not null, 'should receive the retry message';
+
+  -- Default queue max_retries=5; retry_count=0; this should take the retry
+  -- branch. nack() must return 1 in either branch (retry or DLQ).
+  v_rc := pgque.nack(v_msg.batch_id, v_msg, '60 seconds'::interval, 'transient');
+  assert v_rc = 1, format('nack(retry branch) must return 1, got %s', v_rc);
+
+  -- Always close the batch so the next test starts clean.
+  perform pgque.ack(v_msg.batch_id);
+  raise notice 'PASS: pgque.nack() returns 1 (retry branch)';
+end $$;
+
+-- =========================================================================
+-- Test 5: pgque.nack() returns 1 on success (DLQ branch)
+-- =========================================================================
+do $$ begin
+  perform pgque.create_queue('test_ack_rowcount_dlq');
+  perform pgque.set_queue_config('test_ack_rowcount_dlq', 'max_retries', '0');
+  perform pgque.subscribe('test_ack_rowcount_dlq', 'rc1');
+end $$;
+
+do $$ begin
+  perform pgque.send('test_ack_rowcount_dlq', 'rc.dead', '{"n":4}'::jsonb);
+end $$;
+
+do $$ begin
+  perform pgque.force_tick('test_ack_rowcount_dlq');
+  perform pgque.ticker();
+end $$;
+
+do $$
+declare
+  v_msg pgque.message;
+  v_rc  integer;
+begin
+  select * into v_msg
+  from pgque.receive('test_ack_rowcount_dlq', 'rc1', 10) limit 1;
+  assert v_msg.msg_id is not null, 'should receive the DLQ-bound message';
+
+  -- max_retries=0; first nack must take the DLQ branch and still return 1.
+  v_rc := pgque.nack(v_msg.batch_id, v_msg, '0 seconds'::interval, 'dead');
+  assert v_rc = 1, format('nack(DLQ branch) must return 1, got %s', v_rc);
+
+  perform pgque.ack(v_msg.batch_id);
+  raise notice 'PASS: pgque.nack() returns 1 (DLQ branch)';
+end $$;
+
+-- =========================================================================
+-- Test 6: pgque.nack() on unknown batch_id raises 'batch not found'
+-- (asymmetric with ack(): nack reaches into queue config first, which is
+-- a hard lookup. We pin this so a future refactor doesn't silently relax
+-- it to "return 0".)
+-- =========================================================================
+do $$
+declare
+  v_msg pgque.message;
+  v_ok  boolean := false;
+begin
+  -- Build a syntactically-valid composite; msg_id and batch_id are both
+  -- bogus so the queue-side subscription lookup must fail first.
+  v_msg := row(
+    1::bigint, 9999999997::bigint,
+    'forge', 'forge', 0, now(),
+    null, null, null, null
+  )::pgque.message;
+
+  begin
+    perform pgque.nack(9999999997::bigint, v_msg, '0 seconds'::interval, 'forge');
+    raise exception 'expected nack(unknown batch) to raise';
+  exception when raise_exception then
+    assert sqlerrm like 'batch not found%',
+      format('expected "batch not found" prefix, got: %s', sqlerrm);
+    v_ok := true;
+  end;
+  assert v_ok, 'nack(unknown batch) did not raise';
+  raise notice 'PASS: pgque.nack(unknown batch) raises batch-not-found';
+end $$;
+
+-- =========================================================================
+-- Cleanup
+-- =========================================================================
+do $$ begin
+  perform pgque.unsubscribe('test_ack_rowcount', 'rc1');
+  perform pgque.drop_queue('test_ack_rowcount');
+  perform pgque.unsubscribe('test_ack_rowcount_dlq', 'rc1');
+  perform pgque.drop_queue('test_ack_rowcount_dlq');
+end $$;
+
+\echo 'PASS: test_ack_rowcount_contract'

--- a/tests/test_ack_rowcount_contract.sql
+++ b/tests/test_ack_rowcount_contract.sql
@@ -1,28 +1,13 @@
--- test_ack_rowcount_contract.sql
--- SQL-level contract tests for pgque.ack() / pgque.finish_batch() / pgque.nack()
--- rowcount semantics. Cross-driver clients (Python, Go, TypeScript) surface
--- the integer return so callers can detect stale / double acks; this test
--- pins the SQL-side contract those drivers depend on.
---
--- Contract:
---   pgque.ack(batch_id)          returns 1 on success (batch finished)
---   pgque.ack(batch_id)          returns 0 on stale / double / unknown id
---   pgque.finish_batch(batch_id) returns 1 / 0 with the same semantics
---   pgque.nack(...)              returns 1 on success (retry or DLQ branch)
---   pgque.nack(...)              raises 'batch not found' on unknown batch id
---   pgque.nack(...)              raises 'msg_id % not found' on forged msg
---
--- A regression that turns ack() into raise-on-not-found, or that returns 1
--- for a stale batch, would silently break the driver contract: stale acks
--- would either crash apps or be invisible. This test catches both.
---
+-- test_ack_rowcount_contract.sql -- pin pgque.ack / finish_batch / nack rowcount semantics
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- ack(batch_id):          1 on success, 0 on stale/double/unknown id.
+-- finish_batch(batch_id): same.
+-- nack(...):              1 on success (retry or DLQ branch);
+--                         raises 'batch not found' on unknown batch.
 
 \set ON_ERROR_STOP on
 
--- =========================================================================
--- Setup
--- =========================================================================
 do $$ begin
   perform pgque.create_queue('test_ack_rowcount');
   perform pgque.subscribe('test_ack_rowcount', 'rc1');
@@ -33,130 +18,82 @@ do $$ begin
 end $$;
 
 do $$ begin
-  perform pgque.force_tick('test_ack_rowcount');
+  perform pgque.force_next_tick('test_ack_rowcount');
   perform pgque.ticker();
 end $$;
 
--- =========================================================================
--- Test 1: pgque.ack() returns 1 on first call, 0 on second (double-ack)
--- =========================================================================
+-- Test 1: pgque.ack() returns 1 then 0 on double-ack.
 do $$
 declare
   v_msg     pgque.message;
   v_batch   bigint;
-  v_first   integer;
-  v_second  integer;
 begin
   select * into v_msg from pgque.receive('test_ack_rowcount', 'rc1', 10) limit 1;
-  assert v_msg.msg_id is not null, 'should receive 1 message';
   v_batch := v_msg.batch_id;
 
-  v_first := pgque.ack(v_batch);
-  assert v_first = 1,
-    format('first ack on a held batch must return 1, got %s', v_first);
-
-  -- Double ack: same batch_id, no longer active. Must return 0, not raise,
-  -- not succeed silently. This is the contract Go/TS drivers depend on for
-  -- "stale ack" detection.
-  v_second := pgque.ack(v_batch);
-  assert v_second = 0,
-    format('second ack on already-finished batch must return 0, got %s', v_second);
+  assert pgque.ack(v_batch) = 1, 'first ack must return 1';
+  -- Stale ack contract: returns 0, no exception. Drivers detect this.
+  assert pgque.ack(v_batch) = 0, 'second ack on finished batch must return 0';
 
   raise notice 'PASS: pgque.ack() returns 1 then 0 (double-ack detected)';
 end $$;
 
--- =========================================================================
--- Test 2: pgque.ack() on unknown batch_id returns 0 (no exception)
--- =========================================================================
-do $$
-declare
-  v_rc integer;
-begin
-  -- Pick a batch_id we know does not exist.
-  v_rc := pgque.ack(9999999999::bigint);
-  assert v_rc = 0,
-    format('ack on unknown batch_id must return 0, got %s', v_rc);
-
+-- Test 2: pgque.ack() on unknown batch_id returns 0 (no exception).
+do $$ begin
+  assert pgque.ack(9999999999::bigint) = 0, 'ack on unknown batch_id must return 0';
   raise notice 'PASS: pgque.ack(unknown) returns 0 without raising';
 end $$;
 
--- =========================================================================
--- Test 3: pgque.finish_batch() mirrors ack() rowcount semantics
--- (ack is a thin SECURITY DEFINER wrapper around finish_batch but the
--- contract is asserted independently so a future inlining/refactor doesn't
--- silently change behavior on either function.)
--- =========================================================================
+-- Test 3: pgque.finish_batch() rowcount mirrors ack() (asserted independently
+-- so a future inlining/refactor can't silently change either function).
 
--- Send + tick a fresh message for finish_batch test.
 do $$ begin
   perform pgque.send('test_ack_rowcount', 'rc.test2', '{"n":2}'::jsonb);
 end $$;
 
 do $$ begin
-  perform pgque.force_tick('test_ack_rowcount');
+  perform pgque.force_next_tick('test_ack_rowcount');
   perform pgque.ticker();
 end $$;
 
 do $$
 declare
-  v_msg     pgque.message;
-  v_batch   bigint;
-  v_first   integer;
-  v_second  integer;
-  v_unknown integer;
+  v_msg   pgque.message;
+  v_batch bigint;
 begin
   select * into v_msg from pgque.receive('test_ack_rowcount', 'rc1', 10) limit 1;
-  assert v_msg.msg_id is not null, 'should receive the second message';
   v_batch := v_msg.batch_id;
 
-  v_first := pgque.finish_batch(v_batch);
-  assert v_first = 1,
-    format('finish_batch on a held batch must return 1, got %s', v_first);
-
-  v_second := pgque.finish_batch(v_batch);
-  assert v_second = 0,
-    format('finish_batch on already-finished batch must return 0, got %s', v_second);
-
-  v_unknown := pgque.finish_batch(9999999998::bigint);
-  assert v_unknown = 0,
-    format('finish_batch(unknown) must return 0, got %s', v_unknown);
+  assert pgque.finish_batch(v_batch) = 1, 'first finish_batch must return 1';
+  assert pgque.finish_batch(v_batch) = 0, 'second finish_batch must return 0';
+  assert pgque.finish_batch(9999999998::bigint) = 0, 'finish_batch(unknown) must return 0';
 
   raise notice 'PASS: pgque.finish_batch() rowcount mirrors ack()';
 end $$;
 
--- =========================================================================
--- Test 4: pgque.nack() returns 1 on success (retry branch)
--- =========================================================================
+-- Test 4: pgque.nack() returns 1 on the retry branch.
 do $$ begin
   perform pgque.send('test_ack_rowcount', 'rc.retry', '{"n":3}'::jsonb);
 end $$;
 
 do $$ begin
-  perform pgque.force_tick('test_ack_rowcount');
+  perform pgque.force_next_tick('test_ack_rowcount');
   perform pgque.ticker();
 end $$;
 
 do $$
 declare
   v_msg pgque.message;
-  v_rc  integer;
 begin
   select * into v_msg from pgque.receive('test_ack_rowcount', 'rc1', 10) limit 1;
-  assert v_msg.msg_id is not null, 'should receive the retry message';
-
-  -- Default queue max_retries=5; retry_count=0; this should take the retry
-  -- branch. nack() must return 1 in either branch (retry or DLQ).
-  v_rc := pgque.nack(v_msg.batch_id, v_msg, '60 seconds'::interval, 'transient');
-  assert v_rc = 1, format('nack(retry branch) must return 1, got %s', v_rc);
-
-  -- Always close the batch so the next test starts clean.
+  -- Default max_retries=5; retry_count=0 → retry branch.
+  assert pgque.nack(v_msg.batch_id, v_msg, '60 seconds'::interval, 'transient') = 1,
+    'nack(retry branch) must return 1';
   perform pgque.ack(v_msg.batch_id);
   raise notice 'PASS: pgque.nack() returns 1 (retry branch)';
 end $$;
 
--- =========================================================================
--- Test 5: pgque.nack() returns 1 on success (DLQ branch)
--- =========================================================================
+-- Test 5: pgque.nack() returns 1 on the DLQ branch.
 do $$ begin
   perform pgque.create_queue('test_ack_rowcount_dlq');
   perform pgque.set_queue_config('test_ack_rowcount_dlq', 'max_retries', '0');
@@ -168,61 +105,45 @@ do $$ begin
 end $$;
 
 do $$ begin
-  perform pgque.force_tick('test_ack_rowcount_dlq');
+  perform pgque.force_next_tick('test_ack_rowcount_dlq');
   perform pgque.ticker();
 end $$;
 
 do $$
 declare
   v_msg pgque.message;
-  v_rc  integer;
 begin
   select * into v_msg
-  from pgque.receive('test_ack_rowcount_dlq', 'rc1', 10) limit 1;
-  assert v_msg.msg_id is not null, 'should receive the DLQ-bound message';
-
-  -- max_retries=0; first nack must take the DLQ branch and still return 1.
-  v_rc := pgque.nack(v_msg.batch_id, v_msg, '0 seconds'::interval, 'dead');
-  assert v_rc = 1, format('nack(DLQ branch) must return 1, got %s', v_rc);
-
+    from pgque.receive('test_ack_rowcount_dlq', 'rc1', 10) limit 1;
+  -- max_retries=0 → first nack takes the DLQ branch.
+  assert pgque.nack(v_msg.batch_id, v_msg, '0 seconds'::interval, 'dead') = 1,
+    'nack(DLQ branch) must return 1';
   perform pgque.ack(v_msg.batch_id);
   raise notice 'PASS: pgque.nack() returns 1 (DLQ branch)';
 end $$;
 
--- =========================================================================
--- Test 6: pgque.nack() on unknown batch_id raises 'batch not found'
--- (asymmetric with ack(): nack reaches into queue config first, which is
--- a hard lookup. We pin this so a future refactor doesn't silently relax
--- it to "return 0".)
--- =========================================================================
+-- Test 6: pgque.nack(unknown batch) raises 'batch not found' (vs. ack which
+-- returns 0 — asymmetric because nack reaches into queue config first).
+-- The forged composite must keep this column order in sync with pgque.message.
 do $$
 declare
-  v_msg pgque.message;
-  v_ok  boolean := false;
-begin
-  -- Build a syntactically-valid composite; msg_id and batch_id are both
-  -- bogus so the queue-side subscription lookup must fail first.
-  v_msg := row(
+  v_msg pgque.message := row(
     1::bigint, 9999999997::bigint,
     'forge', 'forge', 0, now(),
     null, null, null, null
   )::pgque.message;
-
+  v_ok boolean := false;
+begin
   begin
     perform pgque.nack(9999999997::bigint, v_msg, '0 seconds'::interval, 'forge');
-    raise exception 'expected nack(unknown batch) to raise';
   exception when raise_exception then
-    assert sqlerrm like 'batch not found%',
-      format('expected "batch not found" prefix, got: %s', sqlerrm);
+    assert sqlerrm like 'batch not found%', 'unexpected message: ' || sqlerrm;
     v_ok := true;
   end;
   assert v_ok, 'nack(unknown batch) did not raise';
   raise notice 'PASS: pgque.nack(unknown batch) raises batch-not-found';
 end $$;
 
--- =========================================================================
--- Cleanup
--- =========================================================================
 do $$ begin
   perform pgque.unsubscribe('test_ack_rowcount', 'rc1');
   perform pgque.drop_queue('test_ack_rowcount');

--- a/tests/test_dlq_edge_cases.sql
+++ b/tests/test_dlq_edge_cases.sql
@@ -1,32 +1,15 @@
--- test_dlq_edge_cases.sql
--- Edge-case coverage for the dead-letter API. Existing tests cover the
--- nack-routes-to-DLQ path and basic dlq_inspect / dlq_replay flow; this
--- file focuses on:
---
---   1. dlq_replay(dl_id) of an already-replayed entry RAISES
---      'dead letter entry not found' (idempotent semantics: callers can
---      detect double-replays).
---   2. dlq_replay_all returns a (replayed, failed, first_error) record
---      with correct counts on success, on partial failure, and on an
---      empty DLQ.
---   3. dlq_purge filters by age (older_than interval) and returns the
---      number of rows deleted.
---   4. dlq_inspect respects ordering (dl_time desc) and the limit.
---
+-- test_dlq_edge_cases.sql -- DLQ idempotency, ordering, purge, replay_all
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 
 \set ON_ERROR_STOP on
 
--- =========================================================================
--- Setup: a queue with max_retries=0 so any nack lands directly in DLQ.
--- =========================================================================
+-- max_retries=0 → any nack lands directly in DLQ.
 do $$ begin
   perform pgque.create_queue('test_dlq_edges');
   perform pgque.set_queue_config('test_dlq_edges', 'max_retries', '0');
   perform pgque.subscribe('test_dlq_edges', 'dle1');
 end $$;
 
--- Send 3 events, tick, receive, nack each so we get 3 DLQ rows.
 do $$ begin
   perform pgque.send('test_dlq_edges', 'dlq.a', '{"k":"a"}'::jsonb);
   perform pgque.send('test_dlq_edges', 'dlq.b', '{"k":"b"}'::jsonb);
@@ -34,18 +17,17 @@ do $$ begin
 end $$;
 
 do $$ begin
-  perform pgque.force_tick('test_dlq_edges');
+  perform pgque.force_next_tick('test_dlq_edges');
   perform pgque.ticker();
 end $$;
 
+-- All three messages share one batch_id; nack each, ack the batch once.
 do $$
 declare
-  v_msg     pgque.message;
-  v_batch   bigint;
+  v_msg   pgque.message;
+  v_batch bigint;
 begin
-  -- All messages share one batch_id; nack each, ack the batch once.
-  for v_msg in select * from pgque.receive('test_dlq_edges', 'dle1', 100)
-  loop
+  for v_msg in select * from pgque.receive('test_dlq_edges', 'dle1', 100) loop
     v_batch := v_msg.batch_id;
     perform pgque.nack(v_msg.batch_id, v_msg, '0 seconds'::interval, 'dead-' || v_msg.type);
   end loop;
@@ -54,7 +36,6 @@ begin
   end if;
 end $$;
 
--- Sanity: 3 DLQ rows landed.
 do $$
 declare
   v_count bigint;
@@ -66,16 +47,12 @@ begin
   assert v_count = 3, format('expected 3 DLQ rows, got %s', v_count);
 end $$;
 
--- =========================================================================
 -- Test 1: dlq_replay(dl_id) of the same id twice raises on the second call.
--- =========================================================================
 do $$
 declare
-  v_dl_id   bigint;
-  v_new_eid bigint;
-  v_ok      boolean := false;
+  v_dl_id bigint;
+  v_ok    boolean := false;
 begin
-  -- Pick the oldest DLQ entry (deterministic ordering by dl_id).
   select dl.dl_id into v_dl_id
     from pgque.dead_letter dl
     join pgque.queue q on q.queue_id = dl.dl_queue_id
@@ -83,71 +60,49 @@ begin
     order by dl.dl_id
     limit 1;
 
-  v_new_eid := pgque.dlq_replay(v_dl_id);
-  assert v_new_eid is not null, 'first dlq_replay must return a new ev_id';
+  assert pgque.dlq_replay(v_dl_id) is not null, 'first dlq_replay must return a new ev_id';
 
-  -- The replayed event sits in the live queue now. Other tests in this
-  -- file expect a clean queue, so drop_queue at the end takes care of it;
-  -- we just need to avoid double-replaying same dl_id below.
-
-  -- Second replay of same dl_id: row was deleted, must raise.
   begin
     perform pgque.dlq_replay(v_dl_id);
-    raise exception 'expected second dlq_replay(%) to raise', v_dl_id;
   exception when raise_exception then
-    assert sqlerrm like 'dead letter entry not found%',
-      format('expected "dead letter entry not found", got: %s', sqlerrm);
+    assert sqlerrm like 'dead letter entry not found%', 'unexpected message: ' || sqlerrm;
     v_ok := true;
   end;
   assert v_ok, 'second dlq_replay did not raise';
   raise notice 'PASS: dlq_replay() of already-replayed dl_id raises';
 end $$;
 
--- =========================================================================
--- Test 2: dlq_replay(unknown dl_id) raises 'dead letter entry not found'
--- =========================================================================
+-- Test 2: dlq_replay(unknown dl_id) raises 'dead letter entry not found'.
 do $$
 declare
   v_ok boolean := false;
 begin
   begin
     perform pgque.dlq_replay(9999999996::bigint);
-    raise exception 'expected dlq_replay(unknown) to raise';
   exception when raise_exception then
-    assert sqlerrm like 'dead letter entry not found%',
-      format('expected "dead letter entry not found", got: %s', sqlerrm);
+    assert sqlerrm like 'dead letter entry not found%', 'unexpected message: ' || sqlerrm;
     v_ok := true;
   end;
   assert v_ok, 'dlq_replay(unknown) did not raise';
   raise notice 'PASS: dlq_replay(unknown dl_id) raises';
 end $$;
 
--- =========================================================================
--- Test 3: dlq_inspect respects limit and returns rows from the right queue.
--- (We can't reliably pin dl_time desc ordering here because all 3 rows
--- were nacked inside one transaction, so they share now() — the dl_time
--- desc order is then a tie. Pin the contract that holds in any case:
--- limit clamps; rows match the underlying table; queue scoping is
--- correct.)
--- =========================================================================
+-- Test 3: dlq_inspect honors limit and matches the underlying table set.
+-- (Can't pin dl_time desc ordering deterministically: rows nacked in one
+-- xact share now(), so the dl_time tie-break order is unspecified.)
 do $$
 declare
   v_rows int;
   v_table_ids bigint[];
   v_inspect_ids bigint[];
 begin
-  -- We replayed one entry above, so 2 remain.
-  select count(*) into v_rows
-    from pgque.dlq_inspect('test_dlq_edges', 100);
-  assert v_rows = 2, format('expected 2 DLQ rows visible to dlq_inspect, got %s', v_rows);
+  -- One entry replayed above, two remain.
+  select count(*) into v_rows from pgque.dlq_inspect('test_dlq_edges', 100);
+  assert v_rows = 2, format('expected 2 DLQ rows, got %s', v_rows);
 
-  -- Limit must clamp.
-  select count(*) into v_rows
-    from pgque.dlq_inspect('test_dlq_edges', 1);
-  assert v_rows = 1, format('expected dlq_inspect(..., 1) to return 1 row, got %s', v_rows);
+  select count(*) into v_rows from pgque.dlq_inspect('test_dlq_edges', 1);
+  assert v_rows = 1, 'limit must clamp dlq_inspect';
 
-  -- The set of dl_ids returned by dlq_inspect must equal the set in the
-  -- underlying table for this queue.
   select array_agg(dl.dl_id order by dl.dl_id) into v_table_ids
     from pgque.dead_letter dl
     join pgque.queue q on q.queue_id = dl.dl_queue_id
@@ -156,72 +111,49 @@ begin
   select array_agg(dl.dl_id order by dl.dl_id) into v_inspect_ids
     from pgque.dlq_inspect('test_dlq_edges', 100) dl;
 
-  assert v_table_ids = v_inspect_ids,
-    format('dlq_inspect rows mismatch table: table=%s inspect=%s',
-      v_table_ids, v_inspect_ids);
-
+  assert v_table_ids = v_inspect_ids, 'dlq_inspect rows must match the underlying table';
   raise notice 'PASS: dlq_inspect rows match underlying table and respect limit';
 end $$;
 
--- =========================================================================
--- Test 4: dlq_purge with cutoff in the future (large interval) returns 0.
--- (Entries are recent; older_than = 1 day means delete rows older than 1 day,
--- which is none.)
--- =========================================================================
+-- Test 4: dlq_purge with cutoff older than every row deletes nothing.
 do $$
 declare
-  v_cnt integer;
   v_remaining bigint;
 begin
-  v_cnt := pgque.dlq_purge('test_dlq_edges', '1 day'::interval);
-  assert v_cnt = 0,
-    format('dlq_purge(1 day) on fresh entries must delete 0, got %s', v_cnt);
+  assert pgque.dlq_purge('test_dlq_edges', '1 day'::interval) = 0,
+    'dlq_purge(1 day) on fresh entries must delete 0';
 
   select count(*) into v_remaining
     from pgque.dead_letter dl
     join pgque.queue q on q.queue_id = dl.dl_queue_id
     where q.queue_name = 'test_dlq_edges';
-  assert v_remaining = 2,
-    format('dlq_purge(1 day) must not touch fresh rows; remaining=%s', v_remaining);
-
+  assert v_remaining = 2, 'dlq_purge(1 day) must not touch fresh rows';
   raise notice 'PASS: dlq_purge with future cutoff is a no-op';
 end $$;
 
--- =========================================================================
--- Test 5: dlq_purge with age 0 deletes everything and returns the count.
--- =========================================================================
+-- Test 5: dlq_purge with age 0 deletes everything; second run is a no-op.
 do $$
 declare
-  v_cnt integer;
   v_remaining bigint;
 begin
-  v_cnt := pgque.dlq_purge('test_dlq_edges', '0 seconds'::interval);
-  assert v_cnt = 2,
-    format('dlq_purge(0s) must delete the 2 remaining rows, got %s', v_cnt);
+  assert pgque.dlq_purge('test_dlq_edges', '0 seconds'::interval) = 2,
+    'dlq_purge(0s) must delete the 2 remaining rows';
 
   select count(*) into v_remaining
     from pgque.dead_letter dl
     join pgque.queue q on q.queue_id = dl.dl_queue_id
     where q.queue_name = 'test_dlq_edges';
-  assert v_remaining = 0,
-    format('after dlq_purge(0s), no DLQ rows for this queue, got %s', v_remaining);
+  assert v_remaining = 0, 'after dlq_purge(0s), DLQ must be empty for this queue';
 
-  -- Re-running dlq_purge on an empty DLQ is a no-op (returns 0).
-  v_cnt := pgque.dlq_purge('test_dlq_edges', '0 seconds'::interval);
-  assert v_cnt = 0,
-    format('dlq_purge on empty DLQ must return 0, got %s', v_cnt);
-
+  assert pgque.dlq_purge('test_dlq_edges', '0 seconds'::interval) = 0,
+    'dlq_purge on empty DLQ must return 0';
   raise notice 'PASS: dlq_purge deletes by age and returns row count';
 end $$;
 
--- =========================================================================
--- Test 6: dlq_replay_all returns (replayed, failed, first_error) record.
--- =========================================================================
-
--- Drain the queue first: Test 1's dlq_replay re-inserted dlq.a as a live
--- event; consume + ack it cleanly so it doesn't pollute the next batch.
+-- Test 6: dlq_replay_all returns (replayed, failed, first_error).
+-- Drain first: Test 1 re-inserted dlq.a as a live event.
 do $$ begin
-  perform pgque.force_tick('test_dlq_edges');
+  perform pgque.force_next_tick('test_dlq_edges');
   perform pgque.ticker();
 end $$;
 
@@ -238,14 +170,13 @@ begin
   end if;
 end $$;
 
--- Repopulate the DLQ with 2 rows.
 do $$ begin
   perform pgque.send('test_dlq_edges', 'dlq.x', '{"k":"x"}'::jsonb);
   perform pgque.send('test_dlq_edges', 'dlq.y', '{"k":"y"}'::jsonb);
 end $$;
 
 do $$ begin
-  perform pgque.force_tick('test_dlq_edges');
+  perform pgque.force_next_tick('test_dlq_edges');
   perform pgque.ticker();
 end $$;
 
@@ -254,8 +185,7 @@ declare
   v_msg   pgque.message;
   v_batch bigint;
 begin
-  for v_msg in select * from pgque.receive('test_dlq_edges', 'dle1', 100)
-  loop
+  for v_msg in select * from pgque.receive('test_dlq_edges', 'dle1', 100) loop
     v_batch := v_msg.batch_id;
     perform pgque.nack(v_msg.batch_id, v_msg, '0 seconds'::interval, 'dead-again');
   end loop;
@@ -273,26 +203,19 @@ declare
 begin
   select replayed, failed, first_error into v_replayed, v_failed, v_first_error
     from pgque.dlq_replay_all('test_dlq_edges');
-  assert v_replayed = 2,
-    format('dlq_replay_all should replay 2 rows, got %s', v_replayed);
-  assert v_failed = 0,
-    format('dlq_replay_all should not fail any, got %s', v_failed);
-  assert v_first_error is null,
-    format('dlq_replay_all on success should leave first_error NULL, got %s', v_first_error);
+  assert v_replayed = 2,        format('expected replayed=2, got %s', v_replayed);
+  assert v_failed = 0,          format('expected failed=0, got %s', v_failed);
+  assert v_first_error is null, 'expected first_error=NULL on full success';
 
   select count(*) into v_remaining
     from pgque.dead_letter dl
     join pgque.queue q on q.queue_id = dl.dl_queue_id
     where q.queue_name = 'test_dlq_edges';
-  assert v_remaining = 0,
-    format('dlq_replay_all should drain the DLQ, %s rows left', v_remaining);
-
+  assert v_remaining = 0, 'dlq_replay_all should drain the DLQ';
   raise notice 'PASS: dlq_replay_all returns (replayed=2, failed=0, first_error=NULL)';
 end $$;
 
--- =========================================================================
--- Test 7: dlq_replay_all on an already-empty DLQ returns (0, 0, NULL).
--- =========================================================================
+-- Test 7: dlq_replay_all on an empty DLQ is a no-op.
 do $$
 declare
   v_replayed    bigint;
@@ -302,18 +225,11 @@ begin
   select replayed, failed, first_error into v_replayed, v_failed, v_first_error
     from pgque.dlq_replay_all('test_dlq_edges');
   assert v_replayed = 0 and v_failed = 0 and v_first_error is null,
-    format('dlq_replay_all on empty DLQ must be (0,0,NULL), got (%s,%s,%s)',
-      v_replayed, v_failed, coalesce(v_first_error, '<null>'));
+    'dlq_replay_all on empty DLQ must return (0, 0, NULL)';
   raise notice 'PASS: dlq_replay_all on empty DLQ is a no-op';
 end $$;
 
--- =========================================================================
--- Cleanup
--- =========================================================================
 do $$ begin
-  delete from pgque.dead_letter
-   where dl_queue_id = (select queue_id from pgque.queue
-                          where queue_name = 'test_dlq_edges');
   perform pgque.unsubscribe('test_dlq_edges', 'dle1');
   perform pgque.drop_queue('test_dlq_edges');
 end $$;

--- a/tests/test_dlq_edge_cases.sql
+++ b/tests/test_dlq_edge_cases.sql
@@ -1,0 +1,321 @@
+-- test_dlq_edge_cases.sql
+-- Edge-case coverage for the dead-letter API. Existing tests cover the
+-- nack-routes-to-DLQ path and basic dlq_inspect / dlq_replay flow; this
+-- file focuses on:
+--
+--   1. dlq_replay(dl_id) of an already-replayed entry RAISES
+--      'dead letter entry not found' (idempotent semantics: callers can
+--      detect double-replays).
+--   2. dlq_replay_all returns a (replayed, failed, first_error) record
+--      with correct counts on success, on partial failure, and on an
+--      empty DLQ.
+--   3. dlq_purge filters by age (older_than interval) and returns the
+--      number of rows deleted.
+--   4. dlq_inspect respects ordering (dl_time desc) and the limit.
+--
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+\set ON_ERROR_STOP on
+
+-- =========================================================================
+-- Setup: a queue with max_retries=0 so any nack lands directly in DLQ.
+-- =========================================================================
+do $$ begin
+  perform pgque.create_queue('test_dlq_edges');
+  perform pgque.set_queue_config('test_dlq_edges', 'max_retries', '0');
+  perform pgque.subscribe('test_dlq_edges', 'dle1');
+end $$;
+
+-- Send 3 events, tick, receive, nack each so we get 3 DLQ rows.
+do $$ begin
+  perform pgque.send('test_dlq_edges', 'dlq.a', '{"k":"a"}'::jsonb);
+  perform pgque.send('test_dlq_edges', 'dlq.b', '{"k":"b"}'::jsonb);
+  perform pgque.send('test_dlq_edges', 'dlq.c', '{"k":"c"}'::jsonb);
+end $$;
+
+do $$ begin
+  perform pgque.force_tick('test_dlq_edges');
+  perform pgque.ticker();
+end $$;
+
+do $$
+declare
+  v_msg     pgque.message;
+  v_batch   bigint;
+begin
+  -- All messages share one batch_id; nack each, ack the batch once.
+  for v_msg in select * from pgque.receive('test_dlq_edges', 'dle1', 100)
+  loop
+    v_batch := v_msg.batch_id;
+    perform pgque.nack(v_msg.batch_id, v_msg, '0 seconds'::interval, 'dead-' || v_msg.type);
+  end loop;
+  if v_batch is not null then
+    perform pgque.ack(v_batch);
+  end if;
+end $$;
+
+-- Sanity: 3 DLQ rows landed.
+do $$
+declare
+  v_count bigint;
+begin
+  select count(*) into v_count
+    from pgque.dead_letter dl
+    join pgque.queue q on q.queue_id = dl.dl_queue_id
+    where q.queue_name = 'test_dlq_edges';
+  assert v_count = 3, format('expected 3 DLQ rows, got %s', v_count);
+end $$;
+
+-- =========================================================================
+-- Test 1: dlq_replay(dl_id) of the same id twice raises on the second call.
+-- =========================================================================
+do $$
+declare
+  v_dl_id   bigint;
+  v_new_eid bigint;
+  v_ok      boolean := false;
+begin
+  -- Pick the oldest DLQ entry (deterministic ordering by dl_id).
+  select dl.dl_id into v_dl_id
+    from pgque.dead_letter dl
+    join pgque.queue q on q.queue_id = dl.dl_queue_id
+    where q.queue_name = 'test_dlq_edges'
+    order by dl.dl_id
+    limit 1;
+
+  v_new_eid := pgque.dlq_replay(v_dl_id);
+  assert v_new_eid is not null, 'first dlq_replay must return a new ev_id';
+
+  -- The replayed event sits in the live queue now. Other tests in this
+  -- file expect a clean queue, so drop_queue at the end takes care of it;
+  -- we just need to avoid double-replaying same dl_id below.
+
+  -- Second replay of same dl_id: row was deleted, must raise.
+  begin
+    perform pgque.dlq_replay(v_dl_id);
+    raise exception 'expected second dlq_replay(%) to raise', v_dl_id;
+  exception when raise_exception then
+    assert sqlerrm like 'dead letter entry not found%',
+      format('expected "dead letter entry not found", got: %s', sqlerrm);
+    v_ok := true;
+  end;
+  assert v_ok, 'second dlq_replay did not raise';
+  raise notice 'PASS: dlq_replay() of already-replayed dl_id raises';
+end $$;
+
+-- =========================================================================
+-- Test 2: dlq_replay(unknown dl_id) raises 'dead letter entry not found'
+-- =========================================================================
+do $$
+declare
+  v_ok boolean := false;
+begin
+  begin
+    perform pgque.dlq_replay(9999999996::bigint);
+    raise exception 'expected dlq_replay(unknown) to raise';
+  exception when raise_exception then
+    assert sqlerrm like 'dead letter entry not found%',
+      format('expected "dead letter entry not found", got: %s', sqlerrm);
+    v_ok := true;
+  end;
+  assert v_ok, 'dlq_replay(unknown) did not raise';
+  raise notice 'PASS: dlq_replay(unknown dl_id) raises';
+end $$;
+
+-- =========================================================================
+-- Test 3: dlq_inspect respects limit and returns rows from the right queue.
+-- (We can't reliably pin dl_time desc ordering here because all 3 rows
+-- were nacked inside one transaction, so they share now() — the dl_time
+-- desc order is then a tie. Pin the contract that holds in any case:
+-- limit clamps; rows match the underlying table; queue scoping is
+-- correct.)
+-- =========================================================================
+do $$
+declare
+  v_rows int;
+  v_table_ids bigint[];
+  v_inspect_ids bigint[];
+begin
+  -- We replayed one entry above, so 2 remain.
+  select count(*) into v_rows
+    from pgque.dlq_inspect('test_dlq_edges', 100);
+  assert v_rows = 2, format('expected 2 DLQ rows visible to dlq_inspect, got %s', v_rows);
+
+  -- Limit must clamp.
+  select count(*) into v_rows
+    from pgque.dlq_inspect('test_dlq_edges', 1);
+  assert v_rows = 1, format('expected dlq_inspect(..., 1) to return 1 row, got %s', v_rows);
+
+  -- The set of dl_ids returned by dlq_inspect must equal the set in the
+  -- underlying table for this queue.
+  select array_agg(dl.dl_id order by dl.dl_id) into v_table_ids
+    from pgque.dead_letter dl
+    join pgque.queue q on q.queue_id = dl.dl_queue_id
+    where q.queue_name = 'test_dlq_edges';
+
+  select array_agg(dl.dl_id order by dl.dl_id) into v_inspect_ids
+    from pgque.dlq_inspect('test_dlq_edges', 100) dl;
+
+  assert v_table_ids = v_inspect_ids,
+    format('dlq_inspect rows mismatch table: table=%s inspect=%s',
+      v_table_ids, v_inspect_ids);
+
+  raise notice 'PASS: dlq_inspect rows match underlying table and respect limit';
+end $$;
+
+-- =========================================================================
+-- Test 4: dlq_purge with cutoff in the future (large interval) returns 0.
+-- (Entries are recent; older_than = 1 day means delete rows older than 1 day,
+-- which is none.)
+-- =========================================================================
+do $$
+declare
+  v_cnt integer;
+  v_remaining bigint;
+begin
+  v_cnt := pgque.dlq_purge('test_dlq_edges', '1 day'::interval);
+  assert v_cnt = 0,
+    format('dlq_purge(1 day) on fresh entries must delete 0, got %s', v_cnt);
+
+  select count(*) into v_remaining
+    from pgque.dead_letter dl
+    join pgque.queue q on q.queue_id = dl.dl_queue_id
+    where q.queue_name = 'test_dlq_edges';
+  assert v_remaining = 2,
+    format('dlq_purge(1 day) must not touch fresh rows; remaining=%s', v_remaining);
+
+  raise notice 'PASS: dlq_purge with future cutoff is a no-op';
+end $$;
+
+-- =========================================================================
+-- Test 5: dlq_purge with age 0 deletes everything and returns the count.
+-- =========================================================================
+do $$
+declare
+  v_cnt integer;
+  v_remaining bigint;
+begin
+  v_cnt := pgque.dlq_purge('test_dlq_edges', '0 seconds'::interval);
+  assert v_cnt = 2,
+    format('dlq_purge(0s) must delete the 2 remaining rows, got %s', v_cnt);
+
+  select count(*) into v_remaining
+    from pgque.dead_letter dl
+    join pgque.queue q on q.queue_id = dl.dl_queue_id
+    where q.queue_name = 'test_dlq_edges';
+  assert v_remaining = 0,
+    format('after dlq_purge(0s), no DLQ rows for this queue, got %s', v_remaining);
+
+  -- Re-running dlq_purge on an empty DLQ is a no-op (returns 0).
+  v_cnt := pgque.dlq_purge('test_dlq_edges', '0 seconds'::interval);
+  assert v_cnt = 0,
+    format('dlq_purge on empty DLQ must return 0, got %s', v_cnt);
+
+  raise notice 'PASS: dlq_purge deletes by age and returns row count';
+end $$;
+
+-- =========================================================================
+-- Test 6: dlq_replay_all returns (replayed, failed, first_error) record.
+-- =========================================================================
+
+-- Drain the queue first: Test 1's dlq_replay re-inserted dlq.a as a live
+-- event; consume + ack it cleanly so it doesn't pollute the next batch.
+do $$ begin
+  perform pgque.force_tick('test_dlq_edges');
+  perform pgque.ticker();
+end $$;
+
+do $$
+declare
+  v_msg   pgque.message;
+  v_batch bigint;
+begin
+  for v_msg in select * from pgque.receive('test_dlq_edges', 'dle1', 100) loop
+    v_batch := v_msg.batch_id;
+  end loop;
+  if v_batch is not null then
+    perform pgque.ack(v_batch);
+  end if;
+end $$;
+
+-- Repopulate the DLQ with 2 rows.
+do $$ begin
+  perform pgque.send('test_dlq_edges', 'dlq.x', '{"k":"x"}'::jsonb);
+  perform pgque.send('test_dlq_edges', 'dlq.y', '{"k":"y"}'::jsonb);
+end $$;
+
+do $$ begin
+  perform pgque.force_tick('test_dlq_edges');
+  perform pgque.ticker();
+end $$;
+
+do $$
+declare
+  v_msg   pgque.message;
+  v_batch bigint;
+begin
+  for v_msg in select * from pgque.receive('test_dlq_edges', 'dle1', 100)
+  loop
+    v_batch := v_msg.batch_id;
+    perform pgque.nack(v_msg.batch_id, v_msg, '0 seconds'::interval, 'dead-again');
+  end loop;
+  if v_batch is not null then
+    perform pgque.ack(v_batch);
+  end if;
+end $$;
+
+do $$
+declare
+  v_replayed    bigint;
+  v_failed      bigint;
+  v_first_error text;
+  v_remaining   bigint;
+begin
+  select replayed, failed, first_error into v_replayed, v_failed, v_first_error
+    from pgque.dlq_replay_all('test_dlq_edges');
+  assert v_replayed = 2,
+    format('dlq_replay_all should replay 2 rows, got %s', v_replayed);
+  assert v_failed = 0,
+    format('dlq_replay_all should not fail any, got %s', v_failed);
+  assert v_first_error is null,
+    format('dlq_replay_all on success should leave first_error NULL, got %s', v_first_error);
+
+  select count(*) into v_remaining
+    from pgque.dead_letter dl
+    join pgque.queue q on q.queue_id = dl.dl_queue_id
+    where q.queue_name = 'test_dlq_edges';
+  assert v_remaining = 0,
+    format('dlq_replay_all should drain the DLQ, %s rows left', v_remaining);
+
+  raise notice 'PASS: dlq_replay_all returns (replayed=2, failed=0, first_error=NULL)';
+end $$;
+
+-- =========================================================================
+-- Test 7: dlq_replay_all on an already-empty DLQ returns (0, 0, NULL).
+-- =========================================================================
+do $$
+declare
+  v_replayed    bigint;
+  v_failed      bigint;
+  v_first_error text;
+begin
+  select replayed, failed, first_error into v_replayed, v_failed, v_first_error
+    from pgque.dlq_replay_all('test_dlq_edges');
+  assert v_replayed = 0 and v_failed = 0 and v_first_error is null,
+    format('dlq_replay_all on empty DLQ must be (0,0,NULL), got (%s,%s,%s)',
+      v_replayed, v_failed, coalesce(v_first_error, '<null>'));
+  raise notice 'PASS: dlq_replay_all on empty DLQ is a no-op';
+end $$;
+
+-- =========================================================================
+-- Cleanup
+-- =========================================================================
+do $$ begin
+  delete from pgque.dead_letter
+   where dl_queue_id = (select queue_id from pgque.queue
+                          where queue_name = 'test_dlq_edges');
+  perform pgque.unsubscribe('test_dlq_edges', 'dle1');
+  perform pgque.drop_queue('test_dlq_edges');
+end $$;
+
+\echo 'PASS: test_dlq_edge_cases'

--- a/tests/test_e2e_role_split.sql
+++ b/tests/test_e2e_role_split.sql
@@ -1,42 +1,21 @@
--- test_e2e_role_split.sql
--- End-to-end produce → tick → consume cycle exercised under the strict
--- producer/consumer role split. test_pgque_roles.sql checks the GRANT
--- table; test_security_producer_isolation.sql checks the cross-role
--- denials. This file checks the legitimate happy path:
---
---   set role pgque_test_producer;  -- has only pgque_writer
---     → pgque.send / pgque.send_batch     succeed
---     → pgque.ack / pgque.receive         denied
---   set role pgque_test_consumer;  -- has only pgque_reader
---     → pgque.subscribe / pgque.receive
---       / pgque.nack / pgque.ack          succeed
---     → pgque.send                        denied
---   admin: ticker + cleanup
---
--- A regression that, e.g., revoked send() from pgque_writer or moved
--- subscribe() back to pgque_writer would still pass test_pgque_roles
--- (it only checks the current grant table, not whether the function is
--- actually callable in a real transaction) but would break the install
--- the moment a real producer connection tried to publish. This test
--- catches that.
---
+-- test_e2e_role_split.sql -- e2e produce → tick → consume under role split
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- Existing role tests check the GRANT table (test_pgque_roles.sql) and
+-- cross-role denials (test_security_producer_isolation.sql). This file
+-- pins the legitimate happy path: a real `set role` produce → tick →
+-- consume cycle under the strict pgque_writer / pgque_reader split.
 
 \set ON_ERROR_STOP on
 
--- =========================================================================
--- Preamble: idempotent test-role cleanup so reruns on a shared dev DB
--- don't fail on duplicate roles.
--- =========================================================================
+-- Idempotent preamble: clean up any leftovers from a prior aborted run.
 do $$
 begin
   if exists (select 1 from pg_roles where rolname = 'pgque_test_producer') then
-    revoke all privileges on schema pgque from pgque_test_producer;
     revoke pgque_writer from pgque_test_producer;
     drop role pgque_test_producer;
   end if;
   if exists (select 1 from pg_roles where rolname = 'pgque_test_consumer') then
-    revoke all privileges on schema pgque from pgque_test_consumer;
     revoke pgque_reader from pgque_test_consumer;
     drop role pgque_test_consumer;
   end if;
@@ -50,11 +29,8 @@ do $$ begin
   end if;
 end $$;
 
--- =========================================================================
--- Setup: admin creates the queue + the two test roles.
--- NOLOGIN: set role does not require LOGIN, and prevents accidental
--- direct authentication if the test aborts before cleanup.
--- =========================================================================
+-- NOLOGIN: `set role` does not require LOGIN; a NOLOGIN role can't be
+-- authenticated against directly even if the test aborts before cleanup.
 create role pgque_test_producer nologin;
 grant pgque_writer to pgque_test_producer;
 
@@ -63,50 +39,34 @@ grant pgque_reader to pgque_test_consumer;
 
 select pgque.create_queue('test_e2e_split');
 
--- The consumer role must be able to subscribe itself (subscribe is on
--- pgque_reader since #163). Verify this end-to-end by calling subscribe
--- under the consumer role rather than the admin role.
+-- Subscribe under the consumer role itself (subscribe is on pgque_reader
+-- per the producer/consumer split).
 set role pgque_test_consumer;
 select pgque.subscribe('test_e2e_split', 'e2e_consumer');
 reset role;
 
--- =========================================================================
--- Producer half (set role pgque_test_producer): send single + batch
--- =========================================================================
+-- Producer: send + send_batch.
 set role pgque_test_producer;
 
 do $$
 declare
-  v_eid bigint;
   v_ids bigint[];
 begin
-  -- send (jsonb)
-  v_eid := pgque.send('test_e2e_split', 'split.single', '{"who":"producer","seq":1}'::jsonb);
-  assert v_eid is not null, 'producer must be able to send (jsonb)';
+  perform pgque.send('test_e2e_split', 'split.single', '{"who":"producer","seq":1}'::jsonb);
+  perform pgque.send('test_e2e_split', 'split.single_text', 'opaque-text'::text);
 
-  -- send (text fast path)
-  v_eid := pgque.send('test_e2e_split', 'split.single_text', 'opaque-text'::text);
-  assert v_eid is not null, 'producer must be able to send (text)';
+  v_ids := pgque.send_batch('test_e2e_split', 'split.batch_json',
+    array['{"n":1}'::jsonb, '{"n":2}'::jsonb, '{"n":3}'::jsonb]);
+  assert cardinality(v_ids) = 3, 'send_batch (jsonb[]) must return 3 ids';
 
-  -- send_batch (jsonb[])
-  v_ids := pgque.send_batch('test_e2e_split', 'split.batch_json', array[
-    '{"n":1}'::jsonb,
-    '{"n":2}'::jsonb,
-    '{"n":3}'::jsonb
-  ]);
-  assert cardinality(v_ids) = 3, 'producer must be able to send_batch (jsonb[])';
-
-  -- send_batch (text[])
-  v_ids := pgque.send_batch('test_e2e_split', 'split.batch_text', array[
-    'a', 'b'
-  ]::text[]);
-  assert cardinality(v_ids) = 2, 'producer must be able to send_batch (text[])';
+  v_ids := pgque.send_batch('test_e2e_split', 'split.batch_text',
+    array['a', 'b']::text[]);
+  assert cardinality(v_ids) = 2, 'send_batch (text[]) must return 2 ids';
 
   raise notice 'PASS: producer (pgque_writer) can send + send_batch';
 end $$;
 
--- Negative checks: producer must NOT be able to receive / ack / nack /
--- subscribe (those moved to pgque_reader in #163).
+-- Producer must NOT be able to receive / ack / subscribe.
 do $$
 declare
   v_ok boolean;
@@ -114,21 +74,18 @@ begin
   v_ok := false;
   begin
     perform * from pgque.receive('test_e2e_split', 'e2e_consumer', 1);
-    raise exception 'producer must not be able to receive';
   exception when insufficient_privilege then v_ok := true; end;
   assert v_ok, 'producer was able to call receive (regression)';
 
   v_ok := false;
   begin
     perform pgque.ack(1::bigint);
-    raise exception 'producer must not be able to ack';
   exception when insufficient_privilege then v_ok := true; end;
   assert v_ok, 'producer was able to call ack (regression)';
 
   v_ok := false;
   begin
     perform pgque.subscribe('test_e2e_split', 'producer_sub_attempt');
-    raise exception 'producer must not be able to subscribe';
   exception when insufficient_privilege then v_ok := true; end;
   assert v_ok, 'producer was able to call subscribe (regression)';
 
@@ -137,24 +94,19 @@ end $$;
 
 reset role;
 
--- =========================================================================
--- Admin half: ticker so the just-sent events become visible to consumers.
--- (ticker / force_tick are admin-only by grant; in production this is
--- pg_cron or a service role.)
--- =========================================================================
-select pgque.force_tick('test_e2e_split');
+-- Admin: ticker so the events become visible. ticker / force_next_tick are
+-- admin-only; in production this is pg_cron or a dedicated service role.
+select pgque.force_next_tick('test_e2e_split');
 select pgque.ticker('test_e2e_split');
 
--- =========================================================================
--- Consumer half (set role pgque_test_consumer): receive + ack + nack
--- =========================================================================
+-- Consumer: receive + ack.
 set role pgque_test_consumer;
 
 do $$
 declare
-  v_msg     pgque.message;
-  v_count   int := 0;
-  v_batch   bigint;
+  v_msg         pgque.message;
+  v_count       int := 0;
+  v_batch       bigint;
   v_seen_single boolean := false;
   v_seen_text   boolean := false;
   v_seen_batch  int := 0;
@@ -163,7 +115,6 @@ begin
   loop
     v_count := v_count + 1;
     v_batch := v_msg.batch_id;
-
     if v_msg.type = 'split.single' then v_seen_single := true; end if;
     if v_msg.type = 'split.single_text' then v_seen_text := true; end if;
     if v_msg.type in ('split.batch_json', 'split.batch_text') then
@@ -171,20 +122,16 @@ begin
     end if;
   end loop;
 
-  -- 1 single (jsonb) + 1 single (text) + 3 batch_json + 2 batch_text = 7
-  assert v_count = 7,
-    format('consumer must receive all 7 produced messages, got %s', v_count);
+  assert v_count = 7, format('consumer must receive 7 produced messages, got %s', v_count);
   assert v_seen_single, 'expected split.single message';
   assert v_seen_text,   'expected split.single_text message';
-  assert v_seen_batch = 5,
-    format('expected 5 batch messages, saw %s', v_seen_batch);
+  assert v_seen_batch = 5, format('expected 5 batch messages, saw %s', v_seen_batch);
 
-  -- ack must succeed and return 1.
   assert pgque.ack(v_batch) = 1, 'consumer ack must return 1 on success';
   raise notice 'PASS: consumer (pgque_reader) can receive + ack the full batch';
 end $$;
 
--- Negative checks: consumer must NOT be able to send (#163 split).
+-- Consumer must NOT be able to send.
 do $$
 declare
   v_ok boolean;
@@ -192,7 +139,6 @@ begin
   v_ok := false;
   begin
     perform pgque.send('test_e2e_split', 'split.illegal', '{"who":"consumer"}'::jsonb);
-    raise exception 'consumer must not be able to send';
   exception when insufficient_privilege then v_ok := true; end;
   assert v_ok, 'consumer was able to call send (regression)';
 
@@ -200,7 +146,6 @@ begin
   begin
     perform pgque.send_batch('test_e2e_split', 'split.illegal',
       array['{"n":1}'::jsonb]);
-    raise exception 'consumer must not be able to send_batch';
   exception when insufficient_privilege then v_ok := true; end;
   assert v_ok, 'consumer was able to call send_batch (regression)';
 
@@ -209,19 +154,11 @@ end $$;
 
 reset role;
 
--- =========================================================================
--- Cleanup
--- =========================================================================
 set role pgque_test_consumer;
 select pgque.unsubscribe('test_e2e_split', 'e2e_consumer');
 reset role;
 
 select pgque.drop_queue('test_e2e_split', true);
-
-revoke pgque_writer from pgque_test_producer;
-revoke pgque_reader from pgque_test_consumer;
-revoke all privileges on schema pgque from pgque_test_producer;
-revoke all privileges on schema pgque from pgque_test_consumer;
 drop role pgque_test_producer;
 drop role pgque_test_consumer;
 

--- a/tests/test_e2e_role_split.sql
+++ b/tests/test_e2e_role_split.sql
@@ -1,0 +1,228 @@
+-- test_e2e_role_split.sql
+-- End-to-end produce → tick → consume cycle exercised under the strict
+-- producer/consumer role split. test_pgque_roles.sql checks the GRANT
+-- table; test_security_producer_isolation.sql checks the cross-role
+-- denials. This file checks the legitimate happy path:
+--
+--   set role pgque_test_producer;  -- has only pgque_writer
+--     → pgque.send / pgque.send_batch     succeed
+--     → pgque.ack / pgque.receive         denied
+--   set role pgque_test_consumer;  -- has only pgque_reader
+--     → pgque.subscribe / pgque.receive
+--       / pgque.nack / pgque.ack          succeed
+--     → pgque.send                        denied
+--   admin: ticker + cleanup
+--
+-- A regression that, e.g., revoked send() from pgque_writer or moved
+-- subscribe() back to pgque_writer would still pass test_pgque_roles
+-- (it only checks the current grant table, not whether the function is
+-- actually callable in a real transaction) but would break the install
+-- the moment a real producer connection tried to publish. This test
+-- catches that.
+--
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+\set ON_ERROR_STOP on
+
+-- =========================================================================
+-- Preamble: idempotent test-role cleanup so reruns on a shared dev DB
+-- don't fail on duplicate roles.
+-- =========================================================================
+do $$
+begin
+  if exists (select 1 from pg_roles where rolname = 'pgque_test_producer') then
+    revoke all privileges on schema pgque from pgque_test_producer;
+    revoke pgque_writer from pgque_test_producer;
+    drop role pgque_test_producer;
+  end if;
+  if exists (select 1 from pg_roles where rolname = 'pgque_test_consumer') then
+    revoke all privileges on schema pgque from pgque_test_consumer;
+    revoke pgque_reader from pgque_test_consumer;
+    drop role pgque_test_consumer;
+  end if;
+exception when others then
+  raise notice 'preamble cleanup: % / %', sqlstate, sqlerrm;
+end $$;
+
+do $$ begin
+  if exists (select 1 from pgque.queue where queue_name = 'test_e2e_split') then
+    perform pgque.drop_queue('test_e2e_split', true);
+  end if;
+end $$;
+
+-- =========================================================================
+-- Setup: admin creates the queue + the two test roles.
+-- NOLOGIN: set role does not require LOGIN, and prevents accidental
+-- direct authentication if the test aborts before cleanup.
+-- =========================================================================
+create role pgque_test_producer nologin;
+grant pgque_writer to pgque_test_producer;
+
+create role pgque_test_consumer nologin;
+grant pgque_reader to pgque_test_consumer;
+
+select pgque.create_queue('test_e2e_split');
+
+-- The consumer role must be able to subscribe itself (subscribe is on
+-- pgque_reader since #163). Verify this end-to-end by calling subscribe
+-- under the consumer role rather than the admin role.
+set role pgque_test_consumer;
+select pgque.subscribe('test_e2e_split', 'e2e_consumer');
+reset role;
+
+-- =========================================================================
+-- Producer half (set role pgque_test_producer): send single + batch
+-- =========================================================================
+set role pgque_test_producer;
+
+do $$
+declare
+  v_eid bigint;
+  v_ids bigint[];
+begin
+  -- send (jsonb)
+  v_eid := pgque.send('test_e2e_split', 'split.single', '{"who":"producer","seq":1}'::jsonb);
+  assert v_eid is not null, 'producer must be able to send (jsonb)';
+
+  -- send (text fast path)
+  v_eid := pgque.send('test_e2e_split', 'split.single_text', 'opaque-text'::text);
+  assert v_eid is not null, 'producer must be able to send (text)';
+
+  -- send_batch (jsonb[])
+  v_ids := pgque.send_batch('test_e2e_split', 'split.batch_json', array[
+    '{"n":1}'::jsonb,
+    '{"n":2}'::jsonb,
+    '{"n":3}'::jsonb
+  ]);
+  assert cardinality(v_ids) = 3, 'producer must be able to send_batch (jsonb[])';
+
+  -- send_batch (text[])
+  v_ids := pgque.send_batch('test_e2e_split', 'split.batch_text', array[
+    'a', 'b'
+  ]::text[]);
+  assert cardinality(v_ids) = 2, 'producer must be able to send_batch (text[])';
+
+  raise notice 'PASS: producer (pgque_writer) can send + send_batch';
+end $$;
+
+-- Negative checks: producer must NOT be able to receive / ack / nack /
+-- subscribe (those moved to pgque_reader in #163).
+do $$
+declare
+  v_ok boolean;
+begin
+  v_ok := false;
+  begin
+    perform * from pgque.receive('test_e2e_split', 'e2e_consumer', 1);
+    raise exception 'producer must not be able to receive';
+  exception when insufficient_privilege then v_ok := true; end;
+  assert v_ok, 'producer was able to call receive (regression)';
+
+  v_ok := false;
+  begin
+    perform pgque.ack(1::bigint);
+    raise exception 'producer must not be able to ack';
+  exception when insufficient_privilege then v_ok := true; end;
+  assert v_ok, 'producer was able to call ack (regression)';
+
+  v_ok := false;
+  begin
+    perform pgque.subscribe('test_e2e_split', 'producer_sub_attempt');
+    raise exception 'producer must not be able to subscribe';
+  exception when insufficient_privilege then v_ok := true; end;
+  assert v_ok, 'producer was able to call subscribe (regression)';
+
+  raise notice 'PASS: producer (pgque_writer) is denied receive/ack/subscribe';
+end $$;
+
+reset role;
+
+-- =========================================================================
+-- Admin half: ticker so the just-sent events become visible to consumers.
+-- (ticker / force_tick are admin-only by grant; in production this is
+-- pg_cron or a service role.)
+-- =========================================================================
+select pgque.force_tick('test_e2e_split');
+select pgque.ticker('test_e2e_split');
+
+-- =========================================================================
+-- Consumer half (set role pgque_test_consumer): receive + ack + nack
+-- =========================================================================
+set role pgque_test_consumer;
+
+do $$
+declare
+  v_msg     pgque.message;
+  v_count   int := 0;
+  v_batch   bigint;
+  v_seen_single boolean := false;
+  v_seen_text   boolean := false;
+  v_seen_batch  int := 0;
+begin
+  for v_msg in select * from pgque.receive('test_e2e_split', 'e2e_consumer', 100)
+  loop
+    v_count := v_count + 1;
+    v_batch := v_msg.batch_id;
+
+    if v_msg.type = 'split.single' then v_seen_single := true; end if;
+    if v_msg.type = 'split.single_text' then v_seen_text := true; end if;
+    if v_msg.type in ('split.batch_json', 'split.batch_text') then
+      v_seen_batch := v_seen_batch + 1;
+    end if;
+  end loop;
+
+  -- 1 single (jsonb) + 1 single (text) + 3 batch_json + 2 batch_text = 7
+  assert v_count = 7,
+    format('consumer must receive all 7 produced messages, got %s', v_count);
+  assert v_seen_single, 'expected split.single message';
+  assert v_seen_text,   'expected split.single_text message';
+  assert v_seen_batch = 5,
+    format('expected 5 batch messages, saw %s', v_seen_batch);
+
+  -- ack must succeed and return 1.
+  assert pgque.ack(v_batch) = 1, 'consumer ack must return 1 on success';
+  raise notice 'PASS: consumer (pgque_reader) can receive + ack the full batch';
+end $$;
+
+-- Negative checks: consumer must NOT be able to send (#163 split).
+do $$
+declare
+  v_ok boolean;
+begin
+  v_ok := false;
+  begin
+    perform pgque.send('test_e2e_split', 'split.illegal', '{"who":"consumer"}'::jsonb);
+    raise exception 'consumer must not be able to send';
+  exception when insufficient_privilege then v_ok := true; end;
+  assert v_ok, 'consumer was able to call send (regression)';
+
+  v_ok := false;
+  begin
+    perform pgque.send_batch('test_e2e_split', 'split.illegal',
+      array['{"n":1}'::jsonb]);
+    raise exception 'consumer must not be able to send_batch';
+  exception when insufficient_privilege then v_ok := true; end;
+  assert v_ok, 'consumer was able to call send_batch (regression)';
+
+  raise notice 'PASS: consumer (pgque_reader) is denied send/send_batch';
+end $$;
+
+reset role;
+
+-- =========================================================================
+-- Cleanup
+-- =========================================================================
+set role pgque_test_consumer;
+select pgque.unsubscribe('test_e2e_split', 'e2e_consumer');
+reset role;
+
+select pgque.drop_queue('test_e2e_split', true);
+
+revoke pgque_writer from pgque_test_producer;
+revoke pgque_reader from pgque_test_consumer;
+revoke all privileges on schema pgque from pgque_test_producer;
+revoke all privileges on schema pgque from pgque_test_consumer;
+drop role pgque_test_producer;
+drop role pgque_test_consumer;
+
+\echo 'PASS: test_e2e_role_split'

--- a/tests/test_redelivery_contract.sql
+++ b/tests/test_redelivery_contract.sql
@@ -1,30 +1,15 @@
--- test_redelivery_contract.sql
--- SQL-level guarantee that backs the cross-driver "skip ack on nack-fail"
--- behavior. The Python / Go / TypeScript Consumers were updated so that
--- if any required nack() fails, the batch ack() is SKIPPED and PgQ is
--- expected to redeliver the affected messages on the next receive.
---
--- That contract only holds if the SQL side actually re-opens an unfinished
--- batch on the next next_batch() call. This test pins that:
---
---   1. receive() then NO ack: next receive() returns the SAME batch_id
---      (same messages, same ev_ids).
---   2. receive() then nack() of every message then ack(): next receive
---      returns nothing immediately (events sit in retry_queue), and
---      reappear after maint_retry_events + tick.
---   3. receive() then ack() (clean path): next receive returns nothing.
---
--- This isolates the at-least-once redelivery semantics PgQ already
--- provides from the higher-level driver behavior built on top.
---
+-- test_redelivery_contract.sql -- pin at-least-once redelivery semantics
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- The cross-driver "skip ack on nack-fail" mitigation only works if the SQL
+-- side actually re-opens an unfinished batch on the next next_batch. Pin:
+--   1. receive without ack → next receive yields the SAME batch_id / msg_id.
+--   2. nack + ack → events sit in retry_queue, redelivered with retry_count=1
+--      after maint_retry_events + tick.
+--   3. clean ack → next receive yields nothing.
+--   4. mixed ok / nack / ok batch → only the nacked row redelivers.
 
 \set ON_ERROR_STOP on
-
--- =========================================================================
--- Scenario 1: receive() with NO ack must redeliver the same batch.
--- This is the foundation of the cross-driver nack-fail mitigation.
--- =========================================================================
 
 create temporary table if not exists _rd_state (
     label text primary key, batch_id bigint, msg_id bigint
@@ -40,25 +25,20 @@ do $$ begin
 end $$;
 
 do $$ begin
-  perform pgque.force_tick('test_rd_no_ack');
+  perform pgque.force_next_tick('test_rd_no_ack');
   perform pgque.ticker();
 end $$;
 
--- First receive: capture batch_id and msg_id, then DO NOT ack.
+-- Scenario 1: receive without ack must redeliver the same batch.
 do $$
 declare
   v_msg pgque.message;
 begin
   select * into v_msg from pgque.receive('test_rd_no_ack', 'rd1', 10) limit 1;
-  assert v_msg.msg_id is not null, 'first receive must yield 1 message';
-
   delete from _rd_state where label = 'first';
-  insert into _rd_state(label, batch_id, msg_id) values ('first', v_msg.batch_id, v_msg.msg_id);
+  insert into _rd_state values ('first', v_msg.batch_id, v_msg.msg_id);
 end $$;
 
--- Second receive (no ack happened in between): MUST yield the same
--- batch_id and the same msg_id. PgQ's next_batch returns the carry-over
--- batch when sub_batch is still set.
 do $$
 declare
   v_msg          pgque.message;
@@ -72,36 +52,22 @@ begin
   for v_msg in select * from pgque.receive('test_rd_no_ack', 'rd1', 10)
   loop
     v_count := v_count + 1;
-    assert v_msg.batch_id = v_first_batch,
-      format('second receive must reopen the same batch_id; first=%s second=%s',
-        v_first_batch, v_msg.batch_id);
-    assert v_msg.msg_id = v_first_msg,
-      format('second receive must yield the same msg_id; first=%s second=%s',
-        v_first_msg, v_msg.msg_id);
+    assert v_msg.batch_id = v_first_batch, 'second receive must reopen the same batch_id';
+    assert v_msg.msg_id = v_first_msg,    'second receive must yield the same msg_id';
   end loop;
 
-  assert v_count = 1,
-    format('second receive must redeliver exactly 1 message, got %s', v_count);
-
-  -- Now ack so we don't strand the consumer for the next scenario.
+  assert v_count = 1, 'second receive must redeliver exactly 1 message';
   perform pgque.ack(v_first_batch);
   raise notice 'PASS: receive() without ack redelivers the same batch on next receive';
 end $$;
 
--- =========================================================================
--- Scenario 2: nack() then ack() routes the message into the retry path.
--- A subsequent receive returns nothing immediately; after
--- maint_retry_events + force_tick + ticker the message is delivered with
--- retry_count incremented. This is the at-least-once contract that the
--- high-level Consumer "ack on success / nack on failure" code relies on.
--- =========================================================================
-
+-- Scenario 2: nack + ack routes through retry_queue, reappears with retry_count=1.
 do $$ begin
   perform pgque.send('test_rd_no_ack', 'rd.msg', '{"n":2}'::jsonb);
 end $$;
 
 do $$ begin
-  perform pgque.force_tick('test_rd_no_ack');
+  perform pgque.force_next_tick('test_rd_no_ack');
   perform pgque.ticker();
 end $$;
 
@@ -110,18 +76,34 @@ declare
   v_msg pgque.message;
 begin
   select * into v_msg from pgque.receive('test_rd_no_ack', 'rd1', 10) limit 1;
-  assert v_msg.msg_id is not null, 'should receive the new message';
-
-  -- nack with 0 delay so maint_retry_events picks it up immediately.
+  -- 0-second delay so maint_retry_events picks it up immediately.
   perform pgque.nack(v_msg.batch_id, v_msg, '0 seconds'::interval, 'transient');
   perform pgque.ack(v_msg.batch_id);
-
-  delete from _rd_state where label = 'retry';
-  insert into _rd_state(label, batch_id, msg_id) values ('retry', v_msg.batch_id, v_msg.msg_id);
 end $$;
 
--- Right after ack: receive must not return the nacked message yet (it is
--- in retry_queue, not the live event table).
+-- Right after ack, the nacked message sits in retry_queue, not the live
+-- event table — receive must return nothing.
+do $$
+declare
+  v_count int := 0;
+  v_msg   pgque.message;
+begin
+  for v_msg in select * from pgque.receive('test_rd_no_ack', 'rd1', 10) loop
+    v_count := v_count + 1;
+  end loop;
+  assert v_count = 0, 'retry events must not be delivered before maint_retry_events';
+end $$;
+
+-- maint_retry_events, force_next_tick, and ticker must each commit in their own
+-- xact: the re-inserted event row has to commit before the next tick's
+-- snapshot is taken, or it will be filtered out as in-flight.
+do $$ begin perform pgque.maint_retry_events(); end $$;
+
+do $$ begin
+  perform pgque.force_next_tick('test_rd_no_ack');
+  perform pgque.ticker();
+end $$;
+
 do $$
 declare
   v_msg   pgque.message;
@@ -129,58 +111,20 @@ declare
 begin
   for v_msg in select * from pgque.receive('test_rd_no_ack', 'rd1', 10) loop
     v_count := v_count + 1;
-  end loop;
-  assert v_count = 0,
-    format('immediately after nack+ack, retry events must NOT be delivered, got %s', v_count);
-end $$;
-
--- Run maintenance to move retry_queue rows back into the event table.
--- IMPORTANT: maint_retry_events, force_tick, and ticker each need their
--- own transaction. The new event row must commit before the next tick's
--- snapshot is taken; otherwise the snapshot includes the inserting xact
--- in xip and filters the row out of the next batch.
-do $$ begin
-  perform pgque.maint_retry_events();
-end $$;
-
-do $$ begin
-  perform pgque.force_tick('test_rd_no_ack');
-  perform pgque.ticker();
-end $$;
-
--- Now receive must yield the retried message with retry_count incremented.
-do $$
-declare
-  v_msg          pgque.message;
-  v_count        int := 0;
-  v_seen_retry   boolean := false;
-begin
-  for v_msg in select * from pgque.receive('test_rd_no_ack', 'rd1', 10) loop
-    v_count := v_count + 1;
-    assert v_msg.retry_count = 1,
-      format('retried message must have retry_count=1, got %s',
-        coalesce(v_msg.retry_count::text, 'NULL'));
-    v_seen_retry := true;
+    assert v_msg.retry_count = 1, 'retried message must have retry_count=1';
     perform pgque.ack(v_msg.batch_id);
   end loop;
-  assert v_count = 1,
-    format('after maint_retry_events + tick, retried message must be delivered, got %s', v_count);
-  assert v_seen_retry, 'expected retried message';
+  assert v_count = 1, 'after maint_retry_events + tick, retried message must be delivered';
   raise notice 'PASS: nack() routes through retry_queue and reappears with retry_count=1';
 end $$;
 
--- =========================================================================
--- Scenario 3: clean ack() leaves no message redelivered.
--- (Sanity guard so a regression that always returns the previous batch
--- on next next_batch is caught from both sides.)
--- =========================================================================
-
+-- Scenario 3: clean ack does not redeliver.
 do $$ begin
   perform pgque.send('test_rd_no_ack', 'rd.msg', '{"n":3}'::jsonb);
 end $$;
 
 do $$ begin
-  perform pgque.force_tick('test_rd_no_ack');
+  perform pgque.force_next_tick('test_rd_no_ack');
   perform pgque.ticker();
 end $$;
 
@@ -189,7 +133,6 @@ declare
   v_msg pgque.message;
 begin
   select * into v_msg from pgque.receive('test_rd_no_ack', 'rd1', 10) limit 1;
-  assert v_msg.msg_id is not null, 'should receive cleanup message';
   perform pgque.ack(v_msg.batch_id);
 end $$;
 
@@ -201,14 +144,83 @@ begin
   for v_msg in select * from pgque.receive('test_rd_no_ack', 'rd1', 10) loop
     v_count := v_count + 1;
   end loop;
-  assert v_count = 0,
-    format('clean-acked message must not redeliver, got %s', v_count);
+  assert v_count = 0, 'clean-acked message must not redeliver';
   raise notice 'PASS: clean ack does not redeliver';
 end $$;
 
--- =========================================================================
--- Cleanup
--- =========================================================================
+-- Scenario 4: mixed batch behavior used by all three high-level clients.
+-- If a consumer successfully processes ok / boom / ok, nacks only boom,
+-- and then acks the underlying batch, only boom must reappear after retry
+-- maintenance. The ok rows are finished by the batch ack.
+do $$ begin
+  perform pgque.send('test_rd_no_ack', 'rd.ok',   '{"n":4}'::jsonb);
+  perform pgque.send('test_rd_no_ack', 'rd.boom', '{"n":5}'::jsonb);
+  perform pgque.send('test_rd_no_ack', 'rd.ok',   '{"n":6}'::jsonb);
+end $$;
+
+do $$ begin
+  perform pgque.force_next_tick('test_rd_no_ack');
+  perform pgque.ticker();
+end $$;
+
+do $$
+declare
+  v_msg       pgque.message;
+  v_batch     bigint;
+  v_seen_ok   int := 0;
+  v_seen_boom int := 0;
+begin
+  for v_msg in select * from pgque.receive('test_rd_no_ack', 'rd1', 10)
+  loop
+    v_batch := v_msg.batch_id;
+    if v_msg.type = 'rd.boom' then
+      v_seen_boom := v_seen_boom + 1;
+      perform pgque.nack(v_msg.batch_id, v_msg, '0 seconds'::interval, 'handler error: boom');
+    elsif v_msg.type = 'rd.ok' then
+      v_seen_ok := v_seen_ok + 1;
+    end if;
+  end loop;
+
+  assert v_seen_ok = 2,   format('expected 2 ok rows in mixed batch, got %s', v_seen_ok);
+  assert v_seen_boom = 1, format('expected 1 boom row in mixed batch, got %s', v_seen_boom);
+  perform pgque.ack(v_batch);
+end $$;
+
+-- The batch cursor advanced; before retry maintenance nothing from the
+-- original batch should be visible.
+do $$
+declare
+  v_count int := 0;
+  v_msg   pgque.message;
+begin
+  for v_msg in select * from pgque.receive('test_rd_no_ack', 'rd1', 10) loop
+    v_count := v_count + 1;
+  end loop;
+  assert v_count = 0, 'after partial nack + batch ack, original ok rows must be finished';
+end $$;
+
+do $$ begin perform pgque.maint_retry_events(); end $$;
+
+do $$ begin
+  perform pgque.force_next_tick('test_rd_no_ack');
+  perform pgque.ticker();
+end $$;
+
+do $$
+declare
+  v_msg   pgque.message;
+  v_count int := 0;
+begin
+  for v_msg in select * from pgque.receive('test_rd_no_ack', 'rd1', 10) loop
+    v_count := v_count + 1;
+    assert v_msg.type = 'rd.boom', format('only rd.boom may redeliver, got %s', v_msg.type);
+    assert v_msg.retry_count = 1, 'mixed-batch redelivery must have retry_count=1';
+    perform pgque.ack(v_msg.batch_id);
+  end loop;
+  assert v_count = 1, format('expected exactly 1 redelivered boom row, got %s', v_count);
+  raise notice 'PASS: mixed ok/nack/ok batch redelivers only the nacked row';
+end $$;
+
 drop table if exists _rd_state;
 
 do $$ begin

--- a/tests/test_redelivery_contract.sql
+++ b/tests/test_redelivery_contract.sql
@@ -1,0 +1,219 @@
+-- test_redelivery_contract.sql
+-- SQL-level guarantee that backs the cross-driver "skip ack on nack-fail"
+-- behavior. The Python / Go / TypeScript Consumers were updated so that
+-- if any required nack() fails, the batch ack() is SKIPPED and PgQ is
+-- expected to redeliver the affected messages on the next receive.
+--
+-- That contract only holds if the SQL side actually re-opens an unfinished
+-- batch on the next next_batch() call. This test pins that:
+--
+--   1. receive() then NO ack: next receive() returns the SAME batch_id
+--      (same messages, same ev_ids).
+--   2. receive() then nack() of every message then ack(): next receive
+--      returns nothing immediately (events sit in retry_queue), and
+--      reappear after maint_retry_events + tick.
+--   3. receive() then ack() (clean path): next receive returns nothing.
+--
+-- This isolates the at-least-once redelivery semantics PgQ already
+-- provides from the higher-level driver behavior built on top.
+--
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+\set ON_ERROR_STOP on
+
+-- =========================================================================
+-- Scenario 1: receive() with NO ack must redeliver the same batch.
+-- This is the foundation of the cross-driver nack-fail mitigation.
+-- =========================================================================
+
+create temporary table if not exists _rd_state (
+    label text primary key, batch_id bigint, msg_id bigint
+);
+
+do $$ begin
+  perform pgque.create_queue('test_rd_no_ack');
+  perform pgque.subscribe('test_rd_no_ack', 'rd1');
+end $$;
+
+do $$ begin
+  perform pgque.send('test_rd_no_ack', 'rd.msg', '{"n":1}'::jsonb);
+end $$;
+
+do $$ begin
+  perform pgque.force_tick('test_rd_no_ack');
+  perform pgque.ticker();
+end $$;
+
+-- First receive: capture batch_id and msg_id, then DO NOT ack.
+do $$
+declare
+  v_msg pgque.message;
+begin
+  select * into v_msg from pgque.receive('test_rd_no_ack', 'rd1', 10) limit 1;
+  assert v_msg.msg_id is not null, 'first receive must yield 1 message';
+
+  delete from _rd_state where label = 'first';
+  insert into _rd_state(label, batch_id, msg_id) values ('first', v_msg.batch_id, v_msg.msg_id);
+end $$;
+
+-- Second receive (no ack happened in between): MUST yield the same
+-- batch_id and the same msg_id. PgQ's next_batch returns the carry-over
+-- batch when sub_batch is still set.
+do $$
+declare
+  v_msg          pgque.message;
+  v_first_batch  bigint;
+  v_first_msg    bigint;
+  v_count        int := 0;
+begin
+  select batch_id, msg_id into v_first_batch, v_first_msg
+    from _rd_state where label = 'first';
+
+  for v_msg in select * from pgque.receive('test_rd_no_ack', 'rd1', 10)
+  loop
+    v_count := v_count + 1;
+    assert v_msg.batch_id = v_first_batch,
+      format('second receive must reopen the same batch_id; first=%s second=%s',
+        v_first_batch, v_msg.batch_id);
+    assert v_msg.msg_id = v_first_msg,
+      format('second receive must yield the same msg_id; first=%s second=%s',
+        v_first_msg, v_msg.msg_id);
+  end loop;
+
+  assert v_count = 1,
+    format('second receive must redeliver exactly 1 message, got %s', v_count);
+
+  -- Now ack so we don't strand the consumer for the next scenario.
+  perform pgque.ack(v_first_batch);
+  raise notice 'PASS: receive() without ack redelivers the same batch on next receive';
+end $$;
+
+-- =========================================================================
+-- Scenario 2: nack() then ack() routes the message into the retry path.
+-- A subsequent receive returns nothing immediately; after
+-- maint_retry_events + force_tick + ticker the message is delivered with
+-- retry_count incremented. This is the at-least-once contract that the
+-- high-level Consumer "ack on success / nack on failure" code relies on.
+-- =========================================================================
+
+do $$ begin
+  perform pgque.send('test_rd_no_ack', 'rd.msg', '{"n":2}'::jsonb);
+end $$;
+
+do $$ begin
+  perform pgque.force_tick('test_rd_no_ack');
+  perform pgque.ticker();
+end $$;
+
+do $$
+declare
+  v_msg pgque.message;
+begin
+  select * into v_msg from pgque.receive('test_rd_no_ack', 'rd1', 10) limit 1;
+  assert v_msg.msg_id is not null, 'should receive the new message';
+
+  -- nack with 0 delay so maint_retry_events picks it up immediately.
+  perform pgque.nack(v_msg.batch_id, v_msg, '0 seconds'::interval, 'transient');
+  perform pgque.ack(v_msg.batch_id);
+
+  delete from _rd_state where label = 'retry';
+  insert into _rd_state(label, batch_id, msg_id) values ('retry', v_msg.batch_id, v_msg.msg_id);
+end $$;
+
+-- Right after ack: receive must not return the nacked message yet (it is
+-- in retry_queue, not the live event table).
+do $$
+declare
+  v_msg   pgque.message;
+  v_count int := 0;
+begin
+  for v_msg in select * from pgque.receive('test_rd_no_ack', 'rd1', 10) loop
+    v_count := v_count + 1;
+  end loop;
+  assert v_count = 0,
+    format('immediately after nack+ack, retry events must NOT be delivered, got %s', v_count);
+end $$;
+
+-- Run maintenance to move retry_queue rows back into the event table.
+-- IMPORTANT: maint_retry_events, force_tick, and ticker each need their
+-- own transaction. The new event row must commit before the next tick's
+-- snapshot is taken; otherwise the snapshot includes the inserting xact
+-- in xip and filters the row out of the next batch.
+do $$ begin
+  perform pgque.maint_retry_events();
+end $$;
+
+do $$ begin
+  perform pgque.force_tick('test_rd_no_ack');
+  perform pgque.ticker();
+end $$;
+
+-- Now receive must yield the retried message with retry_count incremented.
+do $$
+declare
+  v_msg          pgque.message;
+  v_count        int := 0;
+  v_seen_retry   boolean := false;
+begin
+  for v_msg in select * from pgque.receive('test_rd_no_ack', 'rd1', 10) loop
+    v_count := v_count + 1;
+    assert v_msg.retry_count = 1,
+      format('retried message must have retry_count=1, got %s',
+        coalesce(v_msg.retry_count::text, 'NULL'));
+    v_seen_retry := true;
+    perform pgque.ack(v_msg.batch_id);
+  end loop;
+  assert v_count = 1,
+    format('after maint_retry_events + tick, retried message must be delivered, got %s', v_count);
+  assert v_seen_retry, 'expected retried message';
+  raise notice 'PASS: nack() routes through retry_queue and reappears with retry_count=1';
+end $$;
+
+-- =========================================================================
+-- Scenario 3: clean ack() leaves no message redelivered.
+-- (Sanity guard so a regression that always returns the previous batch
+-- on next next_batch is caught from both sides.)
+-- =========================================================================
+
+do $$ begin
+  perform pgque.send('test_rd_no_ack', 'rd.msg', '{"n":3}'::jsonb);
+end $$;
+
+do $$ begin
+  perform pgque.force_tick('test_rd_no_ack');
+  perform pgque.ticker();
+end $$;
+
+do $$
+declare
+  v_msg pgque.message;
+begin
+  select * into v_msg from pgque.receive('test_rd_no_ack', 'rd1', 10) limit 1;
+  assert v_msg.msg_id is not null, 'should receive cleanup message';
+  perform pgque.ack(v_msg.batch_id);
+end $$;
+
+do $$
+declare
+  v_count int := 0;
+  v_msg   pgque.message;
+begin
+  for v_msg in select * from pgque.receive('test_rd_no_ack', 'rd1', 10) loop
+    v_count := v_count + 1;
+  end loop;
+  assert v_count = 0,
+    format('clean-acked message must not redeliver, got %s', v_count);
+  raise notice 'PASS: clean ack does not redeliver';
+end $$;
+
+-- =========================================================================
+-- Cleanup
+-- =========================================================================
+drop table if exists _rd_state;
+
+do $$ begin
+  perform pgque.unsubscribe('test_rd_no_ack', 'rd1');
+  perform pgque.drop_queue('test_rd_no_ack');
+end $$;
+
+\echo 'PASS: test_redelivery_contract'

--- a/tests/test_snapshot_visibility_contract.sql
+++ b/tests/test_snapshot_visibility_contract.sql
@@ -1,74 +1,42 @@
--- test_snapshot_visibility_contract.sql
--- Codify PgQ's snapshot-isolation contract at the SQL level so client
--- drivers and example code can rely on it explicitly:
---
---   In a single transaction, send → ticker → receive returns ZERO
---   messages. The producing transaction's xid is in the tick snapshot's
---   xip list, so its events are filtered out of the next batch until
---   it commits.
---
--- The cross-driver Python tests exercise this from the application side
--- (see clients/python/tests/test_transaction_visibility.py); pin it on
--- the SQL side too. A regression that allowed in-progress xacts into the
--- batch would silently break at-least-once delivery (consumers could ack
--- a message whose producer later rolled back).
---
--- The complementary test — separate transactions for produce / tick /
--- receive deliver normally — is covered throughout the regression and
--- acceptance suites.
---
+-- test_snapshot_visibility_contract.sql -- pin PgQ snapshot isolation contract
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- A regression that let in-progress xacts into a tick batch would silently
+-- break at-least-once delivery: consumers could ack a message whose producer
+-- later rolled back. Pin four invariants:
+--   1. send + tick + receive in ONE xact yields 0 (producing xid is in xip).
+--   2. After commit + new tick, the deferred message delivers exactly once.
+--   3. A rolled-back send is invisible to consumers.
+--   4. maint_retry_events + tick + receive has the same separate-xact rule.
 
 \set ON_ERROR_STOP on
 
--- =========================================================================
--- Setup (separate transaction so create_queue + subscribe commit cleanly).
--- =========================================================================
 do $$ begin
   perform pgque.create_queue('test_snapshot_vis');
   perform pgque.subscribe('test_snapshot_vis', 'sv1');
 end $$;
 
--- =========================================================================
--- Test 1: send + force_tick + ticker + receive in ONE transaction yields
--- 0 messages. The whole DO block is a single PL/pgSQL transaction.
--- =========================================================================
+-- Test 1: same-xact send + tick + receive returns 0.
 do $$
 declare
-  v_msg     pgque.message;
-  v_count   int := 0;
-  v_eid     bigint;
-  v_tid     bigint;
+  v_msg   pgque.message;
+  v_count int := 0;
 begin
-  v_eid := pgque.send('test_snapshot_vis', 'sv.same_xact', '{"k":"sv"}'::jsonb);
-  assert v_eid is not null, 'send must return a non-NULL ev_id';
-
-  v_tid := pgque.force_tick('test_snapshot_vis');
-  assert v_tid is not null, 'force_tick must return a non-NULL tick id';
-
+  perform pgque.send('test_snapshot_vis', 'sv.same_xact', '{"k":"sv"}'::jsonb);
+  perform pgque.force_next_tick('test_snapshot_vis');
   perform pgque.ticker('test_snapshot_vis');
 
   for v_msg in select * from pgque.receive('test_snapshot_vis', 'sv1', 100) loop
     v_count := v_count + 1;
   end loop;
 
-  assert v_count = 0,
-    format('PgQ snapshot contract: send + tick + receive in ONE xact must '
-           'yield 0 messages (the producing xid is in the tick snapshot xip '
-           'list); got %s', v_count);
-
+  assert v_count = 0, 'same-xact send + tick + receive must yield 0 messages';
   raise notice 'PASS: same-xact send + tick + receive returns 0 (snapshot contract)';
 end $$;
 
--- =========================================================================
--- Test 2: after the previous DO block committed, a fresh receive() in a
--- NEW transaction must see the message that test 1 sent. The same-xact
--- invisibility was not loss — it was just deferred until commit.
--- =========================================================================
--- Re-tick from a separate xact so a new tick snapshot captures the
--- now-committed event.
+-- Test 2: after commit + new tick, the deferred message delivers exactly once.
 do $$ begin
-  perform pgque.force_tick('test_snapshot_vis');
+  perform pgque.force_next_tick('test_snapshot_vis');
   perform pgque.ticker('test_snapshot_vis');
 end $$;
 
@@ -82,39 +50,23 @@ begin
     perform pgque.ack(v_msg.batch_id);
   end loop;
 
-  assert v_count = 1,
-    format('after commit + new tick, the deferred message must deliver '
-           'exactly once, got %s', v_count);
+  assert v_count = 1, 'after commit + new tick, the deferred message must deliver exactly once';
   raise notice 'PASS: deferred message delivers in next xact (commit + tick)';
 end $$;
 
--- =========================================================================
--- Test 3: rollback semantics. Send inside a sub-block that intentionally
--- rolls back via raise+catch must NOT leave any visible message — the
--- canonical "consumer never sees uncommitted work" guarantee that
--- transactional outboxes rely on.
---
--- A PL/pgSQL EXCEPTION block creates a subtransaction; raising inside it
--- and catching outside rolls back only that subtransaction's work.
--- Verify that a send() rolled back this way produces 0 visible messages
--- after a fresh tick + receive.
--- =========================================================================
-do $$
-declare
-  v_eid bigint;
-begin
+-- Test 3: a rolled-back send is invisible to consumers. A PL/pgSQL
+-- exception block is a subtransaction; raising inside and catching
+-- outside rolls back only that subtransaction's work.
+do $$ begin
   begin
-    v_eid := pgque.send('test_snapshot_vis', 'sv.rollback', '{"k":"rb"}'::jsonb);
-    assert v_eid is not null;
+    perform pgque.send('test_snapshot_vis', 'sv.rollback', '{"k":"rb"}'::jsonb);
     raise exception 'rollback this subxact';
-  exception when others then
-    -- Swallow: the inner block's send() is rolled back.
-    null;
+  exception when others then null;
   end;
 end $$;
 
 do $$ begin
-  perform pgque.force_tick('test_snapshot_vis');
+  perform pgque.force_next_tick('test_snapshot_vis');
   perform pgque.ticker('test_snapshot_vis');
 end $$;
 
@@ -122,25 +74,76 @@ do $$
 declare
   v_msg   pgque.message;
   v_count int := 0;
-  v_batch bigint;
 begin
   for v_msg in select * from pgque.receive('test_snapshot_vis', 'sv1', 100) loop
     v_count := v_count + 1;
-    v_batch := v_msg.batch_id;
   end loop;
-
-  -- The rolled-back send must not produce any deliverable message.
-  assert v_count = 0,
-    format('rolled-back send must produce 0 deliverable messages, got %s', v_count);
-
-  -- empty receive() must finish the empty batch internally (#103); no
-  -- v_batch to ack here.
+  assert v_count = 0, 'rolled-back send must be invisible to consumers';
   raise notice 'PASS: rolled-back send is invisible to consumers';
 end $$;
 
--- =========================================================================
--- Cleanup
--- =========================================================================
+-- Test 4: maint_retry_events + tick + receive also needs committed xact
+-- boundaries. The docs call this out as a contract: the retry row is
+-- reinserted with the current xid, so a tick snapshot taken in the same xact
+-- must not expose it.
+do $$ begin
+  perform pgque.send('test_snapshot_vis', 'sv.retry', '{"k":"retry"}'::jsonb);
+end $$;
+
+do $$ begin
+  perform pgque.force_next_tick('test_snapshot_vis');
+  perform pgque.ticker('test_snapshot_vis');
+end $$;
+
+do $$
+declare
+  v_msg pgque.message;
+begin
+  select * into v_msg from pgque.receive('test_snapshot_vis', 'sv1', 100) limit 1;
+  assert v_msg.msg_id is not null, 'retry setup expected one visible message';
+  perform pgque.nack(v_msg.batch_id, v_msg, '0 seconds'::interval, 'snapshot retry');
+  perform pgque.ack(v_msg.batch_id);
+end $$;
+
+-- Anti-pattern from the docs: same transaction for retry maintenance, tick,
+-- and receive. It must return zero rows.
+do $$
+declare
+  v_msg   pgque.message;
+  v_count int := 0;
+begin
+  perform pgque.maint_retry_events();
+  perform pgque.force_next_tick('test_snapshot_vis');
+  perform pgque.ticker('test_snapshot_vis');
+
+  for v_msg in select * from pgque.receive('test_snapshot_vis', 'sv1', 100) loop
+    v_count := v_count + 1;
+  end loop;
+
+  assert v_count = 0, 'same-xact maint_retry_events + tick + receive must yield 0 messages';
+  raise notice 'PASS: same-xact maint_retry_events + tick + receive returns 0';
+end $$;
+
+-- Correct pattern: after commit, tick again in a new xact, then receive.
+do $$ begin
+  perform pgque.force_next_tick('test_snapshot_vis');
+  perform pgque.ticker('test_snapshot_vis');
+end $$;
+
+do $$
+declare
+  v_msg   pgque.message;
+  v_count int := 0;
+begin
+  for v_msg in select * from pgque.receive('test_snapshot_vis', 'sv1', 100) loop
+    v_count := v_count + 1;
+    assert v_msg.type = 'sv.retry', format('expected sv.retry redelivery, got %s', v_msg.type);
+    perform pgque.ack(v_msg.batch_id);
+  end loop;
+  assert v_count = 1, 'after committed retry maintenance + new tick, retried row must deliver';
+  raise notice 'PASS: committed maint_retry_events + tick + receive delivers retry row';
+end $$;
+
 do $$ begin
   perform pgque.unsubscribe('test_snapshot_vis', 'sv1');
   perform pgque.drop_queue('test_snapshot_vis');

--- a/tests/test_snapshot_visibility_contract.sql
+++ b/tests/test_snapshot_visibility_contract.sql
@@ -1,0 +1,149 @@
+-- test_snapshot_visibility_contract.sql
+-- Codify PgQ's snapshot-isolation contract at the SQL level so client
+-- drivers and example code can rely on it explicitly:
+--
+--   In a single transaction, send → ticker → receive returns ZERO
+--   messages. The producing transaction's xid is in the tick snapshot's
+--   xip list, so its events are filtered out of the next batch until
+--   it commits.
+--
+-- The cross-driver Python tests exercise this from the application side
+-- (see clients/python/tests/test_transaction_visibility.py); pin it on
+-- the SQL side too. A regression that allowed in-progress xacts into the
+-- batch would silently break at-least-once delivery (consumers could ack
+-- a message whose producer later rolled back).
+--
+-- The complementary test — separate transactions for produce / tick /
+-- receive deliver normally — is covered throughout the regression and
+-- acceptance suites.
+--
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+\set ON_ERROR_STOP on
+
+-- =========================================================================
+-- Setup (separate transaction so create_queue + subscribe commit cleanly).
+-- =========================================================================
+do $$ begin
+  perform pgque.create_queue('test_snapshot_vis');
+  perform pgque.subscribe('test_snapshot_vis', 'sv1');
+end $$;
+
+-- =========================================================================
+-- Test 1: send + force_tick + ticker + receive in ONE transaction yields
+-- 0 messages. The whole DO block is a single PL/pgSQL transaction.
+-- =========================================================================
+do $$
+declare
+  v_msg     pgque.message;
+  v_count   int := 0;
+  v_eid     bigint;
+  v_tid     bigint;
+begin
+  v_eid := pgque.send('test_snapshot_vis', 'sv.same_xact', '{"k":"sv"}'::jsonb);
+  assert v_eid is not null, 'send must return a non-NULL ev_id';
+
+  v_tid := pgque.force_tick('test_snapshot_vis');
+  assert v_tid is not null, 'force_tick must return a non-NULL tick id';
+
+  perform pgque.ticker('test_snapshot_vis');
+
+  for v_msg in select * from pgque.receive('test_snapshot_vis', 'sv1', 100) loop
+    v_count := v_count + 1;
+  end loop;
+
+  assert v_count = 0,
+    format('PgQ snapshot contract: send + tick + receive in ONE xact must '
+           'yield 0 messages (the producing xid is in the tick snapshot xip '
+           'list); got %s', v_count);
+
+  raise notice 'PASS: same-xact send + tick + receive returns 0 (snapshot contract)';
+end $$;
+
+-- =========================================================================
+-- Test 2: after the previous DO block committed, a fresh receive() in a
+-- NEW transaction must see the message that test 1 sent. The same-xact
+-- invisibility was not loss — it was just deferred until commit.
+-- =========================================================================
+-- Re-tick from a separate xact so a new tick snapshot captures the
+-- now-committed event.
+do $$ begin
+  perform pgque.force_tick('test_snapshot_vis');
+  perform pgque.ticker('test_snapshot_vis');
+end $$;
+
+do $$
+declare
+  v_msg   pgque.message;
+  v_count int := 0;
+begin
+  for v_msg in select * from pgque.receive('test_snapshot_vis', 'sv1', 100) loop
+    v_count := v_count + 1;
+    perform pgque.ack(v_msg.batch_id);
+  end loop;
+
+  assert v_count = 1,
+    format('after commit + new tick, the deferred message must deliver '
+           'exactly once, got %s', v_count);
+  raise notice 'PASS: deferred message delivers in next xact (commit + tick)';
+end $$;
+
+-- =========================================================================
+-- Test 3: rollback semantics. Send inside a sub-block that intentionally
+-- rolls back via raise+catch must NOT leave any visible message — the
+-- canonical "consumer never sees uncommitted work" guarantee that
+-- transactional outboxes rely on.
+--
+-- A PL/pgSQL EXCEPTION block creates a subtransaction; raising inside it
+-- and catching outside rolls back only that subtransaction's work.
+-- Verify that a send() rolled back this way produces 0 visible messages
+-- after a fresh tick + receive.
+-- =========================================================================
+do $$
+declare
+  v_eid bigint;
+begin
+  begin
+    v_eid := pgque.send('test_snapshot_vis', 'sv.rollback', '{"k":"rb"}'::jsonb);
+    assert v_eid is not null;
+    raise exception 'rollback this subxact';
+  exception when others then
+    -- Swallow: the inner block's send() is rolled back.
+    null;
+  end;
+end $$;
+
+do $$ begin
+  perform pgque.force_tick('test_snapshot_vis');
+  perform pgque.ticker('test_snapshot_vis');
+end $$;
+
+do $$
+declare
+  v_msg   pgque.message;
+  v_count int := 0;
+  v_batch bigint;
+begin
+  for v_msg in select * from pgque.receive('test_snapshot_vis', 'sv1', 100) loop
+    v_count := v_count + 1;
+    v_batch := v_msg.batch_id;
+  end loop;
+
+  -- The rolled-back send must not produce any deliverable message.
+  assert v_count = 0,
+    format('rolled-back send must produce 0 deliverable messages, got %s', v_count);
+
+  -- empty receive() must finish the empty batch internally (#103); no
+  -- v_batch to ack here.
+  raise notice 'PASS: rolled-back send is invisible to consumers';
+end $$;
+
+-- =========================================================================
+-- Cleanup
+-- =========================================================================
+do $$ begin
+  perform pgque.unsubscribe('test_snapshot_vis', 'sv1');
+  perform pgque.drop_queue('test_snapshot_vis');
+end $$;
+
+\echo 'PASS: test_snapshot_visibility_contract'

--- a/tests/test_ticker_returns_contract.sql
+++ b/tests/test_ticker_returns_contract.sql
@@ -1,39 +1,17 @@
--- test_ticker_returns_contract.sql
--- SQL-level contract tests for pgque.ticker() and pgque.force_tick() return
--- values. The TypeScript driver (and operator scripts) consume these
--- integers; a regression that returns void / NULL / wrong shape would be
--- silent on the SQL side but break tooling.
---
--- Contract pinned here:
---   pgque.ticker(queue text)       returns bigint -- new tick id, or NULL
---                                                    when no tick was needed
---                                                    (throttle in effect)
---   pgque.ticker()                 returns bigint -- count of queues that
---                                                    had a tick inserted
---                                                    on this call
---   pgque.force_tick(queue text)   returns bigint -- last tick id (every
---                                                    queue carries an
---                                                    initial tick from
---                                                    create_queue, so this
---                                                    is non-NULL whenever
---                                                    the queue exists);
---                                                    NULL if the queue
---                                                    name is unknown
---   pgque.ticker(queue) on an unknown queue  RAISES 'no such queue'
---   pgque.ticker(queue) on paused queue      RAISES 'Ticker has been paused'
---   pgque.ticker(queue) on external_ticker   RAISES 'external tick source'
---
--- Subtlety: force_tick on a paused / external queue does NOT bump
--- event_seq (the WHERE clause filters those out), but the second SELECT
--- still returns the existing last tick id. Pin both halves explicitly.
---
+-- test_ticker_returns_contract.sql -- pin pgque.ticker / force_next_tick return shapes
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- ticker(queue text)       -> bigint  -- new tick id, or NULL when throttled
+-- ticker()                 -> bigint  -- count of queues that ticked
+-- force_next_tick(queue)   -> bigint  -- last tick id; raises for unknown / paused / external queues
+-- force_tick(queue)        -> compatibility alias, covered by test_force_next_tick_alias.sql
+-- ticker(unknown)          RAISES 'no such queue'
+-- ticker(paused)           RAISES 'Ticker has been paused'
+-- ticker(external)         RAISES 'external tick source'
 
 \set ON_ERROR_STOP on
 
--- =========================================================================
--- Test 1: ticker(queue) returns a bigint > 0 when a tick is created
--- =========================================================================
+-- Test 1: ticker(queue) returns bigint > 0 when a tick is created.
 do $$ begin
   perform pgque.create_queue('test_ticker_ret');
   perform pgque.subscribe('test_ticker_ret', 'rt1');
@@ -43,109 +21,74 @@ do $$ begin
   perform pgque.send('test_ticker_ret', 'rt.test', '{"n":1}'::jsonb);
 end $$;
 
--- The first call after we have new events should insert a tick and return
--- a positive bigint (the new tick id). Use force_tick first to bump the
--- event_seq above ticker_max_count so the throttle never fires.
 do $$
 declare
   v_force bigint;
   v_tid   bigint;
 begin
-  v_force := pgque.force_tick('test_ticker_ret');
-  -- force_tick inserts (or no-ops) and reports the last tick id; with our
-  -- fresh queue + one event, the last tick id must be a positive bigint.
-  assert v_force is not null,
-    'force_tick on a fresh queue with events must return a tick id';
-  assert v_force > 0,
-    format('force_tick should return a positive bigint, got %s', v_force);
+  v_force := pgque.force_next_tick('test_ticker_ret');
+  assert v_force > 0, 'force_next_tick must return a positive tick id';
 
-  -- ticker(queue) returns either a tick id or NULL (if throttled). After
-  -- force_tick we just bumped event_seq aggressively, so the next ticker
-  -- call should also tick. We can't pin "always non-null" without timing
-  -- assumptions, so test the *type* (bigint) and that it's non-negative
-  -- when set.
+  -- ticker(queue) may return NULL when throttled; if non-null, must be > 0.
   v_tid := pgque.ticker('test_ticker_ret');
-  if v_tid is not null then
-    assert v_tid > 0,
-      format('ticker(queue) tick id must be positive when present, got %s', v_tid);
-  end if;
+  assert v_tid is null or v_tid > 0, 'ticker(queue) tick id must be positive when present';
 
-  raise notice 'PASS: ticker(queue) and force_tick(queue) return bigint';
+  raise notice 'PASS: ticker(queue) and force_next_tick(queue) return bigint';
 end $$;
 
--- =========================================================================
--- Test 2: ticker() (zero-arg) returns the count of queues that ticked
--- =========================================================================
+-- Test 2: zero-arg ticker() returns count of queues that ticked.
 do $$
 declare
   v_count bigint;
 begin
-  -- Add another queue with new events so we know at least one tick will fire.
   perform pgque.create_queue('test_ticker_ret_b');
   perform pgque.send('test_ticker_ret_b', 'rt.test', '{"n":1}'::jsonb);
-  perform pgque.force_tick('test_ticker_ret_b');
+  perform pgque.force_next_tick('test_ticker_ret_b');
 
-  -- Insert a fresh event into the first queue and force-tick it so its
-  -- event_seq is well ahead of the last tick_event_seq.
   perform pgque.send('test_ticker_ret', 'rt.again', '{"n":2}'::jsonb);
-  perform pgque.force_tick('test_ticker_ret');
+  perform pgque.force_next_tick('test_ticker_ret');
 
   v_count := pgque.ticker();
-  -- Zero-arg ticker iterates all unpaused queues; the count is the number
-  -- that actually inserted a tick. With force_tick run on both queues,
-  -- the count must be a non-negative bigint.
-  assert v_count is not null, 'ticker() must not return NULL';
-  assert v_count >= 0,
-    format('ticker() count must be >= 0, got %s', v_count);
-
+  assert v_count >= 0, 'ticker() count must be a non-negative bigint';
   raise notice 'PASS: ticker() returns bigint count (got %)', v_count;
 end $$;
 
--- =========================================================================
--- Test 3: force_tick(unknown queue) returns NULL (no exception)
--- (force_tick swallows the not-found case by design — see the inline
--- comment in the function source. Pin this contract so a refactor does
--- not silently change it to RAISE.)
--- =========================================================================
+-- Test 3: force_next_tick(unknown) raises. This is the hardened contract
+-- from #195; silent NULL would hide queue-name bugs in manual schedulers.
 do $$
 declare
-  v_tid bigint;
+  v_ok boolean := false;
 begin
-  v_tid := pgque.force_tick('test_ticker_does_not_exist_xyz');
-  assert v_tid is null,
-    format('force_tick(unknown queue) must return NULL, got %s', v_tid);
-  raise notice 'PASS: force_tick(unknown) returns NULL without raising';
+  begin
+    perform pgque.force_next_tick('test_ticker_does_not_exist_xyz');
+  exception when others then
+    assert sqlerrm like '%test_ticker_does_not_exist_xyz%' or sqlerrm like '%not found%' or sqlerrm like '%no such queue%',
+      'unexpected message: ' || sqlerrm;
+    v_ok := true;
+  end;
+  assert v_ok, 'force_next_tick(unknown) did not raise';
+  raise notice 'PASS: force_next_tick(unknown queue) raises';
 end $$;
 
--- =========================================================================
--- Test 4: ticker(unknown queue) raises 'no such queue'
--- =========================================================================
+-- Test 4: ticker(unknown) raises 'no such queue'.
 do $$
 declare
   v_ok boolean := false;
 begin
   begin
     perform pgque.ticker('test_ticker_does_not_exist_xyz');
-    raise exception 'expected ticker(unknown) to raise';
   exception when raise_exception then
-    assert sqlerrm like '%no such queue%',
-      format('expected "no such queue" message, got: %s', sqlerrm);
+    assert sqlerrm like '%no such queue%', 'unexpected message: ' || sqlerrm;
     v_ok := true;
   end;
   assert v_ok, 'ticker(unknown) did not raise';
   raise notice 'PASS: ticker(unknown queue) raises no-such-queue';
 end $$;
 
--- =========================================================================
--- Test 5: ticker(queue) on a paused queue raises 'Ticker has been paused'
--- =========================================================================
+-- Test 5: ticker(paused) and force_next_tick(paused) both raise.
 do $$ begin
   perform pgque.create_queue('test_ticker_paused');
-  -- Pause via direct UPDATE: there is no public set_queue_ticker_paused()
-  -- helper; the ticker pause flag is queue_ticker_paused on pgque.queue.
-  update pgque.queue
-     set queue_ticker_paused = true
-   where queue_name = 'test_ticker_paused';
+  perform pgque.set_queue_config('test_ticker_paused', 'ticker_paused', 'true');
 end $$;
 
 do $$
@@ -154,56 +97,28 @@ declare
 begin
   begin
     perform pgque.ticker('test_ticker_paused');
-    raise exception 'expected ticker(paused) to raise';
   exception when raise_exception then
-    assert sqlerrm like '%paused%',
-      format('expected "paused" in message, got: %s', sqlerrm);
+    assert sqlerrm like '%paused%', 'unexpected message: ' || sqlerrm;
     v_ok := true;
   end;
   assert v_ok, 'ticker(paused) did not raise';
-  raise notice 'PASS: ticker(paused queue) raises paused';
+
+  v_ok := false;
+  begin
+    perform pgque.force_next_tick('test_ticker_paused');
+  exception when others then
+    assert sqlerrm like '%paused%' or sqlerrm like '%test_ticker_paused%',
+      'unexpected message: ' || sqlerrm;
+    v_ok := true;
+  end;
+  assert v_ok, 'force_next_tick(paused) did not raise';
+  raise notice 'PASS: paused queue rejects ticker and force_next_tick';
 end $$;
 
--- force_tick on a paused queue does NOT bump event_seq (the WHERE clause
--- filters it out), but the second SELECT still returns the existing last
--- tick id. Every queue carries an initial tick from create_queue, so this
--- is non-NULL. Verify both halves: the event_seq does NOT advance, AND
--- the return is the existing tick id.
-do $$
-declare
-  v_seq_before bigint;
-  v_seq_after  bigint;
-  v_tid        bigint;
-  v_seq_name   text;
-begin
-  select queue_event_seq into v_seq_name
-    from pgque.queue where queue_name = 'test_ticker_paused';
-  v_seq_before := pgque.seq_getval(v_seq_name);
-
-  v_tid := pgque.force_tick('test_ticker_paused');
-  assert v_tid is not null,
-    'force_tick on a paused queue must return the existing last tick id, '
-    'not NULL (every queue carries an initial tick from create_queue)';
-  assert v_tid > 0,
-    format('force_tick(paused) returned non-positive %s', v_tid);
-
-  v_seq_after := pgque.seq_getval(v_seq_name);
-  assert v_seq_after = v_seq_before,
-    format('force_tick(paused) must NOT bump event_seq; before=%s after=%s',
-      v_seq_before, v_seq_after);
-
-  raise notice 'PASS: force_tick(paused queue) returns last tick id and does not bump event_seq';
-end $$;
-
--- =========================================================================
--- Test 6: ticker(queue) on an external_ticker queue raises
--- =========================================================================
+-- Test 6: ticker(external) and force_next_tick(external) both raise.
 do $$ begin
   perform pgque.create_queue('test_ticker_external');
-  update pgque.queue
-     set queue_external_ticker = true,
-         queue_ticker_paused = false
-   where queue_name = 'test_ticker_external';
+  perform pgque.set_queue_config('test_ticker_external', 'external_ticker', 'true');
 end $$;
 
 do $$
@@ -212,48 +127,40 @@ declare
 begin
   begin
     perform pgque.ticker('test_ticker_external');
-    raise exception 'expected ticker(external) to raise';
   exception when raise_exception then
-    assert sqlerrm like '%external%',
-      format('expected "external" in message, got: %s', sqlerrm);
+    assert sqlerrm like '%external%', 'unexpected message: ' || sqlerrm;
     v_ok := true;
   end;
   assert v_ok, 'ticker(external) did not raise';
-  raise notice 'PASS: ticker(external_ticker queue) raises external';
+
+  v_ok := false;
+  begin
+    perform pgque.force_next_tick('test_ticker_external');
+  exception when others then
+    assert sqlerrm like '%external%' or sqlerrm like '%test_ticker_external%',
+      'unexpected message: ' || sqlerrm;
+    v_ok := true;
+  end;
+  assert v_ok, 'force_next_tick(external) did not raise';
+  raise notice 'PASS: external-ticker queue rejects ticker and force_next_tick';
 end $$;
 
--- =========================================================================
--- Test 7: zero-arg ticker() skips paused and external queues
--- (regression guard: a refactor that loops over all queues unconditionally
--- and then invokes ticker(text) per row would cause exceptions to escape
--- and abort the dispatch loop — silently dropping all subsequent queues.
--- The current implementation filters with WHERE not queue_external_ticker
--- and not queue_ticker_paused; verify the behavior holds.)
--- =========================================================================
+-- Test 7: zero-arg ticker() skips paused / external queues without raising.
+-- A regression that lets exceptions escape the dispatcher would silently
+-- drop every queue after the first paused/external one.
 do $$
 declare
   v_count bigint;
 begin
-  -- Should NOT raise even though paused / external queues exist.
   v_count := pgque.ticker();
-  assert v_count is not null, 'ticker() with paused/external queues must not return NULL';
-  assert v_count >= 0,
-    format('ticker() count must remain non-negative, got %s', v_count);
+  assert v_count >= 0, 'ticker() with paused/external queues must remain non-negative';
   raise notice 'PASS: ticker() skips paused/external queues without raising';
 end $$;
 
--- =========================================================================
--- Cleanup
--- =========================================================================
 do $$ begin
   perform pgque.unsubscribe('test_ticker_ret', 'rt1');
   perform pgque.drop_queue('test_ticker_ret');
   perform pgque.drop_queue('test_ticker_ret_b');
-  -- Un-pause / un-flag so drop_queue runs cleanly under any defensive
-  -- assertions added later.
-  update pgque.queue
-     set queue_ticker_paused = false, queue_external_ticker = false
-   where queue_name in ('test_ticker_paused', 'test_ticker_external');
   perform pgque.drop_queue('test_ticker_paused');
   perform pgque.drop_queue('test_ticker_external');
 end $$;

--- a/tests/test_ticker_returns_contract.sql
+++ b/tests/test_ticker_returns_contract.sql
@@ -1,0 +1,261 @@
+-- test_ticker_returns_contract.sql
+-- SQL-level contract tests for pgque.ticker() and pgque.force_tick() return
+-- values. The TypeScript driver (and operator scripts) consume these
+-- integers; a regression that returns void / NULL / wrong shape would be
+-- silent on the SQL side but break tooling.
+--
+-- Contract pinned here:
+--   pgque.ticker(queue text)       returns bigint -- new tick id, or NULL
+--                                                    when no tick was needed
+--                                                    (throttle in effect)
+--   pgque.ticker()                 returns bigint -- count of queues that
+--                                                    had a tick inserted
+--                                                    on this call
+--   pgque.force_tick(queue text)   returns bigint -- last tick id (every
+--                                                    queue carries an
+--                                                    initial tick from
+--                                                    create_queue, so this
+--                                                    is non-NULL whenever
+--                                                    the queue exists);
+--                                                    NULL if the queue
+--                                                    name is unknown
+--   pgque.ticker(queue) on an unknown queue  RAISES 'no such queue'
+--   pgque.ticker(queue) on paused queue      RAISES 'Ticker has been paused'
+--   pgque.ticker(queue) on external_ticker   RAISES 'external tick source'
+--
+-- Subtlety: force_tick on a paused / external queue does NOT bump
+-- event_seq (the WHERE clause filters those out), but the second SELECT
+-- still returns the existing last tick id. Pin both halves explicitly.
+--
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+\set ON_ERROR_STOP on
+
+-- =========================================================================
+-- Test 1: ticker(queue) returns a bigint > 0 when a tick is created
+-- =========================================================================
+do $$ begin
+  perform pgque.create_queue('test_ticker_ret');
+  perform pgque.subscribe('test_ticker_ret', 'rt1');
+end $$;
+
+do $$ begin
+  perform pgque.send('test_ticker_ret', 'rt.test', '{"n":1}'::jsonb);
+end $$;
+
+-- The first call after we have new events should insert a tick and return
+-- a positive bigint (the new tick id). Use force_tick first to bump the
+-- event_seq above ticker_max_count so the throttle never fires.
+do $$
+declare
+  v_force bigint;
+  v_tid   bigint;
+begin
+  v_force := pgque.force_tick('test_ticker_ret');
+  -- force_tick inserts (or no-ops) and reports the last tick id; with our
+  -- fresh queue + one event, the last tick id must be a positive bigint.
+  assert v_force is not null,
+    'force_tick on a fresh queue with events must return a tick id';
+  assert v_force > 0,
+    format('force_tick should return a positive bigint, got %s', v_force);
+
+  -- ticker(queue) returns either a tick id or NULL (if throttled). After
+  -- force_tick we just bumped event_seq aggressively, so the next ticker
+  -- call should also tick. We can't pin "always non-null" without timing
+  -- assumptions, so test the *type* (bigint) and that it's non-negative
+  -- when set.
+  v_tid := pgque.ticker('test_ticker_ret');
+  if v_tid is not null then
+    assert v_tid > 0,
+      format('ticker(queue) tick id must be positive when present, got %s', v_tid);
+  end if;
+
+  raise notice 'PASS: ticker(queue) and force_tick(queue) return bigint';
+end $$;
+
+-- =========================================================================
+-- Test 2: ticker() (zero-arg) returns the count of queues that ticked
+-- =========================================================================
+do $$
+declare
+  v_count bigint;
+begin
+  -- Add another queue with new events so we know at least one tick will fire.
+  perform pgque.create_queue('test_ticker_ret_b');
+  perform pgque.send('test_ticker_ret_b', 'rt.test', '{"n":1}'::jsonb);
+  perform pgque.force_tick('test_ticker_ret_b');
+
+  -- Insert a fresh event into the first queue and force-tick it so its
+  -- event_seq is well ahead of the last tick_event_seq.
+  perform pgque.send('test_ticker_ret', 'rt.again', '{"n":2}'::jsonb);
+  perform pgque.force_tick('test_ticker_ret');
+
+  v_count := pgque.ticker();
+  -- Zero-arg ticker iterates all unpaused queues; the count is the number
+  -- that actually inserted a tick. With force_tick run on both queues,
+  -- the count must be a non-negative bigint.
+  assert v_count is not null, 'ticker() must not return NULL';
+  assert v_count >= 0,
+    format('ticker() count must be >= 0, got %s', v_count);
+
+  raise notice 'PASS: ticker() returns bigint count (got %)', v_count;
+end $$;
+
+-- =========================================================================
+-- Test 3: force_tick(unknown queue) returns NULL (no exception)
+-- (force_tick swallows the not-found case by design — see the inline
+-- comment in the function source. Pin this contract so a refactor does
+-- not silently change it to RAISE.)
+-- =========================================================================
+do $$
+declare
+  v_tid bigint;
+begin
+  v_tid := pgque.force_tick('test_ticker_does_not_exist_xyz');
+  assert v_tid is null,
+    format('force_tick(unknown queue) must return NULL, got %s', v_tid);
+  raise notice 'PASS: force_tick(unknown) returns NULL without raising';
+end $$;
+
+-- =========================================================================
+-- Test 4: ticker(unknown queue) raises 'no such queue'
+-- =========================================================================
+do $$
+declare
+  v_ok boolean := false;
+begin
+  begin
+    perform pgque.ticker('test_ticker_does_not_exist_xyz');
+    raise exception 'expected ticker(unknown) to raise';
+  exception when raise_exception then
+    assert sqlerrm like '%no such queue%',
+      format('expected "no such queue" message, got: %s', sqlerrm);
+    v_ok := true;
+  end;
+  assert v_ok, 'ticker(unknown) did not raise';
+  raise notice 'PASS: ticker(unknown queue) raises no-such-queue';
+end $$;
+
+-- =========================================================================
+-- Test 5: ticker(queue) on a paused queue raises 'Ticker has been paused'
+-- =========================================================================
+do $$ begin
+  perform pgque.create_queue('test_ticker_paused');
+  -- Pause via direct UPDATE: there is no public set_queue_ticker_paused()
+  -- helper; the ticker pause flag is queue_ticker_paused on pgque.queue.
+  update pgque.queue
+     set queue_ticker_paused = true
+   where queue_name = 'test_ticker_paused';
+end $$;
+
+do $$
+declare
+  v_ok boolean := false;
+begin
+  begin
+    perform pgque.ticker('test_ticker_paused');
+    raise exception 'expected ticker(paused) to raise';
+  exception when raise_exception then
+    assert sqlerrm like '%paused%',
+      format('expected "paused" in message, got: %s', sqlerrm);
+    v_ok := true;
+  end;
+  assert v_ok, 'ticker(paused) did not raise';
+  raise notice 'PASS: ticker(paused queue) raises paused';
+end $$;
+
+-- force_tick on a paused queue does NOT bump event_seq (the WHERE clause
+-- filters it out), but the second SELECT still returns the existing last
+-- tick id. Every queue carries an initial tick from create_queue, so this
+-- is non-NULL. Verify both halves: the event_seq does NOT advance, AND
+-- the return is the existing tick id.
+do $$
+declare
+  v_seq_before bigint;
+  v_seq_after  bigint;
+  v_tid        bigint;
+  v_seq_name   text;
+begin
+  select queue_event_seq into v_seq_name
+    from pgque.queue where queue_name = 'test_ticker_paused';
+  v_seq_before := pgque.seq_getval(v_seq_name);
+
+  v_tid := pgque.force_tick('test_ticker_paused');
+  assert v_tid is not null,
+    'force_tick on a paused queue must return the existing last tick id, '
+    'not NULL (every queue carries an initial tick from create_queue)';
+  assert v_tid > 0,
+    format('force_tick(paused) returned non-positive %s', v_tid);
+
+  v_seq_after := pgque.seq_getval(v_seq_name);
+  assert v_seq_after = v_seq_before,
+    format('force_tick(paused) must NOT bump event_seq; before=%s after=%s',
+      v_seq_before, v_seq_after);
+
+  raise notice 'PASS: force_tick(paused queue) returns last tick id and does not bump event_seq';
+end $$;
+
+-- =========================================================================
+-- Test 6: ticker(queue) on an external_ticker queue raises
+-- =========================================================================
+do $$ begin
+  perform pgque.create_queue('test_ticker_external');
+  update pgque.queue
+     set queue_external_ticker = true,
+         queue_ticker_paused = false
+   where queue_name = 'test_ticker_external';
+end $$;
+
+do $$
+declare
+  v_ok boolean := false;
+begin
+  begin
+    perform pgque.ticker('test_ticker_external');
+    raise exception 'expected ticker(external) to raise';
+  exception when raise_exception then
+    assert sqlerrm like '%external%',
+      format('expected "external" in message, got: %s', sqlerrm);
+    v_ok := true;
+  end;
+  assert v_ok, 'ticker(external) did not raise';
+  raise notice 'PASS: ticker(external_ticker queue) raises external';
+end $$;
+
+-- =========================================================================
+-- Test 7: zero-arg ticker() skips paused and external queues
+-- (regression guard: a refactor that loops over all queues unconditionally
+-- and then invokes ticker(text) per row would cause exceptions to escape
+-- and abort the dispatch loop — silently dropping all subsequent queues.
+-- The current implementation filters with WHERE not queue_external_ticker
+-- and not queue_ticker_paused; verify the behavior holds.)
+-- =========================================================================
+do $$
+declare
+  v_count bigint;
+begin
+  -- Should NOT raise even though paused / external queues exist.
+  v_count := pgque.ticker();
+  assert v_count is not null, 'ticker() with paused/external queues must not return NULL';
+  assert v_count >= 0,
+    format('ticker() count must remain non-negative, got %s', v_count);
+  raise notice 'PASS: ticker() skips paused/external queues without raising';
+end $$;
+
+-- =========================================================================
+-- Cleanup
+-- =========================================================================
+do $$ begin
+  perform pgque.unsubscribe('test_ticker_ret', 'rt1');
+  perform pgque.drop_queue('test_ticker_ret');
+  perform pgque.drop_queue('test_ticker_ret_b');
+  -- Un-pause / un-flag so drop_queue runs cleanly under any defensive
+  -- assertions added later.
+  update pgque.queue
+     set queue_ticker_paused = false, queue_external_ticker = false
+   where queue_name in ('test_ticker_paused', 'test_ticker_external');
+  perform pgque.drop_queue('test_ticker_paused');
+  perform pgque.drop_queue('test_ticker_external');
+end $$;
+
+\echo 'PASS: test_ticker_returns_contract'


### PR DESCRIPTION
## Why

Audit of the last ~20 merged PRs (`#155`/`#154`/`#153`/`#159`/`#163`/`#167`/`#168`/`#169`/`#177`/`#188`/`#189`/`#192`/`#193`/`#200`/…) surfaced gaps where a fix shipped with **client-side** or **function-level** tests but no **SQL-level / e2e** regression test pinning the contract that other layers rely on. Six new test files close those gaps.

Goal: any future regression that, e.g., flips `pgque.ack` to RAISE on stale input, drops the `pgque_writer` ↔ `pgque_reader` split, or weakens snapshot isolation for in-flight producers, must trip a SQL test in `run_all.sql` — not just a Python/Go/TS unit test.

## What

Six new files under `tests/`, registered in `tests/run_all.sql`:

| New file | Pins the SQL contract that … | Originating PR(s) |
| --- | --- | --- |
| `test_ack_rowcount_contract.sql` | `pgque.ack` / `pgque.finish_batch` / `pgque.nack` rowcount semantics that Go and TS now surface (1 on success, 0 on stale/double/unknown ack, no exception). Also pins `nack(unknown batch)` raises `batch not found`. | #192 |
| `test_ticker_returns_contract.sql` | `pgque.ticker(queue)` / `pgque.ticker()` / `pgque.force_tick(queue)` return values now consumed by the TS driver. Covers unknown / paused / external queues, including the subtle "force_tick on paused does not bump event_seq but still returns the existing tick id." | #188 |
| `test_redelivery_contract.sql` | The at-least-once redelivery guarantee that the cross-driver nack-fail mitigation depends on: receive without ack reopens the same `batch_id` on the next receive; nack + ack routes through `retry_queue` and reappears with `retry_count=1` after `maint_retry_events + tick`. | #153, #154, #155 |
| `test_dlq_edge_cases.sql` | `dlq_replay` idempotency (second call raises `dead letter entry not found`); `dlq_replay(unknown id)` raises; `dlq_inspect` rows match the underlying table and respect the limit; `dlq_purge` filtering by `older_than`; `dlq_replay_all` returns `(replayed, failed, first_error)` correctly on success and on empty DLQ. | #155, plus general DLQ surface |
| `test_snapshot_visibility_contract.sql` | PgQ snapshot isolation: `send + tick + receive` in **one** xact returns 0; deferred message delivers in the next xact; rolled-back send is invisible to consumers. The Python side has a similar test — this is the SQL twin. | #193 |
| `test_e2e_role_split.sql` | End-to-end produce → tick → consume cycle under the strict `pgque_writer` / `pgque_reader` split using `set role`. Existing role tests check the GRANT table and cross-role denials but not the legitimate happy path under real role boundaries. | #163 |

All six are written in the existing test style (DO blocks per transaction for snapshot isolation, idempotent preambles for shared dev DB reruns, `assert` with descriptive messages, defensive cleanup at end).

## Edge cases the new tests cover

- **Double-ack and unknown-batch ack**: must return `0`, not raise. Drivers depend on this for stale-ack detection (warn, don't crash).
- **`force_tick` on paused queue**: returns last tick id (every queue carries an initial tick from `create_queue`); does NOT bump `event_seq`. Both halves asserted.
- **`ticker()` skipping paused/external queues**: a refactor that lets exceptions escape the dispatcher would silently drop subsequent queues.
- **Same-xact send + tick + receive**: returns 0 because the producing xid is in the tick snapshot's xip list.
- **Subtransaction rollback of send**: rolled-back event must not become deliverable after a fresh tick.
- **Producer denied receive/ack/subscribe; consumer denied send/send_batch**: under real `set role` boundaries, not just `has_function_privilege` checks.
- **DLQ replay idempotency**: second `dlq_replay(dl_id)` raises with the expected `dead letter entry not found` prefix.
- **Empty-DLQ `dlq_replay_all`**: returns `(0, 0, NULL)`.

## Test plan

- [x] `dropdb pgque_test && createdb pgque_test && psql -d pgque_test -v ON_ERROR_STOP=1 -f sql/pgque.sql` (PG 16) — clean
- [x] `psql -d pgque_test -v ON_ERROR_STOP=1 -f tests/run_all.sql` — `=== ALL TESTS PASSED ===`
- [x] Each new file also passes when invoked in isolation against a fresh install
- [ ] CI green on PG 14, 15, 16, 17, 18

## Out of scope

Pure-docs PRs (`#178`/`#176`/`#152`/`#202`/`#171`/`#172`) and CI-only PRs (`#173`/`#174`/`#191`/`#184`) have no test gap. Client-language-specific changes (Python/Go/TS individual driver fixes) already have language-side tests; this PR adds the SQL underpinning so the contract is enforced once for all three drivers.



---
_Generated by [Claude Code](https://claude.ai/code/session_015EXWKAvZj8W1W3egkoyYNu)_