### PR TITLE
ci: harden release workflow validation

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # Pin to the workflow-dispatch SHA validated by this run. Do not
+          # re-read a later main after protected environment approval.
           ref: ${{ github.sha }}
           fetch-depth: 0
 
@@ -100,6 +102,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # Pin to the workflow-dispatch SHA validated by this run. Do not
+          # re-read a later main after protected environment approval.
           ref: ${{ github.sha }}
           fetch-depth: 0
 

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -61,6 +61,7 @@ jobs:
           if str(parsed) != v:
               sys.exit(f'version {v!r} is not in PEP 440 canonical form (would normalise to {str(parsed)!r})')
           "
+
           actual=$(python - <<'PY'
           import tomllib
           print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])


### PR DESCRIPTION
Follow-up to #222.

Fixes two release workflow issues found during REV review:

- Pin Go release workflow checkouts to `github.sha` in both validate and publish jobs, so protected environment approval cannot publish a later, unvalidated `main` revision.
- Make the Python release workflow accept PEP 440 versions such as `0.2.0.dev1` / `0.2.0rc1` and reject Git-style `0.2.0-dev`, matching clients/python/RELEASE.md and PyPI behavior.

Validation run locally:
- parsed edited workflow YAML with Python/PyYAML
- `git diff --check`
