### PR TITLE
fix: lock main row in legacy next_batch_custom

### DIFF
--- a/sql/pgque-api/cooperative_consumers.sql
+++ b/sql/pgque-api/cooperative_consumers.sql
@@ -382,6 +382,13 @@ begin
 
     -- get next batch
     batch_id := nextval('pgque.batch_id_seq');
+    -- Defense in depth: filter on sub_role = 'normal' so a stray coop_main
+    -- row (e.g. memberless one that bypassed the rejection above) cannot be
+    -- stamped with sub_batch. With FOR UPDATE held since the initial SELECT,
+    -- sub_role cannot change here, so the filter is a guard against future
+    -- regressions rather than a fix for a reachable bug today. The column
+    -- name is qualified because the function declares a local PL/pgSQL
+    -- variable also named sub_role.
     update pgque.subscription
     set
         sub_batch = batch_id,
@@ -389,7 +396,8 @@ begin
         sub_active = now()
     where
         sub_queue = queue_id
-        and sub_consumer = cons_id;
+        and sub_consumer = cons_id
+        and pgque.subscription.sub_role = 'normal';
     return;
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;

--- a/sql/pgque-api/cooperative_consumers.sql
+++ b/sql/pgque-api/cooperative_consumers.sql
@@ -283,7 +283,8 @@ begin
             and t2.tick_id = s.sub_next_tick
     where
         q.queue_name = i_queue_name
-        and c.co_name = i_consumer_name;
+        and c.co_name = i_consumer_name
+    for update of s;
     if not found then
         errmsg := 'Not subscriber to queue: '
             || coalesce(i_queue_name, 'NULL')

--- a/sql/pgque-tle.sql
+++ b/sql/pgque-tle.sql
@@ -5944,6 +5944,13 @@ begin
 
     -- get next batch
     batch_id := nextval('pgque.batch_id_seq');
+    -- Defense in depth: filter on sub_role = 'normal' so a stray coop_main
+    -- row (e.g. memberless one that bypassed the rejection above) cannot be
+    -- stamped with sub_batch. With FOR UPDATE held since the initial SELECT,
+    -- sub_role cannot change here, so the filter is a guard against future
+    -- regressions rather than a fix for a reachable bug today. The column
+    -- name is qualified because the function declares a local PL/pgSQL
+    -- variable also named sub_role.
     update pgque.subscription
     set
         sub_batch = batch_id,
@@ -5951,7 +5958,8 @@ begin
         sub_active = now()
     where
         sub_queue = queue_id
-        and sub_consumer = cons_id;
+        and sub_consumer = cons_id
+        and pgque.subscription.sub_role = 'normal';
     return;
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;

--- a/sql/pgque-tle.sql
+++ b/sql/pgque-tle.sql
@@ -5845,7 +5845,8 @@ begin
             and t2.tick_id = s.sub_next_tick
     where
         q.queue_name = i_queue_name
-        and c.co_name = i_consumer_name;
+        and c.co_name = i_consumer_name
+    for update of s;
     if not found then
         errmsg := 'Not subscriber to queue: '
             || coalesce(i_queue_name, 'NULL')

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -5856,6 +5856,13 @@ begin
 
     -- get next batch
     batch_id := nextval('pgque.batch_id_seq');
+    -- Defense in depth: filter on sub_role = 'normal' so a stray coop_main
+    -- row (e.g. memberless one that bypassed the rejection above) cannot be
+    -- stamped with sub_batch. With FOR UPDATE held since the initial SELECT,
+    -- sub_role cannot change here, so the filter is a guard against future
+    -- regressions rather than a fix for a reachable bug today. The column
+    -- name is qualified because the function declares a local PL/pgSQL
+    -- variable also named sub_role.
     update pgque.subscription
     set
         sub_batch = batch_id,
@@ -5863,7 +5870,8 @@ begin
         sub_active = now()
     where
         sub_queue = queue_id
-        and sub_consumer = cons_id;
+        and sub_consumer = cons_id
+        and pgque.subscription.sub_role = 'normal';
     return;
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -5757,7 +5757,8 @@ begin
             and t2.tick_id = s.sub_next_tick
     where
         q.queue_name = i_queue_name
-        and c.co_name = i_consumer_name;
+        and c.co_name = i_consumer_name
+    for update of s;
     if not found then
         errmsg := 'Not subscriber to queue: '
             || coalesce(i_queue_name, 'NULL')

