### PR TITLE
fix(ci/release-ts): npm publish --tag for prereleases

### DIFF
--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -67,9 +67,26 @@ jobs:
       - name: Pack smoke test
         run: npm pack --dry-run
 
+      - name: Resolve npm dist-tag
+        run: |
+          set -Eeuo pipefail
+          # Prereleases must NOT inherit the default `latest` dist-tag, or `npm install pgque`
+          # would resolve to a prerelease for everyone. Pull the prerelease identifier (rc, dev,
+          # beta, alpha, ...) out of the version and use it as the tag; final releases get `latest`.
+          case "$VERSION" in
+            *-rc*)    NPM_TAG=rc ;;
+            *-dev*)   NPM_TAG=dev ;;
+            *-beta*)  NPM_TAG=beta ;;
+            *-alpha*) NPM_TAG=alpha ;;
+            *-*)      NPM_TAG=next ;;
+            *)        NPM_TAG=latest ;;
+          esac
+          echo "NPM_TAG=$NPM_TAG" >> "$GITHUB_ENV"
+          echo "resolved npm dist-tag: $NPM_TAG (version=$VERSION)"
+
       - name: Publish dry run
         if: inputs.dry_run
-        run: npm publish --dry-run --provenance
+        run: npm publish --dry-run --provenance --tag "$NPM_TAG"
 
   publish:
     if: ${{ !inputs.dry_run }}
@@ -120,5 +137,19 @@ jobs:
           bun run build
           npm pack --dry-run
 
+      - name: Resolve npm dist-tag
+        run: |
+          set -Eeuo pipefail
+          case "$VERSION" in
+            *-rc*)    NPM_TAG=rc ;;
+            *-dev*)   NPM_TAG=dev ;;
+            *-beta*)  NPM_TAG=beta ;;
+            *-alpha*) NPM_TAG=alpha ;;
+            *-*)      NPM_TAG=next ;;
+            *)        NPM_TAG=latest ;;
+          esac
+          echo "NPM_TAG=$NPM_TAG" >> "$GITHUB_ENV"
+          echo "resolved npm dist-tag: $NPM_TAG (version=$VERSION)"
+
       - name: Publish to npm
-        run: npm publish --provenance
+        run: npm publish --provenance --tag "$NPM_TAG"


### PR DESCRIPTION
## Summary

Surfaced by the v0.2.0-rc.1 dry-run, which is the first time the TypeScript release workflow has run end-to-end (it was env-gated until #222). The prerelease publish failed at the dry-run step:

\`\`\`
npm error You must specify a tag using --tag when publishing a prerelease version.
\`\`\`

This is real even outside dry-run: without an explicit \`--tag\`, npm would assign the prerelease the default \`latest\` dist-tag, and \`npm install pgque\` would resolve to a prerelease for every user.

## Fix

Resolve the dist-tag from the version's prerelease identifier in both publish steps (validate-stage \`npm publish --dry-run --provenance\` and gated \`npm publish --provenance\`):

| Version | Resolved \`--tag\` |
|---|---|
| \`0.2.0\` | \`latest\` |
| \`0.2.0-rc.1\` | \`rc\` |
| \`0.2.0-dev.0\` | \`dev\` |
| \`0.2.0-beta.3\` | \`beta\` |
| \`0.2.0-alpha.1\` | \`alpha\` |
| \`0.2.0-<anything-else>\` | \`next\` |

Final releases (no prerelease component) get \`latest\` as before. Prereleases never inherit \`latest\`.

## Validation

- \`actionlint\` clean.
- Tag resolution logic verified locally against all 6 representative inputs above.
- Plan to re-dispatch \`Release TypeScript client\` with version=\`0.2.0-rc.1\` and dry_run=true after merge; expected \`resolved npm dist-tag: rc\` followed by clean \`npm publish --dry-run --tag rc\`.

## Related

- Follow-up to #225 (PEP 440 + checkout SHA pinning); same dry-run that #225 unblocked is what surfaced this.
- Once merged, re-running the v0.2.0-rc.1 dry-run trio should be clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)