### PR TITLE
chore: stamp v0.2.0-rc.1

### DIFF
--- a/build/transform.sh
+++ b/build/transform.sh
@@ -646,7 +646,7 @@ apply_idempotency_guards() {
 # Start with header
 cat > "${INSTALL_FILE}" << 'HEADER'
 -- pgque.sql -- PgQ Universal Edition
--- Version: 0.2.0-dev1
+-- Version: 0.2.0-rc.1
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 -- Includes code derived from PgQ (ISC license, Marko Kreen / Skype Technologies OU).
 --

--- a/build/transform.sh
+++ b/build/transform.sh
@@ -646,7 +646,7 @@ apply_idempotency_guards() {
 # Start with header
 cat > "${INSTALL_FILE}" << 'HEADER'
 -- pgque.sql -- PgQ Universal Edition
--- Version: 0.2.0-dev
+-- Version: 0.2.0-dev1
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 -- Includes code derived from PgQ (ISC license, Marko Kreen / Skype Technologies OU).
 --

--- a/clients/python/pgque/__init__.py
+++ b/clients/python/pgque/__init__.py
@@ -27,7 +27,7 @@ from .errors import (
 )
 from .types import Event, Message
 
-__version__ = "0.2.0.dev1"
+__version__ = "0.2.0rc1"
 
 __all__ = [
     "PgqueClient",

--- a/clients/python/pgque/__init__.py
+++ b/clients/python/pgque/__init__.py
@@ -27,7 +27,7 @@ from .errors import (
 )
 from .types import Event, Message
 
-__version__ = "0.2.0"
+__version__ = "0.2.0.dev1"
 
 __all__ = [
     "PgqueClient",

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pgque-py"
-version = "0.2.0.dev1"
+version = "0.2.0rc1"
 description = "Python client for PgQue -- PgQ Universal Edition"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pgque-py"
-version = "0.2.0"
+version = "0.2.0.dev1"
 description = "Python client for PgQue -- PgQ Universal Edition"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pgque",
-  "version": "0.2.0",
+  "version": "0.2.0-dev.1",
   "description": "TypeScript client for PgQue — the PgQ-based universal PostgreSQL queue",
   "license": "Apache-2.0",
   "packageManager": "bun@1.3.8",

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pgque",
-  "version": "0.2.0-dev.1",
+  "version": "0.2.0-rc.1",
   "description": "TypeScript client for PgQue — the PgQ-based universal PostgreSQL queue",
   "license": "Apache-2.0",
   "packageManager": "bun@1.3.8",

--- a/sql/pgque-additions/lifecycle.sql
+++ b/sql/pgque-additions/lifecycle.sql
@@ -438,7 +438,7 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 create or replace function pgque.version()
 returns text as $$
 begin
-    return '0.2.0-dev1';
+    return '0.2.0-rc.1';
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 

--- a/sql/pgque-additions/lifecycle.sql
+++ b/sql/pgque-additions/lifecycle.sql
@@ -438,7 +438,7 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 create or replace function pgque.version()
 returns text as $$
 begin
-    return '0.2.0-dev';
+    return '0.2.0-dev1';
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 

--- a/sql/pgque-tle.sql
+++ b/sql/pgque-tle.sql
@@ -68,8 +68,8 @@ begin
     from pgtle.available_extensions()
     where name = 'pgque';
 
-    if existing_version = '0.2.0-dev1' then
-        raise notice 'pgque 0.2.0-dev1 already registered with pg_tle; skipping install_extension().';
+    if existing_version = '0.2.0-rc.1' then
+        raise notice 'pgque 0.2.0-rc.1 already registered with pg_tle; skipping install_extension().';
         return;
     end if;
 
@@ -78,16 +78,16 @@ begin
             'but this script registers version %. Run '
             'sql/pgque-tle-uninstall.sql first to remove the existing '
             'registration, then re-run this script.',
-            existing_version, '0.2.0-dev1';
+            existing_version, '0.2.0-rc.1';
     end if;
 
     perform pgtle.install_extension(
         'pgque',
-        '0.2.0-dev1',
+        '0.2.0-rc.1',
         'PgQue — PgQ Universal Edition (zero-bloat Postgres queue)',
 $pgque_extension_body$
 -- pgque.sql -- PgQ Universal Edition
--- Version: 0.2.0-dev1
+-- Version: 0.2.0-rc.1
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 -- Includes code derived from PgQ (ISC license, Marko Kreen / Skype Technologies OU).
 --
@@ -4658,7 +4658,7 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 create or replace function pgque.version()
 returns text as $$
 begin
-    return '0.2.0-dev1';
+    return '0.2.0-rc.1';
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
@@ -7025,5 +7025,5 @@ $pgque_extension_body$
 end $wrapper$;
 
 \echo ''
-\echo 'PgQue 0.2.0-dev1 registered with pg_tle.'
+\echo 'PgQue 0.2.0-rc.1 registered with pg_tle.'
 \echo 'Run create extension pgque; to materialise the schema in this database.'

--- a/sql/pgque-tle.sql
+++ b/sql/pgque-tle.sql
@@ -68,8 +68,8 @@ begin
     from pgtle.available_extensions()
     where name = 'pgque';
 
-    if existing_version = '0.2.0-dev' then
-        raise notice 'pgque 0.2.0-dev already registered with pg_tle; skipping install_extension().';
+    if existing_version = '0.2.0-dev1' then
+        raise notice 'pgque 0.2.0-dev1 already registered with pg_tle; skipping install_extension().';
         return;
     end if;
 
@@ -78,16 +78,16 @@ begin
             'but this script registers version %. Run '
             'sql/pgque-tle-uninstall.sql first to remove the existing '
             'registration, then re-run this script.',
-            existing_version, '0.2.0-dev';
+            existing_version, '0.2.0-dev1';
     end if;
 
     perform pgtle.install_extension(
         'pgque',
-        '0.2.0-dev',
+        '0.2.0-dev1',
         'PgQue — PgQ Universal Edition (zero-bloat Postgres queue)',
 $pgque_extension_body$
 -- pgque.sql -- PgQ Universal Edition
--- Version: 0.2.0-dev
+-- Version: 0.2.0-dev1
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 -- Includes code derived from PgQ (ISC license, Marko Kreen / Skype Technologies OU).
 --
@@ -4658,7 +4658,7 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 create or replace function pgque.version()
 returns text as $$
 begin
-    return '0.2.0-dev';
+    return '0.2.0-dev1';
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
@@ -7025,5 +7025,5 @@ $pgque_extension_body$
 end $wrapper$;
 
 \echo ''
-\echo 'PgQue 0.2.0-dev registered with pg_tle.'
+\echo 'PgQue 0.2.0-dev1 registered with pg_tle.'
 \echo 'Run create extension pgque; to materialise the schema in this database.'

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -1,5 +1,5 @@
 -- pgque.sql -- PgQ Universal Edition
--- Version: 0.2.0-dev1
+-- Version: 0.2.0-rc.1
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 -- Includes code derived from PgQ (ISC license, Marko Kreen / Skype Technologies OU).
 --
@@ -4570,7 +4570,7 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 create or replace function pgque.version()
 returns text as $$
 begin
-    return '0.2.0-dev1';
+    return '0.2.0-rc.1';
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -1,5 +1,5 @@
 -- pgque.sql -- PgQ Universal Edition
--- Version: 0.2.0-dev
+-- Version: 0.2.0-dev1
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 -- Includes code derived from PgQ (ISC license, Marko Kreen / Skype Technologies OU).
 --
@@ -4570,7 +4570,7 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 create or replace function pgque.version()
 returns text as $$
 begin
-    return '0.2.0-dev';
+    return '0.2.0-dev1';
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 

--- a/tests/test_pgque_config.sql
+++ b/tests/test_pgque_config.sql
@@ -15,8 +15,8 @@ begin
   end;
 
   -- Version function works
-  assert pgque.version() = '0.2.0-dev1',
-    'version should be 0.2.0-dev1, got ' || pgque.version();
+  assert pgque.version() = '0.2.0-rc.1',
+    'version should be 0.2.0-rc.1, got ' || pgque.version();
 
   raise notice 'PASS: pgque_config';
 end $$;

--- a/tests/test_pgque_config.sql
+++ b/tests/test_pgque_config.sql
@@ -15,8 +15,8 @@ begin
   end;
 
   -- Version function works
-  assert pgque.version() = '0.2.0-dev',
-    'version should be 0.2.0-dev, got ' || pgque.version();
+  assert pgque.version() = '0.2.0-dev1',
+    'version should be 0.2.0-dev1, got ' || pgque.version();
 
   raise notice 'PASS: pgque_config';
 end $$;


### PR DESCRIPTION
## Summary

Pre-release dev drop stamp. Bumps client + SQL versions in lockstep to the first public client RC:

- `pgque-py`: `0.2.0` → `0.2.0rc1` (PEP 440 canonical)
- `pgque` (npm): `0.2.0` → `0.2.0-rc.1` (semver)
- `pgque.version()` SQL + `-- Version:` header + pg_tle wrapper: `0.2.0-dev` → `0.2.0-rc.1`
- Regenerated `sql/pgque.sql` and `sql/pgque-tle.sql` via `bash build/transform.sh`

Closes the audit phase of #211. The original audit targeted `dev1`; we pivoted to `rc1` per advisor feedback (cleaner mapping across Python/npm/Go for first public library distribution; `dev → rc` is a normal progression). The audit findings carry over unchanged — no SQL surface or client API differences between dev1 and rc1.

## Audit evidence (#211)

All four scoped audits ran against isolated PG 18 databases on a prior `main` (b7ede47) and posted evidence comments on #211:

| Scope | Tests | Result |
|---|---|---|
| Python (`pgque-py`) | 67 / 67 | PASS |
| TypeScript (`pgque`) | 69 / 69 | PASS |
| Go (`pgque-go`) | 93 / 93 (1 bench skipped) | PASS |
| Cross-client smoke matrix | 8 / 8 | PASS |

Local re-verification on the rebased branch (origin/main + this PR, includes #219 pg_timetable scheduler + #222 release-workflow split):

- `bash build/transform.sh`: clean assembly, all sanity checks PASS
- `psql -f sql/pgque.sql` on a fresh DB: install OK, `pgque.version()` returns `0.2.0-rc.1`
- `psql -f tests/run_all.sql`: 138 PASS, exit 0, `=== ALL TESTS PASSED ===`

## Test plan

- [ ] CI green on all PG versions (14–18)
- [ ] CI green on Python / TypeScript / Go client suites
- [ ] CI green on pg_cron, pg_tle, pg_timetable install paths
- [ ] Tag `v0.2.0-rc.1` on the squash-merge commit after merge
- [ ] Run release workflow dry-runs (post-tag; depends on follow-up release-workflow-prerelease fix landing first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)