### PR TITLE
feat: add pg_timetable scheduler support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,9 +231,109 @@ jobs:
             exit 1
           fi
 
+      - name: Verify pg_timetable to pg_cron scheduler switch
+        run: |
+          set -Eeuo pipefail
+          # Run the pg_timetable lifecycle file directly in the pg_cron image.
+          # This creates the fake pg_timetable schema, starts PgQue with it,
+          # switches back to pg_cron, and must exercise the non-SKIP switch path.
+          out=$(PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
+            -v ON_ERROR_STOP=1 -f tests/test_pgtimetable_lifecycle.sql 2>&1)
+          echo "$out"
+          if echo "$out" | grep -q 'SKIP: pg_cron not installed (cannot test pg_timetable -> pg_cron switch)'; then
+            echo "FAIL: pg_timetable -> pg_cron switch test skipped despite pg_cron being installed"
+            exit 1
+          fi
+          if ! echo "$out" | grep -q 'PASS: start() switches pg_timetable to pg_cron cleanly'; then
+            echo "FAIL: pg_timetable -> pg_cron switch assertion did not run"
+            exit 1
+          fi
+
       - name: Cleanup
         if: always()
         run: docker rm -f pgque-pgcron-test
+
+
+  pgtimetable-real-test:
+    name: pg_timetable real worker
+    runs-on: ubuntu-latest
+    env:
+      PG_VERSION: '18'
+      PGTT_IMAGE: cybertecpostgresql/pg_timetable@sha256:6bed16f944ab91392fac9cd04aba82cd6690769e179d411748fd0bb538f55acd
+      PGTT_NET: pgque-pgtimetable-test
+      PG_CONTAINER: pgque-pgtimetable-pg
+      PGTT_CONTAINER: pgque-pgtimetable-worker
+      PGPASSWORD: pgque_test
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build pgque
+        run: bash build/transform.sh
+
+      - name: Start PostgreSQL 18
+        run: |
+          set -Eeuo pipefail
+          docker network create "${PGTT_NET}"
+          docker run -d --name "${PG_CONTAINER}" --network "${PGTT_NET}" \
+            -e POSTGRES_PASSWORD=pgque_test \
+            -e POSTGRES_DB=pgque_test \
+            postgres:${PG_VERSION}
+
+          ready=0
+          for _ in $(seq 1 60); do
+            if docker exec "${PG_CONTAINER}" pg_isready -U postgres -d pgque_test; then
+              ready=1
+              break
+            fi
+            sleep 1
+          done
+          if [[ "${ready}" -ne 1 ]]; then
+            echo "PG not ready after 60 seconds"
+            docker logs "${PG_CONTAINER}"
+            exit 1
+          fi
+
+      - name: Initialize real pg_timetable schema
+        run: |
+          set -Eeuo pipefail
+          docker run --rm --network "${PGTT_NET}" "${PGTT_IMAGE}" \
+            --init \
+            --connstr="postgresql://postgres:pgque_test@${PG_CONTAINER}:5432/pgque_test" \
+            --clientname=pgque
+
+      - name: Install pgque and schedule pg_timetable jobs
+        run: |
+          set -Eeuo pipefail
+          docker cp sql/pgque.sql "${PG_CONTAINER}":/tmp/pgque.sql
+          docker cp tests/test_pgtimetable_real_setup.sql "${PG_CONTAINER}":/tmp/test_pgtimetable_real_setup.sql
+          docker exec -e PGPASSWORD "${PG_CONTAINER}" \
+            psql -U postgres -d pgque_test -v ON_ERROR_STOP=1 -f /tmp/pgque.sql
+          docker exec -e PGPASSWORD "${PG_CONTAINER}" \
+            psql -U postgres -d pgque_test -v ON_ERROR_STOP=1 -f /tmp/test_pgtimetable_real_setup.sql
+
+      - name: Start real pg_timetable worker
+        run: |
+          set -Eeuo pipefail
+          docker run -d --name "${PGTT_CONTAINER}" --network "${PGTT_NET}" "${PGTT_IMAGE}" \
+            --connstr="postgresql://postgres:pgque_test@${PG_CONTAINER}:5432/pgque_test" \
+            --clientname=pgque \
+            --log-level=debug
+
+      - name: Verify real pg_timetable executes PgQue ticker_loop
+        run: |
+          set -Eeuo pipefail
+          docker cp tests/test_pgtimetable_real_assert.sql "${PG_CONTAINER}":/tmp/test_pgtimetable_real_assert.sql
+          docker exec -e PGPASSWORD "${PG_CONTAINER}" \
+            psql -U postgres -d pgque_test -v ON_ERROR_STOP=1 -f /tmp/test_pgtimetable_real_assert.sql
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker logs "${PGTT_CONTAINER}" || true
+          docker rm -f "${PGTT_CONTAINER}" "${PG_CONTAINER}" || true
+          docker network rm "${PGTT_NET}" || true
 
   python-client-tests:
     name: Python client tests

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">PgQue – PgQ, universal edition</h1>
 
-<p align="center"><strong>Zero-bloat Postgres queue. One SQL file to install, <code>pg_cron</code> to tick.</strong></p>
+<p align="center"><strong>Zero-bloat Postgres queue. One SQL file to install, <code>pg_cron</code> or <code>pg_timetable</code> to tick.</strong></p>
 
 <p align="center">
   <a href="https://github.com/NikolayS/pgque/actions/workflows/ci.yml"><img src="https://github.com/NikolayS/pgque/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
@@ -150,17 +150,33 @@ Or from the shell, same single-transaction guarantee via `psql --single-transact
 PAGER=cat psql --no-psqlrc --single-transaction -d mydb -f sql/pgque.sql
 ```
 
-With `pg_cron` available in the same database as PgQue, `pgque.start()` creates the default ticker and maintenance jobs:
+With `pg_cron` available in the same database as PgQue, `pgque.start()` creates the default ticker and maintenance jobs. The ticker uses a one-second pg_cron slot and calls `pgque.ticker_loop()`, which ticks every 100 ms by default (10 ticks/sec) with a commit between ticks:
 
 ```sql
 select pgque.start();
 ```
 
+With `pg_timetable`, run the external pg_timetable worker against the database where PgQue is installed, then schedule PgQue with the same 10 ticks/sec default. For example:
+
+```bash
+pg_timetable --dbname=mydb --clientname=pgque
+```
+
+The `--clientname=pgque` flag is required; pg_timetable only executes chains whose `job_client_name` matches the running worker's client name. Keep that worker running; unlike `pg_cron`, pg_timetable is an external scheduler process, not a Postgres extension background worker. See the [pg_timetable docs](https://github.com/cybertec-postgresql/pg_timetable) for production service setup.
+
+```sql
+select pgque.start_timetable();      -- default: 10 ticks/sec
+-- or explicitly:
+select pgque.start_timetable(10);
+```
+
+`pgque.stop_timetable()` removes the PgQue pg_timetable jobs. `pgque.stop()` also stops whichever PgQue scheduler is active. Calling `pgque.start_timetable()` automatically removes existing PgQue `pg_cron` jobs first; `pgque.start()` does the same for PgQue pg_timetable jobs. `pgque.set_tick_period_ms(ms)` still controls the loop cadence; for example `100` means 10 ticks/sec, `200` means 5 ticks/sec, and `1000` means 1 tick/sec.
+
 ### Tick rate
 
-PgQue ticks **10 times per second by default** (every 100 ms), even though `pg_cron`'s minimum schedule is 1 second. `pgque.start()` schedules a single 1-second pg_cron slot that calls `CALL pgque.ticker_loop()`; the procedure then re-invokes `pgque.ticker()` every `tick_period_ms` ms inside that slot, committing between iterations so each tick gets its own transaction (snapshot semantics; bounded held-xmin so rotation isn't blocked).
+PgQue ticks **10 times per second by default** (every 100 ms), even though `pg_cron`'s minimum schedule is 1 second. `pgque.start()` schedules a single 1-second pg_cron slot that calls `CALL pgque.ticker_loop()`; `pgque.start_timetable()` schedules the same loop through one pg_timetable `@every 1 second` job. The procedure then re-invokes `pgque.ticker()` every `tick_period_ms` ms inside that slot, committing between iterations so each tick gets its own transaction (snapshot semantics; bounded held-xmin so rotation isn't blocked).
 
