### PR TITLE
ci: make client release dry-runs approval-free

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -22,10 +22,9 @@ permissions:
   contents: read
 
 jobs:
-  mirror-and-tag:
+  validate:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    environment: go-release
     env:
       VERSION: ${{ inputs.version }}
       MIRROR_REPO: NikolayS/pgque-go
@@ -57,12 +56,10 @@ jobs:
           echo "split_sha=$split_sha" >> "$GITHUB_ENV"
           echo "mirror commit: $split_sha"
 
-      - name: Check mirror tag does not exist
-        env:
-          GH_TOKEN: ${{ secrets.PGQUE_GO_MIRROR_TOKEN }}
+      - name: Check public mirror tag does not exist
         run: |
           set -Eeuo pipefail
-          remote="https://x-access-token:${GH_TOKEN}@github.com/${MIRROR_REPO}.git"
+          remote="https://github.com/${MIRROR_REPO}.git"
           if git ls-remote --exit-code --tags "$remote" "refs/tags/$VERSION" >/dev/null; then
             echo "mirror tag $VERSION already exists"
             exit 1
@@ -91,13 +88,48 @@ jobs:
           set -Eeuo pipefail
           echo "dry run: would push subtree $split_sha to ${MIRROR_REPO}:main and tag $VERSION"
 