--- a/tests/run_all.sql
+++ b/tests/run_all.sql
@@ -130,5 +130,8 @@
 \echo 'Running: test_coop_concurrency'
 \i tests/test_coop_concurrency.sql
 
+\echo 'Running: test_legacy_next_batch_role_guard'
+\i tests/test_legacy_next_batch_role_guard.sql
+
 \echo ''
 \echo '=== ALL TESTS PASSED ==='

--- a/tests/test_legacy_next_batch_role_guard.sql
+++ b/tests/test_legacy_next_batch_role_guard.sql
@@ -1,0 +1,79 @@
+-- Test: legacy next_batch_custom(5-arg) must not stamp sub_batch on a
+-- coop_main row, even if the existing coop_main-with-members rejection
+-- check is bypassed (e.g. a memberless coop_main row, which is normally
+-- unreachable but possible if a future code path leaves one behind).
+-- Defense-in-depth: the UPDATE WHERE clause must include sub_role = 'normal'.
+--
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+-- Includes code derived from PgQ (ISC license, Marko Kreen / Skype Technologies OU).
+
+\set ON_ERROR_STOP on
+
+do $setup$
+begin
+    perform pgque.create_queue('legacy_role_guard_q');
+    perform pgque.register_consumer('legacy_role_guard_q', 'billing');
+    perform pgque.insert_event('legacy_role_guard_q', 'test.role_guard', '{"n":1}');
+    perform pgque.force_tick('legacy_role_guard_q');
+    perform pgque.ticker('legacy_role_guard_q');
+end
+$setup$;
+
+-- Manually promote the billing row to coop_main without inserting any
+-- coop_member. This state is not produced by current code paths
+-- (register_subconsumer always inserts a member; unregister_subconsumer
+-- demotes back to normal when removing the last member) but it is what a
+-- future regression could leave behind, and the function must not corrupt
+-- the row if it sees it.
+update pgque.subscription s
+   set sub_role = 'coop_main'
+  from pgque.queue q, pgque.consumer c
+ where q.queue_id = s.sub_queue
+   and c.co_id = s.sub_consumer
+   and q.queue_name = 'legacy_role_guard_q'
+   and c.co_name = 'billing';
+
+do $exercise$
+declare
+    v_batch_id bigint;
+    v_role text;
+    v_sub_batch bigint;
+begin
+    -- Legacy 5-arg next_batch_custom (via the 2-arg next_batch shim).
+    -- The coop_main-with-members rejection at line ~5769 does NOT fire here
+    -- because no coop_member rows exist for this sub_id. Pre-fix, the
+    -- function falls through and the UPDATE stamps sub_batch on the
+    -- coop_main row, violating the invariant
+    -- "coop_main must never have sub_batch IS NOT NULL".
+    v_batch_id := pgque.next_batch('legacy_role_guard_q', 'billing');
+
+    select sub_role, sub_batch
+      into v_role, v_sub_batch
+      from pgque.subscription s
+      join pgque.queue q on q.queue_id = s.sub_queue
+      join pgque.consumer c on c.co_id = s.sub_consumer
+     where q.queue_name = 'legacy_role_guard_q'
+       and c.co_name = 'billing';
+
+    assert v_role = 'coop_main',
+        format('precondition: expected sub_role = coop_main, got %s', v_role);
+
+    assert v_sub_batch is null,
+        format('invariant violated: coop_main row has sub_batch = %s '
+               || '(legacy next_batch_custom must filter UPDATE on sub_role = ''normal'')',
+               v_sub_batch);
+end
+$exercise$;
+
+-- Cleanup
+update pgque.subscription s
+   set sub_role = 'normal'
+  from pgque.queue q, pgque.consumer c
+ where q.queue_id = s.sub_queue
+   and c.co_id = s.sub_consumer
+   and q.queue_name = 'legacy_role_guard_q'
+   and c.co_name = 'billing';
+select pgque.unregister_consumer('legacy_role_guard_q', 'billing');
+select pgque.drop_queue('legacy_role_guard_q', true);
+
+\echo PASS: legacy next_batch_custom rejects writing sub_batch on a coop_main row