-Tune at runtime — no need to call `start()` again, the change picks up on the next pg_cron slot (≤1 s):
+Tune at runtime — no need to call `start()` again, the change picks up on the next scheduler slot (≤1 s):
 
 ```sql
 select pgque.set_tick_period_ms(50);    -- 20 ticks/sec, ~25 ms median e2e
@@ -178,9 +194,9 @@ Trade-offs to keep in mind when raising the rate:
 
 **pg_cron in a different database.** `pg_cron` runs jobs in one designated database (`cron.database_name`, typically `postgres`). If your PgQue schema lives in a different database, use the [cross-database pattern](https://github.com/citusdata/pg_cron#creating-a-cron-job-in-a-different-database) to call `pgque.ticker_loop()`, `pgque.maint_retry_events()`, and `pgque.maint()` across databases. *Todo: a future release will detect this and emit the correct `cron.schedule_in_database` calls from `pgque.start()` automatically.*
 
-**pg_cron log hygiene.** Every `pg_cron` job execution writes a row to `cron.job_run_details`, with no built-in purge. PgQue's internal sub-second loop does **not** make this worse — there is still only **one** `pg_cron` slot per second per job, regardless of `tick_period_ms`, so the per-second row count is the same as a 1 tick/sec schedule. Across PgQue's four scheduled jobs (ticker, retry, maint, rotate_step2), that is roughly **5,000 rows per hour** on top of any other pg_cron jobs, growing forever unless you intervene. Prefer a PgQue-specific purge job; disable `cron.log_run` globally only if you do not need successful-run history for any pg_cron jobs. See [the tutorial](docs/tutorial.md#production-cadence-use-pg_cron) for both recipes. *(Independent issue: `pg_cron` itself has no per-job log toggle as of 1.6.)*
+**Scheduler log hygiene.** Every `pg_cron` job execution writes a row to `cron.job_run_details`, with no built-in purge. PgQue's internal sub-second loop does **not** make this worse — there is still only **one** `pg_cron` slot per second per job, regardless of `tick_period_ms`, so the per-second row count is the same as a 1 tick/sec schedule. Across PgQue's four scheduled jobs (ticker, retry, maint, rotate_step2), that is roughly **5,000 rows per hour** on top of any other pg_cron jobs, growing forever unless you intervene. Prefer a PgQue-specific purge job; disable `cron.log_run` globally only if you do not need successful-run history for any pg_cron jobs. See [the tutorial](docs/tutorial.md#production-cadence-use-pg_cron) for both recipes. *(Independent issue: `pg_cron` itself has no per-job log toggle as of 1.6.)* If you use pg_timetable, monitor and purge pg_timetable's own execution history tables according to its retention policy; PgQue does not manage those logs.
 
-Without `pg_cron`, PgQue still installs. Drive ticking and maintenance from your application or an external scheduler:
+Without `pg_cron` or `pg_timetable`, PgQue still installs. Drive ticking and maintenance from your application or an external scheduler:
 
 ```bash
 PAGER=cat psql --no-psqlrc -d mydb -c "select pgque.ticker()"              # at your chosen tick period
@@ -434,8 +450,8 @@ PgQue keeps PgQ's proven core architecture — snapshot-based batch isolation, t
 | Pure SQL / PL/pgSQL install | ✅ |
 | Managed Postgres support | ✅ |
 | No daemon / no C extension | ✅ |
-| `pg_cron` or external ticking | ✅ |
-| Sub-second ticking with `pg_cron` (default 10 ticks/sec, tunable with exact-divisor periods from 1–1000 ticks/sec) | ✅ |
+| `pg_cron`, `pg_timetable`, or external ticking | ✅ |
+| Sub-second ticking with `pg_cron` / `pg_timetable` (default 10 ticks/sec, tunable with exact-divisor periods from 1–1000 ticks/sec) | ✅ |
 | System-table rotation / bloat mitigation |  |
 | Cooperative consumers / subconsumers | 🔬 experimental |
 | Queue splitter |  |

--- a/docs/tick-frequency.md
+++ b/docs/tick-frequency.md
@@ -1,6 +1,6 @@
 # Tick frequency tuning
 
-PgQue is tick-based. A consumer sees events only after a tick creates a batch boundary. `pgque.start()` uses `pg_cron` to run one 1-second slot, but that slot calls `pgque.ticker_loop()`, which invokes `pgque.ticker()` every `pgque.config.tick_period_ms` ms and commits between iterations.
+PgQue is tick-based. A consumer sees events only after a tick creates a batch boundary. `pgque.start()` uses `pg_cron` to run one 1-second slot; `pgque.start_timetable()` does the same with `pg_timetable`. In both cases, the scheduled slot calls `pgque.ticker_loop()`, which invokes `pgque.ticker()` every `pgque.config.tick_period_ms` ms and commits between iterations.
 
 Default: `tick_period_ms = 100`, i.e. 10 checks/sec.
 