+  publish:
+    if: ${{ !inputs.dry_run }}
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: go-release
+    env:
+      VERSION: ${{ inputs.version }}
+      MIRROR_REPO: NikolayS/pgque-go
+      GH_TOKEN: ${{ secrets.PGQUE_GO_MIRROR_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: clients/go/go.mod
+          cache-dependency-path: clients/go/go.sum
+
+      - name: Split clients/go subtree
+        run: |
+          set -Eeuo pipefail
+          split_sha=$(git subtree split --prefix=clients/go HEAD)
+          echo "split_sha=$split_sha" >> "$GITHUB_ENV"
+          echo "mirror commit: $split_sha"
+
       - name: Push mirror main and tag
-        if: ${{ !inputs.dry_run }}
-        env:
-          GH_TOKEN: ${{ secrets.PGQUE_GO_MIRROR_TOKEN }}
         run: |
           set -Eeuo pipefail
           remote="https://x-access-token:${GH_TOKEN}@github.com/${MIRROR_REPO}.git"
+          if git ls-remote --exit-code --tags "$remote" "refs/tags/$VERSION" >/dev/null; then
+            echo "mirror tag $VERSION already exists"
+            exit 1
+          else
+            rc=$?
+            if [ "$rc" -ne 2 ]; then
+              echo "failed to check mirror tag $VERSION"
+              exit "$rc"
+            fi
+          fi
+
           candidate="refs/heads/release-candidate/$VERSION"
           git push "$remote" "$split_sha:$candidate"
 
@@ -112,9 +144,7 @@ jobs:
           git push "$remote" ":$candidate"
 
       - name: Create GitHub Release in mirror
-        if: ${{ !inputs.dry_run && inputs.create_release }}
-        env:
-          GH_TOKEN: ${{ secrets.PGQUE_GO_MIRROR_TOKEN }}
+        if: inputs.create_release
         run: |
           set -Eeuo pipefail
           gh release create "$VERSION" \
@@ -124,7 +154,6 @@ jobs:
             --notes "Go client release for module github.com/NikolayS/pgque-go. Install with: go get github.com/NikolayS/pgque-go@$VERSION"
 
       - name: Warm Go module proxy cache
-        if: ${{ !inputs.dry_run }}
         run: |
           set -Eeuo pipefail
           curl -fsSL "https://proxy.golang.org/github.com/!nikolay!s/pgque-go/@v/$VERSION.info" >/dev/null || true

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -23,13 +23,11 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
-  build-and-publish:
+  build:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    environment: ${{ inputs.repository == 'pypi' && 'pypi' || 'testpypi' }}
     env:
       VERSION: ${{ inputs.version }}
     defaults:
@@ -81,15 +79,49 @@ jobs:
           assert hasattr(pgque, 'PgqueClient')
           PY
 
+      - name: Upload distributions
+        if: ${{ !inputs.dry_run }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-dist
+          path: clients/python/dist/*
+          if-no-files-found: error
+
+  publish-testpypi:
+    if: ${{ !inputs.dry_run && inputs.repository == 'testpypi' }}
+    needs: build
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist
+
       - name: Publish to TestPyPI
-        if: ${{ !inputs.dry_run && inputs.repository == 'testpypi' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: clients/python/dist
+          packages-dir: dist
           repository-url: https://test.pypi.org/legacy/
 
+  publish-pypi:
+    if: ${{ !inputs.dry_run && inputs.repository == 'pypi' }}
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist
+
       - name: Publish to PyPI
-        if: ${{ !inputs.dry_run && inputs.repository == 'pypi' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: clients/python/dist
+          packages-dir: dist

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -8,20 +8,18 @@ on:
         required: true
         type: string
       dry_run:
-        description: "Run npm publish --dry-run instead of publishing"
+        description: "Run validation without publishing"
         required: true
         default: true
         type: boolean
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
-  build-and-publish:
+  validate:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    environment: npm
     env:
       VERSION: ${{ inputs.version }}
     defaults:
@@ -73,6 +71,54 @@ jobs:
         if: inputs.dry_run
         run: npm publish --dry-run --provenance
 
+  publish:
+    if: ${{ !inputs.dry_run }}
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      VERSION: ${{ inputs.version }}
+    defaults:
+      run:
+        working-directory: clients/typescript
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.8
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.14.0"
+          registry-url: https://registry.npmjs.org
+
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@^11.5.1
+
+      - name: Verify version input
+        run: |
+          set -Eeuo pipefail
+          actual=$(node -p "require('./package.json').version")
+          test "$actual" = "$VERSION" || {
+            echo "version input $VERSION != package.json $actual"
+            exit 1
+          }
+
+      - name: Install and build
+        run: |
+          set -Eeuo pipefail
+          bun install --frozen-lockfile
+          bun run check
+          bun run test
+          bun run build
+          npm pack --dry-run
+
       - name: Publish to npm
-        if: ${{ !inputs.dry_run }}
         run: npm publish --provenance

--- a/clients/go/RELEASE.md
+++ b/clients/go/RELEASE.md
@@ -18,6 +18,9 @@ The Go client version is independent from the SQL/server `pgque.version()`.
 Choose the next Go module tag when the Go API, behavior, or packaging changes;
 server-only SQL changes do not require a Go client release.
 
+Use Go module semver tags in the mirror repository: `v0.2.0`, `v0.2.0-rc.1`,
+or `v0.2.0-dev` are valid.
+
 ## Tagging convention
 
 The mirror repository uses normal Go module tags:
@@ -53,6 +56,9 @@ The release workflow is `.github/workflows/release-go.yml`.
 2. Ensure the `go-release` GitHub environment exists and is protected.
 3. Ensure `PGQUE_GO_MIRROR_TOKEN` is configured.
 4. Run **Release Go client** from `main` with `version=vX.Y.Z` and `dry_run=true`.
+   Dry runs validate tests, subtree split, mirror-root module layout, and public
+   tag availability; they do not require the protected `go-release` environment
+   or `PGQUE_GO_MIRROR_TOKEN`.
 5. If the dry run is clean, run it again with `dry_run=false`.
 6. The workflow runs `go test ./...`, splits `clients/go`, pushes the mirror's
    `main`, creates annotated tag `vX.Y.Z` in the mirror, and optionally creates

--- a/clients/python/RELEASE.md
+++ b/clients/python/RELEASE.md
@@ -19,6 +19,10 @@ The Python client version is independent from the SQL/server
 `pgque.version()`. Bump this package when the Python API or packaging changes;
 server-only SQL changes do not require a Python client release.
 
+Use Python/PEP 440 version strings in `pyproject.toml`. For a development or
+pre-release build, use forms like `0.2.0.dev0` or `0.2.0rc1`; do **not** use
+Git-style `0.2.0-dev`, which PyPI rejects.
+
 ## GitHub environment prerequisite
 
 Before the first real publish, create GitHub environments in `NikolayS/pgque`:
@@ -43,7 +47,9 @@ The release workflow is `.github/workflows/release-python.yml`.
    - environment: `pypi`
    - package: `pgque-py`
 5. In TestPyPI, configure the same workflow with environment `testpypi`.
-6. Run **Release Python client** with `dry_run=true` first.
+6. Run **Release Python client** with `dry_run=true` first. Dry runs only build
+   and validate artifacts; they do not require `testpypi` / `pypi` environment
+   approval or OIDC permissions.
 7. Run it with `dry_run=false` and `repository=testpypi`.
 8. Verify the TestPyPI artifact installs in a clean environment, using PyPI
    as the extra index for dependencies:

--- a/clients/typescript/RELEASE.md
+++ b/clients/typescript/RELEASE.md
@@ -16,6 +16,10 @@ The TypeScript client version is independent from the SQL/server
 `pgque.version()`. Bump this package when the TypeScript API, runtime behavior,
 or packaging changes; server-only SQL changes do not require an npm release.
 
+Use npm semver in `package.json`. Pre-release forms like `0.2.0-dev.0`,
+`0.2.0-rc.1`, or `0.2.0-dev` are valid for npm; publish them with an
+appropriate dist-tag if needed.
+
 ## Package shape
 
 - Runtime: Node.js 20+
@@ -48,7 +52,9 @@ The release workflow is `.github/workflows/release-typescript.yml`.
    - repository: `NikolayS/pgque`
    - workflow: `release-typescript.yml`
    - environment: `npm`
-5. Run **Release TypeScript client** with `dry_run=true` first.
+5. Run **Release TypeScript client** with `dry_run=true` first. Dry runs only
+   build, test, and run `npm publish --dry-run`; they do not require the
+   protected `npm` environment or OIDC permissions.
 6. Verify the packed file list and build output.
 7. Run the workflow again with `dry_run=false`.
 


### PR DESCRIPTION
## Summary

Prepare issues #181, #182, and #183 for actual client distribution once 0.2.0 stamping is ready.

Changes:
- split Python release workflow into build + protected publish jobs; dry-run no longer waits on TestPyPI/PyPI environments
- split TypeScript release workflow into validate + protected publish jobs; dry-run no longer waits on npm environment
- split Go release workflow into validate + protected mirror publish jobs; dry-run no longer requires go-release environment or mirror token
- document prerelease version format differences: Python/PEP 440 vs npm semver vs Go module semver

## Validation

- actionlint clean for all three release workflows
- Python: `python -m build` + `twine check dist/*` passed
- TypeScript: `bun run check`, `bun run test`, `bun run build`, `npm pack --dry-run` passed
- Go: `go test ./...` passed in Docker Go 1.23

## Notes

Issue #180 low-effort discoverability step is already done: GitHub topics were added directly to the repo.

Closes none; publish issues stay open until packages are actually published/indexed.
