### PR TITLE
docs: surface PgQ heritage in README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ PgQ was designed at Skype to run messaging for hundreds of millions of users, an
 
 PgQue rebuilds that battle-tested engine in pure PL/pgSQL, so the zero-bloat queue pattern works anywhere you can run SQL — without adding another distributed system to your stack.
 
+PgQ shipped at Skype in 2007; pgque is the same engine, repackaged for managed Postgres, and ships with libraries for TypeScript, Python, and Go.
+
 **The anti-extension.** Pure SQL + PL/pgSQL on any Postgres 14+ — including RDS, Aurora, Cloud SQL, AlloyDB, Supabase, Neon, and most other managed providers. No C extension, no `shared_preload_libraries`, no provider approval, no restart.
 
 Historical context, two decks:

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ Discussion on [Hacker News](https://news.ycombinator.com/item?id=47817349).
 
 PgQue brings back [PgQ](https://github.com/pgq/pgq) — one of the longest-running Postgres queue architectures in production — in a form that runs on any Postgres platform, managed providers included.
 
-PgQ was designed at Skype to run messaging for hundreds of millions of users, and it ran on large self-managed Postgres deployments for over a decade. Standard PgQ depends on a C extension (`pgq`) and an external daemon (`pgqd`), neither of which run on most managed Postgres providers.
+PgQ was designed at Skype in 2006 to run messaging for hundreds of millions of users, and it ran on large self-managed Postgres deployments for over a decade. Standard PgQ depends on a C extension (`pgq`) and an external daemon (`pgqd`), neither of which run on most managed Postgres providers.
 
 PgQue rebuilds that battle-tested engine in pure PL/pgSQL, so the zero-bloat queue pattern works anywhere you can run SQL — without adding another distributed system to your stack.
 
-PgQ shipped at Skype in 2007; pgque is the same engine, repackaged for managed Postgres, and ships with libraries for TypeScript, Python, and Go.
+It is the same engine – PgQ – repackaged for managed Postgres, and provided with client libraries for TypeScript, Python, and Go.
 
 **The anti-extension.** Pure SQL + PL/pgSQL on any Postgres 14+ — including RDS, Aurora, Cloud SQL, AlloyDB, Supabase, Neon, and most other managed providers. No C extension, no `shared_preload_libraries`, no provider approval, no restart.
 


### PR DESCRIPTION
## Summary

- Adds a single sentence to the README intro naming the year PgQ first shipped (2007) and making the TypeScript, Python, and Go library coverage visible at the top of the file.
- Placement is immediately after the existing three-paragraph Skype/C-extension heritage block, before the "The anti-extension." callout.
- No other files changed.

## Test plan

- [ ] Read the README intro from the title to the first H2 (`## Why PgQue`); confirm that PgQ's 2007 origin and the three client libraries now read as one natural beat alongside the existing heritage description.