@@ -32,7 +32,7 @@ select pgque.set_tick_period_ms(100);   -- 10 checks/sec, default
 select pgque.set_tick_period_ms(50);    -- 20 checks/sec
 ```
 
-The change applies on the next `pg_cron` slot (≤1 s); no rescheduling needed.
+The change applies on the next scheduler slot (≤1 s for `pgque.start()` / `pgque.start_timetable()`); no rescheduling needed.
 
 ## WAL budget for active queues
 
@@ -56,7 +56,7 @@ Things that can move the number:
 - **Postgres version and settings.** `wal_compression`, page layout, checkpoint cadence, and storage settings matter.
 - **Table state.** Page splits, relation extension, and vacuum/rotation timing can change per-tick WAL.
 - **Number of active queues.** Ticking is per queue. Ten continuously-active queues at 10 materialized ticks/sec are roughly ten times the single-queue estimate. Ten idle queues are not.
-- **pg_cron logging.** `cron.job_run_details` WAL is separate. PgQue's sub-second loop does not multiply pg_cron log rows: there is still one cron slot per second regardless of `tick_period_ms`, but successful-run logging can still dominate small deployments unless disabled or purged.
+- **Scheduler logging.** `cron.job_run_details` WAL is separate when using pg_cron. PgQue's sub-second loop does not multiply pg_cron log rows: there is still one cron slot per second regardless of `tick_period_ms`, but successful-run logging can still dominate small deployments unless disabled or purged. With pg_timetable, use its own execution-log retention knobs/policies instead.
 
 ## Why idle queues back off
 
@@ -75,7 +75,7 @@ So a quiet queue tends toward occasional idle ticks rather than 10 materialized 
 - Use 1000 ms / 1 check/sec for small projects, low-throughput queues, or environments where WAL volume and logical replication lag matter more than sub-100 ms delivery.
 - For many queues in one database, estimate active queues separately from idle queues; idle queues back off.
 - If you raise the rate below 50 ms, monitor WAL generation, `pg_stat_user_tables` dead tuples for PgQue metadata tables, NOTIFY queue pressure, and replica/apply lag.
-- Purge PgQue's `cron.job_run_details` rows if pg_cron logging noise matters, without disabling history for unrelated jobs:
+- If using pg_cron, purge PgQue's `cron.job_run_details` rows if logging noise matters, without disabling history for unrelated jobs:
 
 ```sql
 select cron.schedule(
@@ -97,7 +97,7 @@ select cron.schedule(
 );
 ```
 
-- If you do not need successful-run history for any pg_cron job, `alter system set cron.log_run = off;` disables it globally after a restart.
+- If you do not need successful-run history for any pg_cron job, `alter system set cron.log_run = off;` disables it globally after a restart. If using pg_timetable, configure/purge pg_timetable's own log tables instead.
 
 ## What still needs better benchmarks
 
@@ -108,6 +108,6 @@ The 280 B/tick number is intentionally conservative documentation from a simple 
 - 1, 10, 100, and 1000 materialized ticks/sec;
 - one queue vs many queues;
 - idle queues vs active queues;
-- pg_cron logging on/off;
+- pg_cron / pg_timetable scheduler logging on/off;
 - logical replication subscriber lag under sustained ticking;
 - interaction with rotation/vacuum cadence.

--- a/sql/pgque-additions/config.sql
+++ b/sql/pgque-additions/config.sql
@@ -5,6 +5,9 @@ create table if not exists pgque.config (
     singleton       bool primary key default true check (singleton),
     ticker_job_id   bigint,
     maint_job_id    bigint,
+    scheduler       text
+        constraint config_scheduler_check
+        check (scheduler in ('pg_cron', 'pg_timetable')),
     tick_period_ms  integer not null default 100
         constraint config_tick_period_ms_check
         check (
@@ -24,6 +27,21 @@ on conflict (singleton) do nothing;
 -- Add tick_period_ms on upgrade from a pre-tick-period install.
 do $$
 begin
+    if not exists (
+        select 1 from information_schema.columns
+        where table_schema = 'pgque' and table_name = 'config'
+          and column_name = 'scheduler'
+    ) then
+        alter table pgque.config
+            add column scheduler text;
+    end if;
+
+    alter table pgque.config
+        drop constraint if exists config_scheduler_check;
+    alter table pgque.config
+        add constraint config_scheduler_check
+        check (scheduler in ('pg_cron', 'pg_timetable'));
+
     if not exists (
         select 1 from information_schema.columns
         where table_schema = 'pgque' and table_name = 'config'

--- a/sql/pgque-additions/lifecycle.sql
+++ b/sql/pgque-additions/lifecycle.sql
@@ -117,6 +117,7 @@ begin
     end if;
 
     -- Idempotent: stop existing jobs first
+    perform pgque.stop_timetable();
     perform pgque.stop();
 
     v_dbname := current_database();
@@ -171,7 +172,8 @@ begin
     -- Store job IDs in config (retry + rotate_step2 unscheduled by name)
     update pgque.config
     set ticker_job_id = v_ticker_id,
-        maint_job_id = v_maint_id;
+        maint_job_id = v_maint_id,
+        scheduler = 'pg_cron';
 
     raise notice 'pgque started: ticker=% (% ticks/sec), retry_events=%, maint=%, rotate_step2=%',
         v_ticker_id, (1000.0 / v_period_ms)::numeric(10, 2),
@@ -185,17 +187,25 @@ declare
     v_ticker_id bigint;
     v_maint_id bigint;
     v_has_pgcron bool;
+    v_scheduler text;
 begin
     -- Read current job IDs
-    select ticker_job_id, maint_job_id
-    into v_ticker_id, v_maint_id
+    select ticker_job_id, maint_job_id, scheduler
+    into v_ticker_id, v_maint_id, v_scheduler
     from pgque.config;
+
+    -- stop() is the generic PgQue stop entrypoint; delegate when pg_timetable
+    -- owns the active jobs.
+    if v_scheduler = 'pg_timetable' then
+        perform pgque.stop_timetable();
+        return;
+    end if;
 
     -- Check if pg_cron is available
     select exists (select 1 from pg_extension where extname = 'pg_cron')
     into v_has_pgcron;
 
-    if v_has_pgcron then
+    if v_has_pgcron and (v_scheduler is null or v_scheduler = 'pg_cron') then
         -- Unschedule ticker if it exists
         if v_ticker_id is not null then
             perform cron.unschedule(v_ticker_id);
@@ -223,10 +233,188 @@ begin
         end;
     end if;
 
-    -- Clear job IDs regardless (even if pg_cron is gone)
+    -- Clear pg_cron job IDs (only when scheduler is pg_cron or unset).
     update pgque.config
     set ticker_job_id = null,
-        maint_job_id = null;
+        maint_job_id = null,
+        scheduler = null
+    where scheduler is null or scheduler = 'pg_cron';
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+
+create or replace function pgque.start_timetable(i_ticks_per_second integer default 10)
+returns void as $$
+declare
+    v_ticker_id bigint;
+    v_retry_id bigint;
+    v_maint_id bigint;
+    v_step2_id bigint;
+    v_period_ms integer;
+    v_timetable_owner oid;
+    v_add_job_reg regprocedure;
+    v_delete_job_reg regprocedure;
+    v_owner_super bool;
+begin
+    -- pg_timetable is optional and external (standalone scheduler). It creates
+    -- the timetable schema on first run; PgQue only needs its SQL API here.
+    if to_regnamespace('timetable') is null then
+        raise exception 'pg_timetable schema/API is not installed. '
+            'Run pg_timetable against this database first, or use pgque.start() for pg_cron.';
+    end if;
+
+    -- Support both modern pg_timetable (12-argument add_job with job_on_error)
+    -- and older v4-style installs (11-argument add_job). The named-argument
+    -- calls below only use parameters common to both versions.
+    v_add_job_reg := coalesce(
+        to_regprocedure('timetable.add_job(text,timetable.cron,text,jsonb,timetable.command_kind,text,integer,boolean,boolean,boolean,boolean,text)'),
+        to_regprocedure('timetable.add_job(text,timetable.cron,text,jsonb,timetable.command_kind,text,integer,boolean,boolean,boolean,boolean)')
+    );
+    v_delete_job_reg := to_regprocedure('timetable.delete_job(text)');
+    if v_add_job_reg is null or v_delete_job_reg is null then
+        raise exception 'pg_timetable schema/API is not installed. '
+            'Run pg_timetable against this database first, or use pgque.start() for pg_cron.';
+    end if;
+
+    -- start_timetable() is SECURITY DEFINER, so do not invoke arbitrary code
+    -- from any schema named "timetable". Trust only a pg_timetable schema owned
+    -- by the PgQue owner or by a superuser, and require the called functions to
+    -- share that owner. This prevents a low-privilege fake timetable schema from
+    -- becoming a definer-privilege trampoline.
+    select nspowner into v_timetable_owner
+    from pg_namespace where oid = 'timetable'::regnamespace;
+    select rolsuper into v_owner_super
+    from pg_roles where oid = v_timetable_owner;
+    if v_timetable_owner <> current_user::regrole and not coalesce(v_owner_super, false) then
+        raise exception 'untrusted pg_timetable schema owner: %', v_timetable_owner::regrole;
+    end if;
+    if exists (
+        select 1
+        from pg_proc
+        where oid in (v_add_job_reg::oid, v_delete_job_reg::oid)
+          and proowner <> v_timetable_owner
+    ) then
+        raise exception 'untrusted pg_timetable API owner: add_job/delete_job must be owned by timetable schema owner';
+    end if;
+
+    if i_ticks_per_second is null or i_ticks_per_second < 1 or i_ticks_per_second > 1000
+       or 1000 % i_ticks_per_second <> 0 then
+        raise exception 'ticks_per_second must be an exact divisor of 1000 between 1 and 1000 (got %)',
+            coalesce(i_ticks_per_second::text, 'NULL');
+    end if;
+
+    v_period_ms := 1000 / i_ticks_per_second;
+    perform pgque.set_tick_period_ms(v_period_ms);
+
+    -- Idempotent: remove any old PgQue jobs from both schedulers.  This avoids
+    -- double-ticking if an operator switches from pg_cron to pg_timetable.
+    perform pgque.stop_timetable();
+    perform pgque.stop();
+
+    execute $sql$
+        select timetable.add_job(
+            job_name => 'pgque_ticker',
+            job_schedule => '@every 1 second'::timetable.cron,
+            job_command => 'CALL pgque.ticker_loop()',
+            job_kind => 'SQL'::timetable.command_kind,
+            job_max_instances => 1,
+            job_ignore_errors => false
+        )
+    $sql$ into v_ticker_id;
+
+    execute $sql$
+        select timetable.add_job(
+            job_name => 'pgque_retry_events',
+            job_schedule => '@every 30 seconds'::timetable.cron,
+            job_command => 'select pgque.maint_retry_events()',
+            job_kind => 'SQL'::timetable.command_kind,
+            job_max_instances => 1,
+            job_ignore_errors => false
+        )
+    $sql$ into v_retry_id;
+
+    execute $sql$
+        select timetable.add_job(
+            job_name => 'pgque_maint',
+            job_schedule => '@every 30 seconds'::timetable.cron,
+            job_command => 'select pgque.maint()',
+            job_kind => 'SQL'::timetable.command_kind,
+            job_max_instances => 1,
+            job_ignore_errors => false
+        )
+    $sql$ into v_maint_id;
+
+    execute $sql$
+        select timetable.add_job(
+            job_name => 'pgque_rotate_step2',
+            job_schedule => '@every 10 seconds'::timetable.cron,
+            job_command => 'select pgque.maint_rotate_tables_step2()',
+            job_kind => 'SQL'::timetable.command_kind,
+            job_max_instances => 1,
+            job_ignore_errors => false
+        )
+    $sql$ into v_step2_id;
+
+    update pgque.config
+    set ticker_job_id = v_ticker_id,
+        maint_job_id = v_maint_id,
+        scheduler = 'pg_timetable';
+
+    raise notice 'pgque started with pg_timetable: ticker=% (% ticks/sec), retry_events=%, maint=%, rotate_step2=%',
+        v_ticker_id, i_ticks_per_second, v_retry_id, v_maint_id, v_step2_id;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+create or replace function pgque.stop_timetable()
+returns void as $$
+declare
+    v_has_timetable bool;
+    v_timetable_owner oid;
+    v_delete_job_reg regprocedure;
+    v_owner_super bool;
+    v_scheduler text;
+begin
+    select scheduler into v_scheduler from pgque.config;
+
+    v_has_timetable := to_regnamespace('timetable') is not null
+        and to_regprocedure('timetable.delete_job(text)') is not null;
+
+    if v_has_timetable then
+        v_delete_job_reg := to_regprocedure('timetable.delete_job(text)');
+        select nspowner into v_timetable_owner
+        from pg_namespace where oid = 'timetable'::regnamespace;
+        select rolsuper into v_owner_super
+        from pg_roles where oid = v_timetable_owner;
+        if v_timetable_owner <> current_user::regrole and not coalesce(v_owner_super, false) then
+            if v_scheduler = 'pg_timetable' then
+                raise exception 'untrusted pg_timetable schema owner: %', v_timetable_owner::regrole;
+            end if;
+            return;
+        end if;
+        if exists (
+            select 1
+            from pg_proc
+            where oid = v_delete_job_reg::oid
+              and proowner <> v_timetable_owner
+        ) then
+            if v_scheduler = 'pg_timetable' then
+                raise exception 'untrusted pg_timetable API owner: delete_job must be owned by timetable schema owner';
+            end if;
+            return;
+        end if;
+
+        -- delete_job(name) returns false when absent; no exception noise needed.
+        execute $sql$select timetable.delete_job('pgque_ticker')$sql$;
+        execute $sql$select timetable.delete_job('pgque_retry_events')$sql$;
+        execute $sql$select timetable.delete_job('pgque_maint')$sql$;
+        execute $sql$select timetable.delete_job('pgque_rotate_step2')$sql$;
+    end if;
+
+    update pgque.config
+    set ticker_job_id = null,
+        maint_job_id = null,
+        scheduler = null
+    where scheduler = 'pg_timetable';
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
@@ -236,6 +424,9 @@ begin
     -- Stop pg_cron jobs before dropping the schema.
     if exists (select 1 from pg_extension where extname = 'pg_cron') then
         perform pgque.stop();
+    end if;
+    if to_regnamespace('timetable') is not null then
+        perform pgque.stop_timetable();
     end if;
     -- Drop everything
     drop schema pgque cascade;
@@ -264,32 +455,49 @@ begin
     -- pgque version
     return query select 'pgque'::text, 'info'::text, pgque.version();
 
-    -- pg_cron status
-    if exists (select 1 from pg_extension where extname = 'pg_cron') then
-        return query
-        select 'ticker'::text,
-            case when c.ticker_job_id is not null then 'scheduled' else 'stopped' end,
-            case when c.ticker_job_id is not null
-                then format('job_id=%s, tick_period_ms=%s (%s ticks/sec)',
-                    c.ticker_job_id,
-                    c.tick_period_ms,
-                    (1000.0 / c.tick_period_ms)::numeric(10, 2))
-                else format('not scheduled (tick_period_ms=%s)', c.tick_period_ms)
-            end
-        from pgque.config c;
+    -- Scheduler status (new summary row).
+    return query
+    select 'scheduler'::text,
+        coalesce(c.scheduler, 'manual')::text,
+        format('ticker_job_id=%s, maint_job_id=%s, tick_period_ms=%s (%s ticks/sec)',
+            coalesce(c.ticker_job_id::text, 'NULL'),
+            coalesce(c.maint_job_id::text, 'NULL'),
+            c.tick_period_ms,
+            (1000.0 / c.tick_period_ms)::numeric(10, 2))
+    from pgque.config c;
 
-        return query
-        select 'maintenance'::text,
-            case when c.maint_job_id is not null then 'scheduled' else 'stopped' end,
-            case when c.maint_job_id is not null
-                then format('job_id=%s', c.maint_job_id)
-                else 'not scheduled'
-            end
-        from pgque.config c;
-    else
+    -- Backward-compatible rows retained for scripts that parse status() by
+    -- component name.
+    return query
+    select 'ticker'::text,
+        case when c.ticker_job_id is not null then 'scheduled' else 'stopped' end,
+        case when c.ticker_job_id is not null
+            then format('scheduler=%s, job_id=%s, tick_period_ms=%s (%s ticks/sec)',
+                coalesce(c.scheduler, 'manual'),
+                c.ticker_job_id,
+                c.tick_period_ms,
+                (1000.0 / c.tick_period_ms)::numeric(10, 2))
+            else format('not scheduled (tick_period_ms=%s)', c.tick_period_ms)
+        end
+    from pgque.config c;
+
+    return query
+    select 'maintenance'::text,
+        case when c.maint_job_id is not null then 'scheduled' else 'stopped' end,
+        case when c.maint_job_id is not null
+            then format('scheduler=%s, job_id=%s', coalesce(c.scheduler, 'manual'), c.maint_job_id)
+            else 'not scheduled'
+        end
+    from pgque.config c;
+
+    if not exists (select 1 from pg_extension where extname = 'pg_cron') then
         return query select 'pg_cron'::text, 'unavailable'::text,
-            format('pg_cron not installed -- call pgque.ticker() and pgque.maint() manually (current tick_period_ms=%s)',
-                (select tick_period_ms from pgque.config));
+            'use pgque.start_timetable() for pg_timetable, or call pgque.ticker() / pgque.maint() manually'::text;
+    end if;
+
+    if to_regnamespace('timetable') is null then
+        return query select 'pg_timetable'::text, 'unavailable'::text,
+            'run pg_timetable against this database, then call pgque.start_timetable()'::text;
     end if;
 
     -- Queue count

--- a/sql/pgque-tle.sql
+++ b/sql/pgque-tle.sql
@@ -4040,6 +4040,9 @@ create table if not exists pgque.config (
     singleton       bool primary key default true check (singleton),
     ticker_job_id   bigint,
     maint_job_id    bigint,
+    scheduler       text
+        constraint config_scheduler_check
+        check (scheduler in ('pg_cron', 'pg_timetable')),
     tick_period_ms  integer not null default 100
         constraint config_tick_period_ms_check
         check (
@@ -4059,6 +4062,21 @@ on conflict (singleton) do nothing;
 -- Add tick_period_ms on upgrade from a pre-tick-period install.
 do $$
 begin
+    if not exists (
+        select 1 from information_schema.columns
+        where table_schema = 'pgque' and table_name = 'config'
+          and column_name = 'scheduler'
+    ) then
+        alter table pgque.config
+            add column scheduler text;
+    end if;
+
+    alter table pgque.config
+        drop constraint if exists config_scheduler_check;
+    alter table pgque.config
+        add constraint config_scheduler_check
+        check (scheduler in ('pg_cron', 'pg_timetable'));
+
     if not exists (
         select 1 from information_schema.columns
         where table_schema = 'pgque' and table_name = 'config'
@@ -4319,6 +4337,7 @@ begin
     end if;
 
     -- Idempotent: stop existing jobs first
+    perform pgque.stop_timetable();
     perform pgque.stop();
 
     v_dbname := current_database();
@@ -4373,7 +4392,8 @@ begin
     -- Store job IDs in config (retry + rotate_step2 unscheduled by name)
     update pgque.config
     set ticker_job_id = v_ticker_id,
-        maint_job_id = v_maint_id;
+        maint_job_id = v_maint_id,
+        scheduler = 'pg_cron';
 
     raise notice 'pgque started: ticker=% (% ticks/sec), retry_events=%, maint=%, rotate_step2=%',
         v_ticker_id, (1000.0 / v_period_ms)::numeric(10, 2),
@@ -4387,17 +4407,25 @@ declare
     v_ticker_id bigint;
     v_maint_id bigint;
     v_has_pgcron bool;
+    v_scheduler text;
 begin
     -- Read current job IDs
-    select ticker_job_id, maint_job_id
-    into v_ticker_id, v_maint_id
+    select ticker_job_id, maint_job_id, scheduler
+    into v_ticker_id, v_maint_id, v_scheduler
     from pgque.config;
+
+    -- stop() is the generic PgQue stop entrypoint; delegate when pg_timetable
+    -- owns the active jobs.
+    if v_scheduler = 'pg_timetable' then
+        perform pgque.stop_timetable();
+        return;
+    end if;
 
     -- Check if pg_cron is available
     select exists (select 1 from pg_extension where extname = 'pg_cron')
     into v_has_pgcron;
 
-    if v_has_pgcron then
+    if v_has_pgcron and (v_scheduler is null or v_scheduler = 'pg_cron') then
         -- Unschedule ticker if it exists
         if v_ticker_id is not null then
             perform cron.unschedule(v_ticker_id);
@@ -4425,10 +4453,188 @@ begin
         end;
     end if;
 
-    -- Clear job IDs regardless (even if pg_cron is gone)
+    -- Clear pg_cron job IDs (only when scheduler is pg_cron or unset).
     update pgque.config
     set ticker_job_id = null,
-        maint_job_id = null;
+        maint_job_id = null,
+        scheduler = null
+    where scheduler is null or scheduler = 'pg_cron';
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+
+create or replace function pgque.start_timetable(i_ticks_per_second integer default 10)
+returns void as $$
+declare
+    v_ticker_id bigint;
+    v_retry_id bigint;
+    v_maint_id bigint;
+    v_step2_id bigint;
+    v_period_ms integer;
+    v_timetable_owner oid;
+    v_add_job_reg regprocedure;
+    v_delete_job_reg regprocedure;
+    v_owner_super bool;
+begin
+    -- pg_timetable is optional and external (standalone scheduler). It creates
+    -- the timetable schema on first run; PgQue only needs its SQL API here.
+    if to_regnamespace('timetable') is null then
+        raise exception 'pg_timetable schema/API is not installed. '
+            'Run pg_timetable against this database first, or use pgque.start() for pg_cron.';
+    end if;
+
+    -- Support both modern pg_timetable (12-argument add_job with job_on_error)
+    -- and older v4-style installs (11-argument add_job). The named-argument
+    -- calls below only use parameters common to both versions.
+    v_add_job_reg := coalesce(
+        to_regprocedure('timetable.add_job(text,timetable.cron,text,jsonb,timetable.command_kind,text,integer,boolean,boolean,boolean,boolean,text)'),
+        to_regprocedure('timetable.add_job(text,timetable.cron,text,jsonb,timetable.command_kind,text,integer,boolean,boolean,boolean,boolean)')
+    );
+    v_delete_job_reg := to_regprocedure('timetable.delete_job(text)');
+    if v_add_job_reg is null or v_delete_job_reg is null then
+        raise exception 'pg_timetable schema/API is not installed. '
+            'Run pg_timetable against this database first, or use pgque.start() for pg_cron.';
+    end if;
+
+    -- start_timetable() is SECURITY DEFINER, so do not invoke arbitrary code
+    -- from any schema named "timetable". Trust only a pg_timetable schema owned
+    -- by the PgQue owner or by a superuser, and require the called functions to
+    -- share that owner. This prevents a low-privilege fake timetable schema from
+    -- becoming a definer-privilege trampoline.
+    select nspowner into v_timetable_owner
+    from pg_namespace where oid = 'timetable'::regnamespace;
+    select rolsuper into v_owner_super
+    from pg_roles where oid = v_timetable_owner;
+    if v_timetable_owner <> current_user::regrole and not coalesce(v_owner_super, false) then
+        raise exception 'untrusted pg_timetable schema owner: %', v_timetable_owner::regrole;
+    end if;
+    if exists (
+        select 1
+        from pg_proc
+        where oid in (v_add_job_reg::oid, v_delete_job_reg::oid)
+          and proowner <> v_timetable_owner
+    ) then
+        raise exception 'untrusted pg_timetable API owner: add_job/delete_job must be owned by timetable schema owner';
+    end if;
+
+    if i_ticks_per_second is null or i_ticks_per_second < 1 or i_ticks_per_second > 1000
+       or 1000 % i_ticks_per_second <> 0 then
+        raise exception 'ticks_per_second must be an exact divisor of 1000 between 1 and 1000 (got %)',
+            coalesce(i_ticks_per_second::text, 'NULL');
+    end if;
+
+    v_period_ms := 1000 / i_ticks_per_second;
+    perform pgque.set_tick_period_ms(v_period_ms);
+
+    -- Idempotent: remove any old PgQue jobs from both schedulers.  This avoids
+    -- double-ticking if an operator switches from pg_cron to pg_timetable.
+    perform pgque.stop_timetable();
+    perform pgque.stop();
+
+    execute $sql$
+        select timetable.add_job(
+            job_name => 'pgque_ticker',
+            job_schedule => '@every 1 second'::timetable.cron,
+            job_command => 'CALL pgque.ticker_loop()',
+            job_kind => 'SQL'::timetable.command_kind,
+            job_max_instances => 1,
+            job_ignore_errors => false
+        )
+    $sql$ into v_ticker_id;
+
+    execute $sql$
+        select timetable.add_job(
+            job_name => 'pgque_retry_events',
+            job_schedule => '@every 30 seconds'::timetable.cron,
+            job_command => 'select pgque.maint_retry_events()',
+            job_kind => 'SQL'::timetable.command_kind,
+            job_max_instances => 1,
+            job_ignore_errors => false
+        )
+    $sql$ into v_retry_id;
+
+    execute $sql$
+        select timetable.add_job(
+            job_name => 'pgque_maint',
+            job_schedule => '@every 30 seconds'::timetable.cron,
+            job_command => 'select pgque.maint()',
+            job_kind => 'SQL'::timetable.command_kind,
+            job_max_instances => 1,
+            job_ignore_errors => false
+        )
+    $sql$ into v_maint_id;
+
+    execute $sql$
+        select timetable.add_job(
+            job_name => 'pgque_rotate_step2',
+            job_schedule => '@every 10 seconds'::timetable.cron,
+            job_command => 'select pgque.maint_rotate_tables_step2()',
+            job_kind => 'SQL'::timetable.command_kind,
+            job_max_instances => 1,
+            job_ignore_errors => false
+        )
+    $sql$ into v_step2_id;
+
+    update pgque.config
+    set ticker_job_id = v_ticker_id,
+        maint_job_id = v_maint_id,
+        scheduler = 'pg_timetable';
+
+    raise notice 'pgque started with pg_timetable: ticker=% (% ticks/sec), retry_events=%, maint=%, rotate_step2=%',
+        v_ticker_id, i_ticks_per_second, v_retry_id, v_maint_id, v_step2_id;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+create or replace function pgque.stop_timetable()
+returns void as $$
+declare
+    v_has_timetable bool;
+    v_timetable_owner oid;
+    v_delete_job_reg regprocedure;
+    v_owner_super bool;
+    v_scheduler text;
+begin
+    select scheduler into v_scheduler from pgque.config;
+
+    v_has_timetable := to_regnamespace('timetable') is not null
+        and to_regprocedure('timetable.delete_job(text)') is not null;
+
+    if v_has_timetable then
+        v_delete_job_reg := to_regprocedure('timetable.delete_job(text)');
+        select nspowner into v_timetable_owner
+        from pg_namespace where oid = 'timetable'::regnamespace;
+        select rolsuper into v_owner_super
+        from pg_roles where oid = v_timetable_owner;
+        if v_timetable_owner <> current_user::regrole and not coalesce(v_owner_super, false) then
+            if v_scheduler = 'pg_timetable' then
+                raise exception 'untrusted pg_timetable schema owner: %', v_timetable_owner::regrole;
+            end if;
+            return;
+        end if;
+        if exists (
+            select 1
+            from pg_proc
+            where oid = v_delete_job_reg::oid
+              and proowner <> v_timetable_owner
+        ) then
+            if v_scheduler = 'pg_timetable' then
+                raise exception 'untrusted pg_timetable API owner: delete_job must be owned by timetable schema owner';
+            end if;
+            return;
+        end if;
+
+        -- delete_job(name) returns false when absent; no exception noise needed.
+        execute $sql$select timetable.delete_job('pgque_ticker')$sql$;
+        execute $sql$select timetable.delete_job('pgque_retry_events')$sql$;
+        execute $sql$select timetable.delete_job('pgque_maint')$sql$;
+        execute $sql$select timetable.delete_job('pgque_rotate_step2')$sql$;
+    end if;
+
+    update pgque.config
+    set ticker_job_id = null,
+        maint_job_id = null,
+        scheduler = null
+    where scheduler = 'pg_timetable';
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
@@ -4438,6 +4644,9 @@ begin
     -- Stop pg_cron jobs before dropping the schema.
     if exists (select 1 from pg_extension where extname = 'pg_cron') then
         perform pgque.stop();
+    end if;
+    if to_regnamespace('timetable') is not null then
+        perform pgque.stop_timetable();
     end if;
     -- Drop everything
     drop schema pgque cascade;
@@ -4466,32 +4675,49 @@ begin
     -- pgque version
     return query select 'pgque'::text, 'info'::text, pgque.version();
 
-    -- pg_cron status
-    if exists (select 1 from pg_extension where extname = 'pg_cron') then
-        return query
-        select 'ticker'::text,
-            case when c.ticker_job_id is not null then 'scheduled' else 'stopped' end,
-            case when c.ticker_job_id is not null
-                then format('job_id=%s, tick_period_ms=%s (%s ticks/sec)',
-                    c.ticker_job_id,
-                    c.tick_period_ms,
-                    (1000.0 / c.tick_period_ms)::numeric(10, 2))
-                else format('not scheduled (tick_period_ms=%s)', c.tick_period_ms)
-            end
-        from pgque.config c;
+    -- Scheduler status (new summary row).
+    return query
+    select 'scheduler'::text,
+        coalesce(c.scheduler, 'manual')::text,
+        format('ticker_job_id=%s, maint_job_id=%s, tick_period_ms=%s (%s ticks/sec)',
+            coalesce(c.ticker_job_id::text, 'NULL'),
+            coalesce(c.maint_job_id::text, 'NULL'),
+            c.tick_period_ms,
+            (1000.0 / c.tick_period_ms)::numeric(10, 2))
+    from pgque.config c;
 
-        return query
-        select 'maintenance'::text,
-            case when c.maint_job_id is not null then 'scheduled' else 'stopped' end,
-            case when c.maint_job_id is not null
-                then format('job_id=%s', c.maint_job_id)
-                else 'not scheduled'
-            end
-        from pgque.config c;
-    else
+    -- Backward-compatible rows retained for scripts that parse status() by
+    -- component name.
+    return query
+    select 'ticker'::text,
+        case when c.ticker_job_id is not null then 'scheduled' else 'stopped' end,
+        case when c.ticker_job_id is not null
+            then format('scheduler=%s, job_id=%s, tick_period_ms=%s (%s ticks/sec)',
+                coalesce(c.scheduler, 'manual'),
+                c.ticker_job_id,
+                c.tick_period_ms,
+                (1000.0 / c.tick_period_ms)::numeric(10, 2))
+            else format('not scheduled (tick_period_ms=%s)', c.tick_period_ms)
+        end
+    from pgque.config c;
+
+    return query
+    select 'maintenance'::text,
+        case when c.maint_job_id is not null then 'scheduled' else 'stopped' end,
+        case when c.maint_job_id is not null
+            then format('scheduler=%s, job_id=%s', coalesce(c.scheduler, 'manual'), c.maint_job_id)
+            else 'not scheduled'
+        end
+    from pgque.config c;
+
+    if not exists (select 1 from pg_extension where extname = 'pg_cron') then
         return query select 'pg_cron'::text, 'unavailable'::text,
-            format('pg_cron not installed -- call pgque.ticker() and pgque.maint() manually (current tick_period_ms=%s)',
-                (select tick_period_ms from pgque.config));
+            'use pgque.start_timetable() for pg_timetable, or call pgque.ticker() / pgque.maint() manually'::text;
+    end if;
+
+    if to_regnamespace('timetable') is null then
+        return query select 'pg_timetable'::text, 'unavailable'::text,
+            'run pg_timetable against this database, then call pgque.start_timetable()'::text;
     end if;
 
     -- Queue count

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -3952,6 +3952,9 @@ create table if not exists pgque.config (
     singleton       bool primary key default true check (singleton),
     ticker_job_id   bigint,
     maint_job_id    bigint,
+    scheduler       text
+        constraint config_scheduler_check
+        check (scheduler in ('pg_cron', 'pg_timetable')),
     tick_period_ms  integer not null default 100
         constraint config_tick_period_ms_check
         check (
@@ -3971,6 +3974,21 @@ on conflict (singleton) do nothing;
 -- Add tick_period_ms on upgrade from a pre-tick-period install.
 do $$
 begin
+    if not exists (
+        select 1 from information_schema.columns
+        where table_schema = 'pgque' and table_name = 'config'
+          and column_name = 'scheduler'
+    ) then
+        alter table pgque.config
+            add column scheduler text;
+    end if;
+
+    alter table pgque.config
+        drop constraint if exists config_scheduler_check;
+    alter table pgque.config
+        add constraint config_scheduler_check
+        check (scheduler in ('pg_cron', 'pg_timetable'));
+
     if not exists (
         select 1 from information_schema.columns
         where table_schema = 'pgque' and table_name = 'config'
@@ -4231,6 +4249,7 @@ begin
     end if;
 
     -- Idempotent: stop existing jobs first
+    perform pgque.stop_timetable();
     perform pgque.stop();
 
     v_dbname := current_database();
@@ -4285,7 +4304,8 @@ begin
     -- Store job IDs in config (retry + rotate_step2 unscheduled by name)
     update pgque.config
     set ticker_job_id = v_ticker_id,
-        maint_job_id = v_maint_id;
+        maint_job_id = v_maint_id,
+        scheduler = 'pg_cron';
 
     raise notice 'pgque started: ticker=% (% ticks/sec), retry_events=%, maint=%, rotate_step2=%',
         v_ticker_id, (1000.0 / v_period_ms)::numeric(10, 2),
@@ -4299,17 +4319,25 @@ declare
     v_ticker_id bigint;
     v_maint_id bigint;
     v_has_pgcron bool;
+    v_scheduler text;
 begin
     -- Read current job IDs
-    select ticker_job_id, maint_job_id
-    into v_ticker_id, v_maint_id
+    select ticker_job_id, maint_job_id, scheduler
+    into v_ticker_id, v_maint_id, v_scheduler
     from pgque.config;
+
+    -- stop() is the generic PgQue stop entrypoint; delegate when pg_timetable
+    -- owns the active jobs.
+    if v_scheduler = 'pg_timetable' then
+        perform pgque.stop_timetable();
+        return;
+    end if;
 
     -- Check if pg_cron is available
     select exists (select 1 from pg_extension where extname = 'pg_cron')
     into v_has_pgcron;
 
-    if v_has_pgcron then
+    if v_has_pgcron and (v_scheduler is null or v_scheduler = 'pg_cron') then
         -- Unschedule ticker if it exists
         if v_ticker_id is not null then
             perform cron.unschedule(v_ticker_id);
@@ -4337,10 +4365,188 @@ begin
         end;
     end if;
 
-    -- Clear job IDs regardless (even if pg_cron is gone)
+    -- Clear pg_cron job IDs (only when scheduler is pg_cron or unset).
     update pgque.config
     set ticker_job_id = null,
-        maint_job_id = null;
+        maint_job_id = null,
+        scheduler = null
+    where scheduler is null or scheduler = 'pg_cron';
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+
+create or replace function pgque.start_timetable(i_ticks_per_second integer default 10)
+returns void as $$
+declare
+    v_ticker_id bigint;
+    v_retry_id bigint;
+    v_maint_id bigint;
+    v_step2_id bigint;
+    v_period_ms integer;
+    v_timetable_owner oid;
+    v_add_job_reg regprocedure;
+    v_delete_job_reg regprocedure;
+    v_owner_super bool;
+begin
+    -- pg_timetable is optional and external (standalone scheduler). It creates
+    -- the timetable schema on first run; PgQue only needs its SQL API here.
+    if to_regnamespace('timetable') is null then
+        raise exception 'pg_timetable schema/API is not installed. '
+            'Run pg_timetable against this database first, or use pgque.start() for pg_cron.';
+    end if;
+
+    -- Support both modern pg_timetable (12-argument add_job with job_on_error)
+    -- and older v4-style installs (11-argument add_job). The named-argument
+    -- calls below only use parameters common to both versions.
+    v_add_job_reg := coalesce(
+        to_regprocedure('timetable.add_job(text,timetable.cron,text,jsonb,timetable.command_kind,text,integer,boolean,boolean,boolean,boolean,text)'),
+        to_regprocedure('timetable.add_job(text,timetable.cron,text,jsonb,timetable.command_kind,text,integer,boolean,boolean,boolean,boolean)')
+    );
+    v_delete_job_reg := to_regprocedure('timetable.delete_job(text)');
+    if v_add_job_reg is null or v_delete_job_reg is null then
+        raise exception 'pg_timetable schema/API is not installed. '
+            'Run pg_timetable against this database first, or use pgque.start() for pg_cron.';
+    end if;
+
+    -- start_timetable() is SECURITY DEFINER, so do not invoke arbitrary code
+    -- from any schema named "timetable". Trust only a pg_timetable schema owned
+    -- by the PgQue owner or by a superuser, and require the called functions to
+    -- share that owner. This prevents a low-privilege fake timetable schema from
+    -- becoming a definer-privilege trampoline.
+    select nspowner into v_timetable_owner
+    from pg_namespace where oid = 'timetable'::regnamespace;
+    select rolsuper into v_owner_super
+    from pg_roles where oid = v_timetable_owner;
+    if v_timetable_owner <> current_user::regrole and not coalesce(v_owner_super, false) then
+        raise exception 'untrusted pg_timetable schema owner: %', v_timetable_owner::regrole;
+    end if;
+    if exists (
+        select 1
+        from pg_proc
+        where oid in (v_add_job_reg::oid, v_delete_job_reg::oid)
+          and proowner <> v_timetable_owner
+    ) then
+        raise exception 'untrusted pg_timetable API owner: add_job/delete_job must be owned by timetable schema owner';
+    end if;
+
+    if i_ticks_per_second is null or i_ticks_per_second < 1 or i_ticks_per_second > 1000
+       or 1000 % i_ticks_per_second <> 0 then
+        raise exception 'ticks_per_second must be an exact divisor of 1000 between 1 and 1000 (got %)',
+            coalesce(i_ticks_per_second::text, 'NULL');
+    end if;
+
+    v_period_ms := 1000 / i_ticks_per_second;
+    perform pgque.set_tick_period_ms(v_period_ms);
+
+    -- Idempotent: remove any old PgQue jobs from both schedulers.  This avoids
+    -- double-ticking if an operator switches from pg_cron to pg_timetable.
+    perform pgque.stop_timetable();
+    perform pgque.stop();
+
+    execute $sql$
+        select timetable.add_job(
+            job_name => 'pgque_ticker',
+            job_schedule => '@every 1 second'::timetable.cron,
+            job_command => 'CALL pgque.ticker_loop()',
+            job_kind => 'SQL'::timetable.command_kind,
+            job_max_instances => 1,
+            job_ignore_errors => false
+        )
+    $sql$ into v_ticker_id;
+
+    execute $sql$
+        select timetable.add_job(
+            job_name => 'pgque_retry_events',
+            job_schedule => '@every 30 seconds'::timetable.cron,
+            job_command => 'select pgque.maint_retry_events()',
+            job_kind => 'SQL'::timetable.command_kind,
+            job_max_instances => 1,
+            job_ignore_errors => false
+        )
+    $sql$ into v_retry_id;
+
+    execute $sql$
+        select timetable.add_job(
+            job_name => 'pgque_maint',
+            job_schedule => '@every 30 seconds'::timetable.cron,
+            job_command => 'select pgque.maint()',
+            job_kind => 'SQL'::timetable.command_kind,
+            job_max_instances => 1,
+            job_ignore_errors => false
+        )
+    $sql$ into v_maint_id;
+
+    execute $sql$
+        select timetable.add_job(
+            job_name => 'pgque_rotate_step2',
+            job_schedule => '@every 10 seconds'::timetable.cron,
+            job_command => 'select pgque.maint_rotate_tables_step2()',
+            job_kind => 'SQL'::timetable.command_kind,
+            job_max_instances => 1,
+            job_ignore_errors => false
+        )
+    $sql$ into v_step2_id;
+
+    update pgque.config
+    set ticker_job_id = v_ticker_id,
+        maint_job_id = v_maint_id,
+        scheduler = 'pg_timetable';
+
+    raise notice 'pgque started with pg_timetable: ticker=% (% ticks/sec), retry_events=%, maint=%, rotate_step2=%',
+        v_ticker_id, i_ticks_per_second, v_retry_id, v_maint_id, v_step2_id;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+create or replace function pgque.stop_timetable()
+returns void as $$
+declare
+    v_has_timetable bool;
+    v_timetable_owner oid;
+    v_delete_job_reg regprocedure;
+    v_owner_super bool;
+    v_scheduler text;
+begin
+    select scheduler into v_scheduler from pgque.config;
+
+    v_has_timetable := to_regnamespace('timetable') is not null
+        and to_regprocedure('timetable.delete_job(text)') is not null;
+
+    if v_has_timetable then
+        v_delete_job_reg := to_regprocedure('timetable.delete_job(text)');
+        select nspowner into v_timetable_owner
+        from pg_namespace where oid = 'timetable'::regnamespace;
+        select rolsuper into v_owner_super
+        from pg_roles where oid = v_timetable_owner;
+        if v_timetable_owner <> current_user::regrole and not coalesce(v_owner_super, false) then
+            if v_scheduler = 'pg_timetable' then
+                raise exception 'untrusted pg_timetable schema owner: %', v_timetable_owner::regrole;
+            end if;
+            return;
+        end if;
+        if exists (
+            select 1
+            from pg_proc
+            where oid = v_delete_job_reg::oid
+              and proowner <> v_timetable_owner
+        ) then
+            if v_scheduler = 'pg_timetable' then
+                raise exception 'untrusted pg_timetable API owner: delete_job must be owned by timetable schema owner';
+            end if;
+            return;
+        end if;
+
+        -- delete_job(name) returns false when absent; no exception noise needed.
+        execute $sql$select timetable.delete_job('pgque_ticker')$sql$;
+        execute $sql$select timetable.delete_job('pgque_retry_events')$sql$;
+        execute $sql$select timetable.delete_job('pgque_maint')$sql$;
+        execute $sql$select timetable.delete_job('pgque_rotate_step2')$sql$;
+    end if;
+
+    update pgque.config
+    set ticker_job_id = null,
+        maint_job_id = null,
+        scheduler = null
+    where scheduler = 'pg_timetable';
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
@@ -4350,6 +4556,9 @@ begin
     -- Stop pg_cron jobs before dropping the schema.
     if exists (select 1 from pg_extension where extname = 'pg_cron') then
         perform pgque.stop();
+    end if;
+    if to_regnamespace('timetable') is not null then
+        perform pgque.stop_timetable();
     end if;
     -- Drop everything
     drop schema pgque cascade;
@@ -4378,32 +4587,49 @@ begin
     -- pgque version
     return query select 'pgque'::text, 'info'::text, pgque.version();
 
-    -- pg_cron status
-    if exists (select 1 from pg_extension where extname = 'pg_cron') then
-        return query
-        select 'ticker'::text,
-            case when c.ticker_job_id is not null then 'scheduled' else 'stopped' end,
-            case when c.ticker_job_id is not null
-                then format('job_id=%s, tick_period_ms=%s (%s ticks/sec)',
-                    c.ticker_job_id,
-                    c.tick_period_ms,
-                    (1000.0 / c.tick_period_ms)::numeric(10, 2))
-                else format('not scheduled (tick_period_ms=%s)', c.tick_period_ms)
-            end
-        from pgque.config c;
+    -- Scheduler status (new summary row).
+    return query
+    select 'scheduler'::text,
+        coalesce(c.scheduler, 'manual')::text,
+        format('ticker_job_id=%s, maint_job_id=%s, tick_period_ms=%s (%s ticks/sec)',
+            coalesce(c.ticker_job_id::text, 'NULL'),
+            coalesce(c.maint_job_id::text, 'NULL'),
+            c.tick_period_ms,
+            (1000.0 / c.tick_period_ms)::numeric(10, 2))
+    from pgque.config c;
 
-        return query
-        select 'maintenance'::text,
-            case when c.maint_job_id is not null then 'scheduled' else 'stopped' end,
-            case when c.maint_job_id is not null
-                then format('job_id=%s', c.maint_job_id)
-                else 'not scheduled'
-            end
-        from pgque.config c;
-    else
+    -- Backward-compatible rows retained for scripts that parse status() by
+    -- component name.
+    return query
+    select 'ticker'::text,
+        case when c.ticker_job_id is not null then 'scheduled' else 'stopped' end,
+        case when c.ticker_job_id is not null
+            then format('scheduler=%s, job_id=%s, tick_period_ms=%s (%s ticks/sec)',
+                coalesce(c.scheduler, 'manual'),
+                c.ticker_job_id,
+                c.tick_period_ms,
+                (1000.0 / c.tick_period_ms)::numeric(10, 2))
+            else format('not scheduled (tick_period_ms=%s)', c.tick_period_ms)
+        end
+    from pgque.config c;
+
+    return query
+    select 'maintenance'::text,
+        case when c.maint_job_id is not null then 'scheduled' else 'stopped' end,
+        case when c.maint_job_id is not null
+            then format('scheduler=%s, job_id=%s', coalesce(c.scheduler, 'manual'), c.maint_job_id)
+            else 'not scheduled'
+        end
+    from pgque.config c;
+
+    if not exists (select 1 from pg_extension where extname = 'pg_cron') then
         return query select 'pg_cron'::text, 'unavailable'::text,
-            format('pg_cron not installed -- call pgque.ticker() and pgque.maint() manually (current tick_period_ms=%s)',
-                (select tick_period_ms from pgque.config));
+            'use pgque.start_timetable() for pg_timetable, or call pgque.ticker() / pgque.maint() manually'::text;
+    end if;
+
+    if to_regnamespace('timetable') is null then
+        return query select 'pg_timetable'::text, 'unavailable'::text,
+            'run pg_timetable against this database, then call pgque.start_timetable()'::text;
     end if;
 
     -- Queue count

--- a/tests/run_all.sql
+++ b/tests/run_all.sql
@@ -61,6 +61,9 @@
 \echo 'Running: test_pgcron_lifecycle'
 \i tests/test_pgcron_lifecycle.sql
 
+\echo 'Running: test_pgtimetable_lifecycle'
+\i tests/test_pgtimetable_lifecycle.sql
+
 \echo 'Running: test_tick_period'
 \i tests/test_tick_period.sql
 

--- a/tests/test_pgtimetable_lifecycle.sql
+++ b/tests/test_pgtimetable_lifecycle.sql
@@ -1,0 +1,357 @@
+-- test_pgtimetable_lifecycle.sql -- Verify pg_timetable lifecycle integration
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- These tests exercise pgque.start_timetable()/stop_timetable().  When real
+-- pg_timetable is not installed, the positive-path tests create a tiny fake
+-- timetable schema with the same delete_job() contract plus the older 11-argument add_job() signature PgQue supports.
+-- This keeps CI coverage deterministic without running the external scheduler.
+
+-- Clean up from interrupted prior runs.
+do $$
+begin
+  if to_regnamespace('timetable') is not null then
+    -- Only drop the lightweight fake schema these tests create, never a real
+    -- pg_timetable install.
+    if to_regclass('timetable.chain') is not null
+       and to_regclass('timetable.task') is not null
+       and to_regclass('timetable.execution_log') is null then
+      drop schema timetable cascade;
+    end if;
+  end if;
+exception when others then
+  null;
+end $$;
+
+-- Test 1: without pg_timetable, start_timetable() raises an informative error
+do $$
+begin
+  if to_regnamespace('timetable') is not null then
+    raise notice 'SKIP: pg_timetable IS installed (cannot test without-pg_timetable path)';
+    return;
+  end if;
+
+  begin
+    perform pgque.start_timetable();
+    assert false, 'start_timetable() should raise without pg_timetable';
+  exception when others then
+    assert sqlerrm like '%pg_timetable%',
+      'error should mention pg_timetable, got: ' || sqlerrm;
+    raise notice 'PASS: start_timetable() raises informative error without pg_timetable';
+  end;
+end $$;
+
+
+-- Test 1b: a fake timetable schema owned by an untrusted role is rejected
+-- before SECURITY DEFINER code calls timetable.add_job()/delete_job().
+do $$
+begin
+  if to_regnamespace('timetable') is not null then
+    raise notice 'SKIP: timetable schema already exists (cannot test untrusted fake owner path)';
+    return;
+  end if;
+
+  if not exists (select 1 from pg_roles where rolname = 'pgque_fake_timetable_owner') then
+    create role pgque_fake_timetable_owner;
+  end if;
+
+  create schema timetable authorization pgque_fake_timetable_owner;
+  create domain timetable.cron as text;
+  create type timetable.command_kind as enum ('SQL', 'PROGRAM', 'BUILTIN');
+  create function timetable.add_job(
+    job_name text,
+    job_schedule timetable.cron,
+    job_command text,
+    job_parameters jsonb default null,
+    job_kind timetable.command_kind default 'SQL'::timetable.command_kind,
+    job_client_name text default null,
+    job_max_instances integer default null,
+    job_live boolean default true,
+    job_self_destruct boolean default false,
+    job_ignore_errors boolean default true,
+    job_exclusive boolean default false,
+    job_on_error text default null
+  ) returns bigint language sql as 'select 1::bigint';
+  create function timetable.delete_job(job_name text) returns boolean language sql as 'select true';
+  alter function timetable.add_job(text,timetable.cron,text,jsonb,timetable.command_kind,text,integer,boolean,boolean,boolean,boolean,text)
+    owner to pgque_fake_timetable_owner;
+  alter function timetable.delete_job(text) owner to pgque_fake_timetable_owner;
+
+  begin
+    perform pgque.start_timetable();
+    assert false, 'start_timetable() should reject untrusted fake timetable owner';
+  exception when others then
+    assert sqlerrm like '%untrusted pg_timetable schema owner%',
+      'error should reject untrusted schema owner, got: ' || sqlerrm;
+    raise notice 'PASS: start_timetable() rejects untrusted fake timetable schema owner';
+  end;
+
+  drop schema timetable cascade;
+  drop role pgque_fake_timetable_owner;
+end $$;
+
+-- Test harness: if pg_timetable is absent, install a minimal fake schema that
+-- matches the SQL API PgQue calls.  It intentionally does not run jobs.
+create temp table _pgque_pgtimetable_harness(fake_installed boolean not null);
+
+do $$
+begin
+  if to_regnamespace('timetable') is not null then
+    insert into _pgque_pgtimetable_harness values (false);
+    return;
+  end if;
+
+  execute 'create schema timetable';
+  execute 'create domain timetable.cron as text';
+  execute $ddl$create type timetable.command_kind as enum ('SQL', 'PROGRAM', 'BUILTIN')$ddl$;
+  execute $sql$
+    create table timetable.chain (
+      chain_id bigserial primary key,
+      chain_name text not null unique,
+      run_at timetable.cron,
+      max_instances integer,
+      live boolean default false
+    )
+  $sql$;
+  execute $sql$
+    create table timetable.task (
+      task_id bigserial primary key,
+      chain_id bigint references timetable.chain(chain_id) on delete cascade,
+      task_order double precision not null,
+      kind timetable.command_kind not null default 'SQL',
+      command text not null,
+      ignore_error boolean not null default false,
+      autonomous boolean not null default false
+    )
+  $sql$;
+  execute $sql$
+    create or replace function timetable.add_job(
+      job_name text,
+      job_schedule timetable.cron,
+      job_command text,
+      job_parameters jsonb default null,
+      job_kind timetable.command_kind default 'SQL'::timetable.command_kind,
+      job_client_name text default null,
+      job_max_instances integer default null,
+      job_live boolean default true,
+      job_self_destruct boolean default false,
+      job_ignore_errors boolean default true,
+      job_exclusive boolean default false
+    ) returns bigint language sql as $fn$
+      with c as (
+        insert into timetable.chain(chain_name, run_at, max_instances, live)
+        values (job_name, job_schedule, job_max_instances, job_live)
+        returning chain_id
+      ), t as (
+        insert into timetable.task(chain_id, task_order, kind, command, ignore_error, autonomous)
+        select chain_id, 10, job_kind, job_command, job_ignore_errors, true from c
+      )
+      select chain_id from c;
+    $fn$
+  $sql$;
+  execute $sql$
+    create or replace function timetable.delete_job(job_name text)
+    returns boolean language sql as $fn$
+      with d as (delete from timetable.chain where chain_name = job_name returning 1)
+      select exists(select 1 from d);
+    $fn$
+  $sql$;
+
+  insert into _pgque_pgtimetable_harness values (true);
+  raise notice 'INFO: installed fake pg_timetable schema for lifecycle tests';
+end $$;
+
+
+-- Test 1c: invalid tick rates are rejected once pg_timetable API exists.
+do $$
+declare
+  r record;
+begin
+  for r in select * from (values
+    (0::integer, '0'),
+    (-1::integer, '-1'),
+    (7::integer, '7'),
+    (1001::integer, '1001'),
+    (null::integer, 'NULL')
+  ) as v(rate, label) loop
+    begin
+      perform pgque.start_timetable(r.rate);
+      assert false, 'start_timetable(' || r.label || ') should fail';
+    exception when others then
+      assert sqlerrm like '%ticks_per_second%',
+        'error should mention ticks_per_second for ' || r.label || ', got: ' || sqlerrm;
+      assert sqlerrm like '%' || r.label || '%',
+        'error should mention bad value ' || r.label || ', got: ' || sqlerrm;
+    end;
+  end loop;
+  raise notice 'PASS: start_timetable() rejects invalid ticks_per_second values';
+end $$;
+
+-- Test 2: start_timetable(10) creates four pg_timetable jobs and stores config
+do $$
+declare
+  v_ticker_id bigint;
+  v_maint_id bigint;
+  v_scheduler text;
+  v_period_ms integer;
+  v_job_count integer;
+  v_ticker_command text;
+  v_status text;
+begin
+  perform pgque.start_timetable(10);
+
+  select ticker_job_id, maint_job_id, scheduler, tick_period_ms
+    into v_ticker_id, v_maint_id, v_scheduler, v_period_ms
+  from pgque.config;
+
+  assert v_scheduler = 'pg_timetable', 'scheduler should be pg_timetable, got ' || coalesce(v_scheduler, 'NULL');
+  assert v_ticker_id is not null, 'ticker_job_id should be set after start_timetable()';
+  assert v_maint_id is not null, 'maint_job_id should be set after start_timetable()';
+  assert v_period_ms = 100, 'start_timetable(10) should set tick_period_ms=100, got ' || v_period_ms;
+
+  execute $sql$
+    select count(*)
+    from timetable.chain
+    where chain_name in ('pgque_ticker', 'pgque_retry_events', 'pgque_maint', 'pgque_rotate_step2')
+      and live
+  $sql$ into v_job_count;
+  assert v_job_count = 4,
+    'expected 4 live pgque_* timetable jobs, found ' || v_job_count;
+
+  execute $sql$
+    select t.command
+    from timetable.chain c
+    join timetable.task t using (chain_id)
+    where c.chain_name = 'pgque_ticker'
+  $sql$ into v_ticker_command;
+  assert v_ticker_command = 'CALL pgque.ticker_loop()',
+    'pg_timetable pgque_ticker should CALL ticker_loop, got: ' || coalesce(v_ticker_command, 'NULL');
+
+  select status into v_status from pgque.status() where component = 'scheduler';
+  assert v_status = 'pg_timetable', 'status() scheduler row should show pg_timetable, got ' || coalesce(v_status, 'NULL');
+  assert exists (select 1 from pgque.status() where component = 'ticker'),
+    'status() should retain backward-compatible ticker row';
+  assert exists (select 1 from pgque.status() where component = 'maintenance'),
+    'status() should retain backward-compatible maintenance row';
+
+  perform pgque.stop_timetable();
+  raise notice 'PASS: start_timetable(10) schedules four jobs and 10/s ticker loop';
+end $$;
+
+-- Test 3: stop_timetable() removes pgque_* jobs and clears config
+do $$
+declare
+  v_job_count integer;
+begin
+  perform pgque.start_timetable(10);
+  perform pgque.stop_timetable();
+
+  execute $sql$
+    select count(*)
+    from timetable.chain
+    where chain_name in ('pgque_ticker', 'pgque_retry_events', 'pgque_maint', 'pgque_rotate_step2')
+  $sql$ into v_job_count;
+  assert v_job_count = 0,
+    'expected 0 pgque_* timetable jobs after stop_timetable(), found ' || v_job_count;
+
+  assert (select scheduler from pgque.config) is null,
+    'scheduler should be NULL after stop_timetable()';
+  assert (select ticker_job_id from pgque.config) is null,
+    'ticker_job_id should be NULL after stop_timetable()';
+  assert (select maint_job_id from pgque.config) is null,
+    'maint_job_id should be NULL after stop_timetable()';
+
+  raise notice 'PASS: stop_timetable() deletes jobs and clears config';
+end $$;
+
+
+-- Test 4: start_timetable() is idempotent; it replaces old PgQue jobs, not duplicates them.
+do $$
+declare
+  v_job_count integer;
+begin
+  perform pgque.start_timetable(10);
+  perform pgque.start_timetable(10);
+
+  execute $sql$
+    select count(*)
+    from timetable.chain
+    where chain_name in ('pgque_ticker', 'pgque_retry_events', 'pgque_maint', 'pgque_rotate_step2')
+  $sql$ into v_job_count;
+  assert v_job_count = 4,
+    'expected exactly 4 pgque_* timetable jobs after repeated start_timetable(), found ' || v_job_count;
+
+  perform pgque.stop_timetable();
+  raise notice 'PASS: start_timetable() is idempotent';
+end $$;
+
+-- Test 5: generic stop() also stops pg_timetable when it is the active scheduler.
+do $$
+declare
+  v_job_count integer;
+begin
+  perform pgque.start_timetable(10);
+  perform pgque.stop();
+
+  execute $sql$
+    select count(*)
+    from timetable.chain
+    where chain_name in ('pgque_ticker', 'pgque_retry_events', 'pgque_maint', 'pgque_rotate_step2')
+  $sql$ into v_job_count;
+  assert v_job_count = 0,
+    'expected generic stop() to remove pg_timetable jobs, found ' || v_job_count;
+  assert (select scheduler from pgque.config) is null,
+    'scheduler should be NULL after generic stop() of pg_timetable';
+  assert (select ticker_job_id from pgque.config) is null,
+    'ticker_job_id should be NULL after generic stop() of pg_timetable';
+  assert (select maint_job_id from pgque.config) is null,
+    'maint_job_id should be NULL after generic stop() of pg_timetable';
+
+  raise notice 'PASS: stop() delegates to stop_timetable() for pg_timetable';
+end $$;
+
+-- Test 6: switching pg_timetable -> pg_cron cleans timetable jobs before scheduling pg_cron.
+do $$
+declare
+  v_job_count integer;
+  v_cron_count integer;
+begin
+  if not exists (select 1 from pg_extension where extname = 'pg_cron') then
+    raise notice 'SKIP: pg_cron not installed (cannot test pg_timetable -> pg_cron switch)';
+    return;
+  end if;
+
+  perform pgque.start_timetable(10);
+  perform pgque.start();
+
+  assert (select scheduler from pgque.config) = 'pg_cron',
+    'scheduler should be pg_cron after switching from pg_timetable to pg_cron';
+
+  execute $sql$
+    select count(*)
+    from timetable.chain
+    where chain_name in ('pgque_ticker', 'pgque_retry_events', 'pgque_maint', 'pgque_rotate_step2')
+  $sql$ into v_job_count;
+  assert v_job_count = 0,
+    'expected no pg_timetable jobs after switch to pg_cron, found ' || v_job_count;
+
+  execute $sql$
+    select count(*)
+    from cron.job
+    where jobname in ('pgque_ticker', 'pgque_retry_events', 'pgque_maint', 'pgque_rotate_step2')
+  $sql$ into v_cron_count;
+  assert v_cron_count = 4,
+    'expected 4 pg_cron jobs after switch from pg_timetable, found ' || v_cron_count;
+
+  perform pgque.stop();
+  raise notice 'PASS: start() switches pg_timetable to pg_cron cleanly';
+end $$;
+
+-- Cleanup fake schema, if this test created one.
+do $$
+begin
+  if (select fake_installed from _pgque_pgtimetable_harness) then
+    drop schema timetable cascade;
+  end if;
+end $$;
+
+drop table _pgque_pgtimetable_harness;

--- a/tests/test_pgtimetable_real_assert.sql
+++ b/tests/test_pgtimetable_real_assert.sql
@@ -1,0 +1,30 @@
+\set ON_ERROR_STOP on
+
+-- Real pg_timetable integration assertion.
+-- Assumes test_pgtimetable_real_setup.sql already scheduled PgQue jobs and a
+-- real pg_timetable worker is now running.
+
+do $$
+declare
+  v_msg pgque.message;
+  v_count int := 0;
+  i int;
+begin
+  for i in 1..60 loop
+    for v_msg in select * from pgque.receive('real_pgtimetable', 'c1', 10) loop
+      v_count := v_count + 1;
+      assert v_msg.type = 'test.type', 'expected test.type, got ' || coalesce(v_msg.type, 'NULL');
+      assert v_msg.payload = '{"real_pg_timetable":true}',
+        'unexpected payload: ' || coalesce(v_msg.payload, 'NULL');
+      perform pgque.ack(v_msg.batch_id);
+    end loop;
+
+    exit when v_count >= 1;
+    perform pg_sleep(0.2);
+  end loop;
+
+  assert v_count = 1, 'real pg_timetable worker did not deliver event via ticker_loop()';
+  raise notice 'PASS: real pg_timetable worker delivered event via ticker_loop()';
+end $$;
+
+select pgque.stop();

--- a/tests/test_pgtimetable_real_setup.sql
+++ b/tests/test_pgtimetable_real_setup.sql
@@ -1,0 +1,19 @@
+\set ON_ERROR_STOP on
+
+-- Real pg_timetable integration setup.
+-- Assumes the real pg_timetable schema has already been initialized, but the
+-- worker is not running yet. Starting the worker after scheduling makes the
+-- test deterministic because pg_timetable loads interval chains at startup.
+
+select pgque.start_timetable(10);
+
+do $$
+begin
+  perform pgque.create_queue('real_pgtimetable');
+  perform pgque.register_consumer('real_pgtimetable', 'c1');
+end $$;
+
+do $$
+begin
+  perform pgque.insert_event('real_pgtimetable', 'test.type', '{"real_pg_timetable":true}');
+end $$;


### PR DESCRIPTION
## Summary

Adds first-class pg_timetable lifecycle support alongside pg_cron:

- `pgque.start_timetable(ticks_per_second default 10)` schedules PgQue jobs in pg_timetable
- `pgque.stop_timetable()` removes the PgQue pg_timetable jobs
- default ticker cadence remains 10/s via existing `CALL pgque.ticker_loop()`
- stores active scheduler in `pgque.config.scheduler`
- updates README and generated install artifacts

## Testing

- `./build/transform.sh`
- fresh install + `tests/test_pgtimetable_lifecycle.sql`
- fresh install + `tests/test_tick_period.sql`
- full fresh-install SQL regression: `tests/run_all.sql`
- fake pg_timetable schema/API smoke test verifying four scheduled jobs and `CALL pgque.ticker_loop()` command

## Notes

The pg_timetable path uses `@every 1 second` and delegates sub-second cadence to `pgque.ticker_loop()`, preserving the per-tick transaction boundary with `COMMIT` between iterations.
