### PR TITLE
docs: update install commands; drop skip-locked keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,13 +328,12 @@ Longer walkthrough in the [tutorial](docs/tutorial.md); patterns like fan-out, e
 
 ## Client libraries
 
-PgQue is SQL-first, so any Postgres driver works. First-party client libraries live in this repo for **Python**, **Go**, and **TypeScript**. The install commands below apply after the first client packages are published.
+PgQue is SQL-first, so any Postgres driver works. First-party client libraries live in this repo for **Python**, **Go**, and **TypeScript**, all published at `v0.2.0-rc.1`.
 
 ### Python (`pgque-py`) — psycopg 3
 
 ```bash
-# after the first Python client release
-pip install pgque-py
+pip install --pre pgque-py        # or: pip install "pgque-py==0.2.0rc1"
 ```
 
 ```python
@@ -360,8 +359,7 @@ consumer.start()
 ### Go (`github.com/NikolayS/pgque-go`) — pgx/v5
 
 ```bash
-# after the first Go client release
-go get github.com/NikolayS/pgque-go@latest
+go get github.com/NikolayS/pgque-go@v0.2.0-rc.1
 ```
 
 ```go
@@ -383,8 +381,7 @@ consumer.Start(ctx)
 ### TypeScript (`pgque`) — node-postgres
 
 ```bash
-# after the first TypeScript client release
-npm install pgque
+npm install pgque@rc        # or: bun add pgque@rc
 ```
 
 ```ts

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -7,11 +7,11 @@ universal PostgreSQL queue. A thin, idiomatic wrapper over the
 
 ## Install
 
-After the first Go client release:
-
 ```bash
-go get github.com/NikolayS/pgque-go@latest
+go get github.com/NikolayS/pgque-go@v0.2.0-rc.1
 ```
+
+`@latest` also resolves to the rc since the v0.2.0 line is in release-candidate. The module is mirrored from `clients/go/` of the parent repo to the public [`NikolayS/pgque-go`](https://github.com/NikolayS/pgque-go) module repo.
 
 Requires Go 1.21+ and PostgreSQL 14+ with the PgQue schema installed
 (`\i pgque.sql` — no extension required).

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -7,10 +7,14 @@ universal PostgreSQL queue. Thin wrapper over `pgque-api` SQL functions:
 
 ## Install
 
-After the first Python client release:
+```bash
+pip install --pre pgque-py
+```
+
+`--pre` is required while v0.2.0 is in release-candidate (the latest published version is `0.2.0rc1`); pip skips prereleases by default. Pin the exact version if you prefer:
 
 ```bash
-pip install pgque-py
+pip install "pgque-py==0.2.0rc1"
 ```
 
 Requires Python 3.10+ and PostgreSQL 14+ with the PgQue schema installed

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -7,15 +7,14 @@ PgQ-based universal PostgreSQL queue. Thin, idiomatic wrapper over the
 
 ## Install
 
-After the first TypeScript client release, install the published package with
-any npm-compatible package manager:
-
 ```bash
-npm install pgque
-# or: bun add pgque
-# or: pnpm add pgque
-# or: yarn add pgque
+npm install pgque@rc
+# or: bun add pgque@rc
+# or: pnpm add pgque@rc
+# or: yarn add pgque@rc
 ```
+
+The `@rc` dist-tag points at the latest v0.2.0 release candidate (currently `0.2.0-rc.1`). Drop the tag once v0.2.0 ships.
 
 Runtime requirements: Node.js 20+ and PostgreSQL 14+ with the PgQue schema
 installed (`\i pgque.sql` — no extension required).

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -24,8 +24,8 @@
     "queue",
     "pgq",
     "pgque",
-    "skip-locked",
-    "job-queue"
+    "job-queue",
+    "background-jobs"
   ],
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

The three client libraries (pgque-py, pgque, pgque-go) are now published at v0.2.0-rc.1 to PyPI, npm, and the public Go module mirror. The READMEs still said \"after the first ... release\" — fixed.

## Changes

- **\`README.md\`** (top-level): drop \"after the first ... release\" comments from each install snippet; replace with the actual rc-aware install commands.
- **\`clients/python/README.md\`**: \`pip install --pre pgque-py\` (or pin \`==0.2.0rc1\`). \`--pre\` is needed because pip skips prereleases by default.
- **\`clients/typescript/README.md\`**: \`npm install pgque@rc\`. The \`@rc\` dist-tag will keep working through rc.N drops; users can drop the tag once v0.2.0 ships.
- **\`clients/go/README.md\`**: \`go get github.com/NikolayS/pgque-go@v0.2.0-rc.1\`. \`@latest\` also works while the v0.2.0 line is in rc.
- **\`clients/typescript/package.json\`**: drop \`skip-locked\` from keywords. Misleading — pgque uses PgQ's tick-based snapshot visibility, not FOR UPDATE SKIP LOCKED (that's pgmq's mechanism). Replaced with \`background-jobs\` (already a keyword in pgque-py's metadata for cross-ecosystem consistency).

## Validation

End-to-end smoke tests against published packages all pass:

| Registry | Install command tested | Send/Receive/Ack | Stale ack rowcount |
|---|---|---|---|
| PyPI | \`pip install --pre pgque-py==0.2.0rc1\` | ✅ | ✅ 0 |
| npm | \`npm install pgque@rc\` (then ESM \`import\`) | ✅ | ✅ 0 |
| Go module proxy | \`go get github.com/NikolayS/pgque-go@v0.2.0-rc.1\` | ✅ | ✅ 0 |

The keyword removal only takes effect on the next npm publish (rc.2 / GA); rc.1 retains \`skip-locked\` on its registry page until then.

## Test plan

- [ ] CI green
- [ ] Verify rendered READMEs on the PR's diff view look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)