### PR TITLE
fix(ci): pin checkout SHA + PEP 440 versions

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - uses: actions/setup-go@v5
@@ -100,7 +100,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - uses: actions/setup-go@v5

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.sha }}
 
       - uses: actions/setup-python@v5
         with:
@@ -45,10 +45,22 @@ jobs:
       - name: Verify version input
         run: |
           set -Eeuo pipefail
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "version must look like 0.2.0"
-            exit 1
-          fi
+          python -m pip install -U packaging
+          # Validate PEP 440 (accepts 0.2.0, 0.2.0rc1, 0.2.0.dev1, 0.2.0a1, 0.2.0.post1, ...).
+          # Reject hyphenated forms like 0.2.0-dev that PyPI normalises into something
+          # the operator did not type, since "version input == pyproject.toml" then
+          # silently disagrees with what the wheel publishes as.
+          python -c "
+          import os, sys
+          from packaging.version import Version, InvalidVersion
+          v = os.environ['VERSION']
+          try:
+              parsed = Version(v)
+          except InvalidVersion as e:
+              sys.exit(f'invalid PEP 440 version: {v!r} ({e})')
+          if str(parsed) != v:
+              sys.exit(f'version {v!r} is not in PEP 440 canonical form (would normalise to {str(parsed)!r})')
+          "
           actual=$(python - <<'PY'
           import tomllib
           print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.sha }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.sha }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0


### PR DESCRIPTION
## Summary

Two real follow-ups to #222 surfaced by review:

### High — Go publish TOCTOU (and the same class in TS)

`release-go.yml`'s `validate` and `publish` jobs both `actions/checkout@v4` with `ref: main`. Between validate finishing and `publish` running after the `go-release` environment approval, main can advance — and the post-approval publish builds a different SHA than the one validate verified. Same pattern in `release-typescript.yml` (validate + publish, gated by the `npm` environment).

Fix: pin every `actions/checkout@v4` in all three release workflows to `ref: ${{ github.sha }}` so a single workflow_dispatch invocation always operates on one commit. The Python workflow's `build` job is also pinned for consistency, even though `publish-{testpypi,pypi}` download the validated artifact rather than re-checkout.

### Medium — Python regex rejects PEP 440 canonical, accepts PyPI-invalid

`release-python.yml:48` regex `^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?\$` (pre-fix) silently misclassifies versions:

| Input | What it is | Old regex | New validator |
|---|---|---|---|
| `0.2.0rc1` | PEP 440 canonical | reject | accept |
| `0.2.0.dev0` | PEP 440 canonical | reject | accept |
| `0.2.0-rc.1` | semver, not PEP 440 (normalises to `0.2.0rc1`) | accept | reject |
| `0.2.0-dev` | PyPI-invalid (normalises to `0.2.0.dev0`) | accept | reject |

Replaced with `packaging.version.Version(...)` that requires the input to be in PEP 440 canonical form. This forces operators to type exactly the string that ends up in pyproject.toml and on PyPI — no silent normalisation surprise where the dispatch input disagrees with what gets published.

## Validation

- `actionlint` clean on all three workflows.
- Validator behaviour confirmed locally:
  ```
  0.2.0rc1     → OK (canonical)
  0.2.0.dev0   → OK (canonical)
  0.2.0-rc.1   → rejected (not canonical; normalises to 0.2.0rc1)
  0.2.0-dev    → rejected (not canonical; normalises to 0.2.0.dev0)
  ```

## Test plan

- [ ] CI green
- [ ] After merge, dispatch \`Release Python\` with version=\`0.2.0rc1\` and dry_run=true, confirm validator accepts and the artifact builds + uploads
- [ ] After #223 merges and \`v0.2.0-rc.1\` is tagged, dispatch all three release workflows in dry-run mode

## Related

- Follow-up to #222 (release workflow split for approval-free dry-runs).
- Unblocks #223 (\`v0.2.0-rc.1\` stamp): without this fix, \`0.2.0rc1\` would be rejected at the Python verify step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)