### PR TITLE
docs: link Pettus pgque overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ Historical context, two decks:
 - [Marko Kreen (Skype), PGCon 2009 — PgQ](https://www.pgcon.org/2009/schedule/attachments/91_pgq.pdf)
 - [Alexander Kukushkin (Microsoft), 2026 — Rediscovering PgQ](https://speakerdeck.com/cyberdemn/rediscovering-pgq)
 
-External coverage: [Christophe Pettus, *pgque: two snapshots and a diff*](https://thebuild.com/blog/2026/05/03/pgque-two-snapshots-and-a-diff/) — walk-through of the snapshot/diff mechanism: how two consecutive tick snapshots determine event visibility and why that avoids row-level locks and dead tuple bloat.
+External coverage:
+
+- [pgque: two snapshots and a diff](https://thebuild.com/blog/2026/05/03/pgque-two-snapshots-and-a-diff/) by Christophe Pettus — walk-through of the snapshot/diff mechanism: how two consecutive tick snapshots determine event visibility and why that avoids row-level locks and dead tuple bloat.
+- [HN discussion](https://news.ycombinator.com/item?id=47817349)
 
 ## Why PgQue
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Historical context, two decks:
 - [Marko Kreen (Skype), PGCon 2009 — PgQ](https://www.pgcon.org/2009/schedule/attachments/91_pgq.pdf)
 - [Alexander Kukushkin (Microsoft), 2026 — Rediscovering PgQ](https://speakerdeck.com/cyberdemn/rediscovering-pgq)
 
+External coverage: [Christophe Pettus, *pgque: two snapshots and a diff*](https://thebuild.com/blog/2026/05/03/pgque-two-snapshots-and-a-diff/) — walk-through of the snapshot/diff mechanism: how two consecutive tick snapshots determine event visibility and why that avoids row-level locks and dead tuple bloat.
+
 ## Why PgQue
 
 Most Postgres queues rely on `SKIP LOCKED` plus `DELETE` and/or `UPDATE`. That holds up in toy examples and then turns into dead tuples, VACUUM pressure, index bloat, and performance drift under sustained load.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Historical context, two decks:
 
 External coverage:
 
-- [pgque: two snapshots and a diff](https://thebuild.com/blog/2026/05/03/pgque-two-snapshots-and-a-diff/) by Christophe Pettus — walk-through of the snapshot/diff mechanism: how two consecutive tick snapshots determine event visibility and why that avoids row-level locks and dead tuple bloat.
+- [PgQue: Two Snapshots and a Diff](https://thebuild.com/blog/2026/05/03/pgque-two-snapshots-and-a-diff/) by Christophe Pettus — walk-through of the snapshot/diff mechanism: how two consecutive tick snapshots determine event visibility and why that avoids row-level locks and dead tuple bloat.
 - [HN discussion](https://news.ycombinator.com/item?id=47817349)
 
 ## Why PgQue


### PR DESCRIPTION
## Summary

- Adds a one-line "External coverage" entry in `README.md`, placed directly after the existing "Historical context, two decks" block.
- Links to Christophe Pettus's post *pgque: two snapshots and a diff* (thebuild.com, 2026-05-03) with a factual description of what it covers.

## Test plan

- [ ] Confirm the link renders correctly, the description matches the post's actual content (snapshot-diff mechanism, event visibility, dead tuple bloat avoidance), and the placement reads naturally in context.