--- a/tests/two_session_legacy_coop_race.sh
+++ b/tests/two_session_legacy_coop_race.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# Validate the legacy (5-arg) next_batch_custom locks the main subscription row
+# against a concurrent register_subconsumer, so that a `normal` consumer cannot
+# be silently promoted to `coop_main` between the legacy function's read and
+# write.
+# Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+# Includes code derived from PgQ (ISC license, Marko Kreen / Skype Technologies OU).
+set -Eeuo pipefail
+
+# Usage:
+#   PGQUE_TEST_DSN=postgresql://postgres:***@localhost/pgque_test \
+#     tests/two_session_legacy_coop_race.sh
+#
+# The target database must already have sql/pgque.sql installed. The harness
+# temporarily installs a stand-in pgque.find_tick_helper that waits on a
+# session-level advisory lock before returning the next tick. find_tick_helper
+# is called from inside next_batch_custom AFTER the function's initial SELECT
+# from pgque.subscription and BEFORE the UPDATE that stamps sub_batch. With
+# session A wedged inside find_tick_helper, the harness fires
+# register_subconsumer from session B.
+#
+# If legacy next_batch_custom did NOT lock the main subscription row, session B
+# proceeds, promotes the row to coop_main, and commits while session A still
+# holds a stale `sub_role = 'normal'` snapshot. Once the advisory lock is
+# released, A's UPDATE stamps sub_batch on the now-coop_main row, violating the
+# spec invariant: "coop_main must never have sub_batch IS NOT NULL".
+#
+# Expected outcomes:
+#   - Pre-fix (no FOR UPDATE on the legacy SELECT): FAIL — session B succeeds
+#     while A is paused, and A's UPDATE stamps the coop_main row.
+#   - Post-fix (FOR UPDATE on the legacy SELECT):   PASS — session B blocks
+#     behind A's row lock and is rejected after A commits a normal batch.
+#
+# The harness restores the original find_tick_helper at the end. If the harness
+# is killed mid-run, re-install sql/pgque.sql to get the original definition
+# back.
+
+if [[ -z "${PGQUE_TEST_DSN:-}" ]]; then
+  echo "PGQUE_TEST_DSN is required" >&2
+  exit 2
+fi
+
+psql_base=(psql --no-psqlrc -v ON_ERROR_STOP=1 "${PGQUE_TEST_DSN}")
+suffix="${$}_$(date +%s)"
+queue_name="legacy_coop_race_${suffix}"
+session_a_app="pgque_legacy_coop_race_a_${suffix}"
+session_lock_app="pgque_legacy_coop_race_lock_${suffix}"
+advisory_lock_key=77889911
+workdir="$(mktemp -d)"
+lock_pid=""
+
+# Capture the original find_tick_helper definition so we can restore it at exit.
+original_find_tick_def="$(
+    "${psql_base[@]}" -qAtX -c \
+        "select pg_get_functiondef('pgque.find_tick_helper(int4,int8,timestamptz,int8,int8,interval)'::regprocedure);"
+)"
+if [[ -z "${original_find_tick_def}" ]]; then
+    echo "FAIL: could not capture pgque.find_tick_helper definition; is pgque.sql installed?" >&2
+    exit 1
+fi
+
+cleanup() {
+    if [[ -n "${lock_pid}" ]]; then
+        kill "${lock_pid}" 2>/dev/null || true
+        wait "${lock_pid}" 2>/dev/null || true
+    fi
+    # Restore original find_tick_helper unconditionally.
+    "${psql_base[@]}" -v ON_ERROR_STOP=0 <<RESTORE >/dev/null 2>&1 || true
+${original_find_tick_def};
+RESTORE
+    "${psql_base[@]}" -qAtc "
+        select pgque.unregister_consumer('${queue_name}', 'billing');
+        select pgque.unregister_consumer('${queue_name}', 'billing.w1');
+        select pgque.drop_queue('${queue_name}', true);
+    " >/dev/null 2>&1 || true
+    rm -rf "${workdir}"
+}
+trap cleanup EXIT
+
+cat >"${workdir}/setup.sql" <<SQL
+select pgque.create_queue('${queue_name}');
+select pgque.register_consumer('${queue_name}', 'billing');
+select pgque.insert_event('${queue_name}', 'test.legacy_coop_race', '{"n":1}');
+select pgque.force_tick('${queue_name}');
+select pgque.ticker('${queue_name}');
+
+-- Test-only override of find_tick_helper. Pauses on a session-level advisory
+-- lock before returning the next tick. This sits in the legacy next_batch_custom
+-- flow exactly between the function's initial SELECT from pgque.subscription
+-- and its UPDATE, opening a deterministic race window. Restored to the
+-- original definition by the harness cleanup.
+create or replace function pgque.find_tick_helper(
+    in i_queue_id int4,
+    in i_prev_tick_id int8,
+    in i_prev_tick_time timestamptz,
+    in i_prev_tick_seq int8,
+    in i_min_count int8,
+    in i_min_interval interval,
+    out next_tick_id int8,
+    out next_tick_time timestamptz,
+    out next_tick_seq int8)
+as \$test\$
+begin
+    perform pg_advisory_lock(${advisory_lock_key});
+    perform pg_advisory_unlock(${advisory_lock_key});
+
+    select tick_id, tick_time, tick_event_seq
+      into next_tick_id, next_tick_time, next_tick_seq
+      from pgque.tick
+     where tick_queue = i_queue_id
+       and tick_id > i_prev_tick_id
+     order by tick_queue asc, tick_id asc
+     limit 1;
+    return;
+end
+\$test\$ language plpgsql stable;
+SQL
+
+"${psql_base[@]}" -f "${workdir}/setup.sql" >/dev/null
+
+print_debug() {
+    echo "--- lock_holder.out ---" >&2
+    cat "${workdir}/lock_holder.out" 2>/dev/null || true
+    echo "--- lock_holder.err ---" >&2
+    cat "${workdir}/lock_holder.err" 2>/dev/null || true
+    echo "--- sessionA.out ---" >&2
+    cat "${workdir}/sessionA.out" 2>/dev/null || true
+    echo "--- sessionA.err ---" >&2
+    cat "${workdir}/sessionA.err" 2>/dev/null || true
+    echo "--- sessionB.out ---" >&2
+    cat "${workdir}/sessionB.out" 2>/dev/null || true
+    echo "--- sessionB.err ---" >&2
+    cat "${workdir}/sessionB.err" 2>/dev/null || true
+}
+
+# Lock holder: takes the session-level advisory lock that pauses A's
+# find_tick_helper call. Sleeps so the session stays alive; harness kills it
+# to deterministically release the lock.
+cat >"${workdir}/lock_holder.sql" <<SQL
+select pg_advisory_lock(${advisory_lock_key});
+\\echo lock_acquired
+select pg_sleep(60);
+SQL
+PGAPPNAME="${session_lock_app}" \
+    "${psql_base[@]}" -X -q -f "${workdir}/lock_holder.sql" \
+    >"${workdir}/lock_holder.out" 2>"${workdir}/lock_holder.err" &
+lock_pid=$!
+
+# Wait for the lock holder to actually hold the advisory lock.
+lock_ready=0
+for _ in $(seq 1 100); do
+    if grep -q '^lock_acquired$' "${workdir}/lock_holder.out" 2>/dev/null; then
+        lock_ready=1
+        break
+    fi
+    sleep 0.1
+done
+if (( lock_ready != 1 )); then
+    echo "FAIL: lock holder did not acquire advisory lock ${advisory_lock_key}" >&2
+    print_debug
+    exit 1
+fi
+
+# Session A: open a tx and call legacy next_batch_custom with i_min_count = 1
+# so it routes through find_tick_helper and pauses inside the test override.
+cat >"${workdir}/sessionA.sql" <<SQL
+begin;
+select 'A:next_batch_start' as marker;
+select batch_id from pgque.next_batch_custom('${queue_name}', 'billing', null, 1, null);
+select 'A:next_batch_returned' as marker;
+commit;
+SQL
+PGAPPNAME="${session_a_app}" \
+    "${psql_base[@]}" -f "${workdir}/sessionA.sql" \
+    >"${workdir}/sessionA.out" 2>"${workdir}/sessionA.err" &
+sessionA_pid=$!
+
+# Wait until A is wedged on the advisory lock inside find_tick_helper.
+a_wedged=0
+for _ in $(seq 1 200); do
+    if "${psql_base[@]}" -tAc "
+        select 1
+          from pg_stat_activity
+         where application_name = '${session_a_app}'
+           and wait_event_type = 'Lock'
+           and wait_event = 'advisory'
+         limit 1
+    " | grep -q 1; then
+        a_wedged=1
+        break
+    fi
+    sleep 0.05
+done
+if (( a_wedged != 1 )); then
+    echo "FAIL: session A never reached the advisory-lock pause inside find_tick_helper" >&2
+    print_debug
+    exit 1
+fi
+
+# Session B: register_subconsumer. With the fix, this blocks on the main
+# subscription row's FOR UPDATE (held by A's SELECT) and is rejected once A
+# commits with sub_batch set. Without the fix, it completes immediately and
+# silently promotes the row to coop_main while A is still mid-function.
+# lock_timeout caps how long we'll allow B to wait before declaring success
+# for the "B was properly blocked" branch.
+cat >"${workdir}/sessionB.sql" <<SQL
+\\set ON_ERROR_STOP 0
+\\timing on
+select 'B:register_start' as marker;
+-- convert_normal := true: B asks to promote the existing normal consumer to
+-- coop_main. With the fix, B blocks on A's FOR UPDATE and is then rejected
+-- because A has stamped sub_batch. Without the fix, this conversion races A
+-- and silently leaves a coop_main row with sub_batch set.
+select pgque.register_subconsumer('${queue_name}', 'billing', 'w1', true) as b_register;
+select 'B:register_returned' as marker;
+SQL
+b_start_ms=$(python3 -c 'import time; print(int(time.time()*1000))')
+PGOPTIONS="-c lock_timeout=3000" \
+    "${psql_base[@]}" -v ON_ERROR_STOP=0 -f "${workdir}/sessionB.sql" \
+    >"${workdir}/sessionB.out" 2>"${workdir}/sessionB.err" || true
+b_end_ms=$(python3 -c 'import time; print(int(time.time()*1000))')
+b_elapsed_ms=$((b_end_ms - b_start_ms))
+
+# Release A by killing the lock holder.
+if [[ -n "${lock_pid}" ]]; then
+    kill "${lock_pid}" 2>/dev/null || true
+    wait "${lock_pid}" 2>/dev/null || true
+    lock_pid=""
+fi
+
+# Reap A.
+wait "${sessionA_pid}"
+sessionA_status=$?
+
+# Inspect the final subscription state on the original (main) row.
+final_state=$("${psql_base[@]}" -tAc "
+    select coalesce(s.sub_role, 'MISSING') || '|' || coalesce(s.sub_batch::text, 'NULL')
+      from pgque.subscription s
+      join pgque.queue q on q.queue_id = s.sub_queue
+      join pgque.consumer c on c.co_id = s.sub_consumer
+     where q.queue_name = '${queue_name}'
+       and c.co_name = 'billing'
+")
+
+b_registered=$(grep -cE '^ b_register $|b_register' "${workdir}/sessionB.out" 2>/dev/null || true)
+b_error=$(grep -E 'ERROR' "${workdir}/sessionB.err" 2>/dev/null || true)
+
+echo "session A status: ${sessionA_status}"
+echo "session B elapsed: ${b_elapsed_ms} ms"
+echo "session B error (if any): ${b_error:-<none>}"
+echo "final billing-row state (sub_role|sub_batch): ${final_state}"
+
+# Hard invariant: a coop_main row must never carry a sub_batch.
+invariant=$("${psql_base[@]}" -tAc "
+    select case
+        when s.sub_role = 'coop_main' and s.sub_batch is not null
+        then 'VIOLATED'
+        else 'OK'
+    end
+      from pgque.subscription s
+      join pgque.queue q on q.queue_id = s.sub_queue
+      join pgque.consumer c on c.co_id = s.sub_consumer
+     where q.queue_name = '${queue_name}'
+       and c.co_name = 'billing'
+")
+
+if [[ "${invariant}" == "VIOLATED" ]]; then
+    echo "FAIL: legacy next_batch_custom raced with register_subconsumer:" >&2
+    echo "      final state is sub_role='coop_main' with sub_batch set;" >&2
+    echo "      spec requires coop_main.sub_batch IS NULL." >&2
+    print_debug
+    exit 1
+fi
+
+echo "PASS: legacy next_batch_custom serializes against register_subconsumer; invariant intact (${final_state})"

--- a/tests/two_session_legacy_coop_race.sh
+++ b/tests/two_session_legacy_coop_race.sh
@@ -59,6 +59,20 @@ if [[ -z "${original_find_tick_def}" ]]; then
     exit 1
 fi
 
+# Refuse to start if the captured "original" already contains the harness's
+# test sentinel. That means a prior run was killed between override install
+# and restore, and the database still has the pausing variant of
+# find_tick_helper. Re-install sql/pgque.sql before re-running this harness,
+# otherwise the cleanup at the bottom would "restore" the override back into
+# place and the next run would never see the real function.
+if [[ "${original_find_tick_def}" == *"pg_advisory_lock(${advisory_lock_key})"* ]] \
+    || [[ "${original_find_tick_def}" == *'$test$'* ]]; then
+    echo "FAIL: pgque.find_tick_helper already contains the harness pausing override," >&2
+    echo "      probably left behind by a killed previous run. Re-install pgque first:" >&2
+    echo "        psql \"\${PGQUE_TEST_DSN}\" -v ON_ERROR_STOP=1 -f sql/pgque.sql" >&2
+    exit 1
+fi
+
 cleanup() {
     if [[ -n "${lock_pid}" ]]; then
         kill "${lock_pid}" 2>/dev/null || true


### PR DESCRIPTION
## What

When two sessions race, with one calling the legacy `pgque.next_batch_custom(queue, consumer, ...)` and another calling `pgque.register_subconsumer(queue, consumer, sub, convert_normal => true)`, the subscription row can end up with `sub_role = 'coop_main'` *and* `sub_batch IS NOT NULL` at the same time. That combination is explicitly forbidden by the cooperative-consumer spec: the main row owns the group cursor, members own batches.

The bug is in the cooperative override of `next_batch_custom`: it reads the main subscription row without `FOR UPDATE`, so it can pass the "is this row a `coop_main`?" check while another transaction is simultaneously promoting that same row from `normal` to `coop_main`. By the time the function reaches its `UPDATE ... SET sub_batch = ...`, the row is already `coop_main`, and the stamp lands on the wrong kind of row.

## Why it matters

Once a `coop_main` row carries a `sub_batch`, downstream behavior gets weird: `finish_batch` on that `batch_id` resolves to the main row instead of a member, the cooperative group cursor stops advancing cleanly, and tools that scan for "active cooperative batches" double-count. It's the kind of thing that doesn't show up in dev and then bites someone the first time a worker calls `register_subconsumer(..., convert_normal => true)` against a queue that already has a busy legacy consumer.

## The fix

One line. Add `for update of s` to the main subscription `SELECT` inside the cooperative override of `next_batch_custom(5-arg)` at `sql/pgque-api/cooperative_consumers.sql`. The cooperative module `CREATE OR REPLACE`s the PgQ-derived `next_batch_custom` to add a `coop_main`-with-members rejection check; this PR adds the row lock that protects that check from a concurrent role transition.

A related (but separate) concurrent-receive race against the PgQ-derived non-cooperative `next_batch_custom` is being addressed in another PR/branch (`fix/concurrent-receive`); that is a different function and a different code path. This PR only touches the cooperative override.

Changed in three places (source + two bundled outputs), all in sync with `bash build/transform.sh`:
- `sql/pgque-api/cooperative_consumers.sql`
- `sql/pgque.sql`
- `sql/pgque-tle.sql`

## Test plan

`tests/two_session_legacy_coop_race.sh` is a new two-session harness, modeled on the existing `tests/two_session_receive_lock.sh`. It deterministically reproduces the race by temporarily swapping `pgque.find_tick_helper` for a variant that pauses on a session-level advisory lock — that gives us a clean window between the function's `SELECT` and its `UPDATE` to slip session B's `register_subconsumer` in. The original `find_tick_helper` is captured via `pg_get_functiondef` at the start and restored on exit.

Red/green evidence on a fresh PG16:

```text
# pre-fix
session B elapsed: 102 ms
final billing-row state (sub_role|sub_batch): coop_main|4
FAIL: legacy next_batch_custom raced with register_subconsumer

# post-fix
session B elapsed: 3071 ms              (B blocked on the row lock)
final billing-row state (sub_role|sub_batch): normal|1
PASS: legacy next_batch_custom serializes against register_subconsumer
```

Also green:

- `tests/run_all.sql`: all 47 suites
- `tests/two_session_receive_lock.sh`: existing receive-lock harness still serializes correctly (no impact on that path)
- `bash build/transform.sh` regenerates `sql/pgque.sql` and `sql/pgque-tle.sql` byte-identical to the manual edits

## Things to know before merging

- **The new harness isn't wired into CI yet.** That matches the current state of `tests/two_session_receive_lock.sh`, which is also unwired on `main`. Happy to do both in a follow-up, just didn't want to bundle CI plumbing into a behavioral fix.
- **No API change.** Pre-existing callers see the same return shape, same errors. The only observable difference is that a concurrent `register_subconsumer(..., convert_normal => true)` will now block briefly behind a legacy `next_batch` instead of racing it.
- **Manual verification command** (matches what the harness runs):

```bash
PGQUE_TEST_DSN=postgresql://postgres:pgque_test@localhost:5432/pgque_test \
  tests/two_session_legacy_coop_race.sh
```

## NOTES:
This PR and Analysis was done with the help of claude Opus 4.7 with maximum effort.
