### PR TITLE
docs: align ticker latency wording with 10 ticks/sec default

### DIFF
--- a/docs/pgq-concepts.md
+++ b/docs/pgq-concepts.md
@@ -15,7 +15,9 @@ Vocabulary adapted from the 2009 PgCon talk by Kreen & Pihlak
   Any number of consumers can subscribe to the same queue; each has its
   own cursor and independently sees every event (fan-out by default).
 - **Ticker** — creates ticks, vacuums, rotates, reschedules retries.
-  In PgQue: `pg_cron` calling `pgque.ticker()`.
+  In PgQue's default `pg_cron` path: one 1-second cron slot calls
+  `pgque.ticker_loop()`, which invokes `pgque.ticker()` every
+  `tick_period_ms` ms (100 ms / 10 ticks/sec by default).
 - **Tick** — position marker in the event stream; delimits batches.
 - **Roles** — three database roles, all created by the install:
   - `pgque_reader` (consume side: `receive`, `ack`, `nack`, `subscribe`, `unsubscribe`, plus the underlying PgQ batch primitives)
@@ -55,9 +57,10 @@ Payload format is a producer/consumer contract — PgQue does not interpret it.
 
 ## Per-queue tuning
 
-Stored on `pgque.queue`, read by `pgque.ticker()` (pg_cron). Set via
-`pgque.set_queue_config(queue, param, value)` — `param` is the short name
-below; the function auto-prefixes `queue_` internally.
+Stored on `pgque.queue`, read by `pgque.ticker()` regardless of whether
+it is driven by `pgque.ticker_loop()` / `pg_cron` or an external scheduler.
+Set via `pgque.set_queue_config(queue, param, value)` — `param` is the
+short name below; the function auto-prefixes `queue_` internally.
 
 - `ticker_max_lag` — max wall time between ticks.
 - `ticker_idle_period` — tick interval when idle.
@@ -82,8 +85,9 @@ combining any chain in one explicit `begin`/`commit` block silently
 produces empty batches and dropped messages.
 
 - **Producer → consumer.** `pgque.send` (or `pgque.insert_event`) →
-  `pgque.ticker` (or `pgque.force_tick` + `pgque.ticker`) →
-  `pgque.receive` (or `pgque.next_batch`).
+  `pgque.ticker` (or canonical `pgque.force_next_tick` + `pgque.ticker`;
+  legacy `pgque.force_tick` is a compatibility alias) → `pgque.receive`
+  (or `pgque.next_batch`).
 - **Retry pump.** `pgque.maint_retry_events` (re-inserts retry rows
   into event tables with `pg_current_xact_id()`) → `pgque.ticker`
   (must run in a later tx so the new `ev_txid`s are visible in its

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -279,7 +279,7 @@ Grant: `pgque_admin`. Source: `sql/pgque-additions/tick_helpers.sql`.
 Alias for `pgque.force_next_tick`. Retained for compatibility with upstream PgQ (the historical name); identical behavior. The name is misleading — the function does not insert a tick by itself, it only bumps the event sequence so the next `pgque.ticker()` call inserts one. Raises if the queue is missing, ticker-paused, or configured for an external ticker. Prefer `force_next_tick` in new code.
 Grant: `pgque_admin`. Source: `sql/pgque.sql`.
 
-> The `force_tick` → `ticker` → `receive` chain must run across separate transactions for the consumer to see the events you just sent. See the [snapshot rule](#snapshot-rule).
+> The `force_next_tick` → `ticker` → `receive` chain (or legacy `force_tick` alias) must run across separate transactions for the consumer to see the events you just sent. See the [snapshot rule](#snapshot-rule).
 
 #### `pgque.uninstall() → void`
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -112,7 +112,7 @@ Zero rows. This surprises every first-time user. Here is why.
 
 PgQue is **tick-based**, not row-claiming. Producers append events to the queue, but consumers do not see rows directly — they see **batches**. A batch is the set of events between two ticks. Until a tick happens, there is no batch boundary, so `pgque.receive` has nothing to return.
 
-In normal operation, a scheduler (`pg_cron` or an external loop) calls `pgque.ticker()` every second and ticks happen continuously. In this tutorial you have not started a scheduler, so no tick has run yet.
+In normal operation, a scheduler (`pg_cron` or an external loop) drives ticks continuously. With the default `pg_cron` path, PgQue ticks every 100 ms (10 ticks/sec) inside a single 1-second cron slot. In this tutorial you have not started a scheduler, so no tick has run yet.
 
 See the [concepts glossary](pgq-concepts.md) for the full definitions of event, batch, tick, and consumer.
 
@@ -156,7 +156,7 @@ select * from pgque.receive('orders', 'processor', 100);
 
 The event is back. `retry_count` is null because this is the first delivery attempt. The `batch_id` is the important value for the next step.
 
-In production, `pg_cron` (or a small worker loop) calls `pgque.ticker()` every second. `force_next_tick` exists for the situation here: advancing the queue without waiting on the ticker's lag threshold.
+In production, `pg_cron` calls `pgque.ticker_loop()` once per second, and that procedure calls `pgque.ticker()` every `tick_period_ms` ms (100 ms by default). An external worker loop can call `pgque.ticker()` at whatever cadence you choose. `force_next_tick` exists for the situation here: advancing the queue without waiting on the ticker's lag threshold.
 
 ## Step 6: Ack the batch
 


### PR DESCRIPTION
## Summary

Updates remaining docs wording that still described the production ticker as `pgque.ticker()` every second or used legacy `force_tick` wording in the snapshot-rule path.

The docs now consistently distinguish:

- default pg_cron path: one 1-second cron slot runs `pgque.ticker_loop()`
- actual default tick cadence: `tick_period_ms = 100` → 10 ticks/sec
- external scheduler path: caller chooses how often to call `pgque.ticker()`
- canonical manual helper: `force_next_tick()` (`force_tick()` remains alias)

## Test

- `git diff --check`
- grep for stale phrases: `up to 1s`, `up to one second`, `calls .*ticker.* every second`, `force_tick.*ticker.*receive`

Docs-only change.