### PR TITLE
fix: support v0.1.0 upgrade path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,8 @@ jobs:
             -v ON_ERROR_STOP=1 -f tests/test_security_public_execute.sql
           PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
             -v ON_ERROR_STOP=1 -f tests/test_upgrade_grants.sql
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
+            -v ON_ERROR_STOP=1 -f tests/test_pgque_roles.sql
 
       - name: Verify post-upgrade idempotency
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,82 @@ jobs:
         if: always()
         run: docker rm -f pgque-test
 
+  upgrade-v0-1-to-head:
+    name: upgrade v0.1.0 to HEAD (PG ${{ matrix.pg_version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pg_version: ['18', '14']
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Start PostgreSQL ${{ matrix.pg_version }}
+        run: |
+          docker run -d --name pgque-upgrade-test \
+            -e POSTGRES_PASSWORD=pgque_test \
+            -e POSTGRES_DB=pgque_test \
+            -p 5432:5432 \
+            postgres:${{ matrix.pg_version }}
+
+          ready=0
+          for i in $(seq 1 30); do
+            if PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test -c 'select 1' >/dev/null 2>&1; then
+              ready=1
+              break
+            fi
+            sleep 1
+          done
+          if [ "$ready" != "1" ]; then
+            echo "PG not ready after 30 seconds"
+            docker logs pgque-upgrade-test
+            exit 1
+          fi
+
+      - name: Build HEAD pgque
+        run: bash build/transform.sh
+
+      - name: Install v0.1.0
+        run: |
+          set -Eeuo pipefail
+          git show v0.1.0:sql/pgque.sql > /tmp/pgque-v0.1.0.sql
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
+            -v ON_ERROR_STOP=1 -f /tmp/pgque-v0.1.0.sql
+
+      - name: Prepare v0.1.0 fixture
+        run: |
+          set -Eeuo pipefail
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
+            -v ON_ERROR_STOP=1 -f tests/test_upgrade_v0_1_fixture.sql
+
+      - name: Upgrade to HEAD
+        run: |
+          set -Eeuo pipefail
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
+            -v ON_ERROR_STOP=1 -f sql/pgque.sql
+
+      - name: Verify upgraded state
+        run: |
+          set -Eeuo pipefail
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
+            -v ON_ERROR_STOP=1 -f tests/test_upgrade_v0_1_assertions.sql
+
+      - name: Verify post-upgrade idempotency
+        run: |
+          set -Eeuo pipefail
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
+            -v ON_ERROR_STOP=1 -f sql/pgque.sql
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
+            -v ON_ERROR_STOP=1 -f tests/test_install_idempotency.sql
+
+      - name: Cleanup
+        if: always()
+        run: docker rm -f pgque-upgrade-test
+
   pg_tle-test:
     name: pg_tle install path
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,8 @@ jobs:
 
           ready=0
           for _ in $(seq 1 30); do
-            if docker exec pgque-tle-test pg_isready -U postgres; then
+            if docker exec -e PGPASSWORD=pgque_test pgque-tle-test \
+              psql -U postgres -d pgque_test -c 'select 1' >/dev/null 2>&1; then
               ready=1
               break
             fi
@@ -196,6 +197,7 @@ jobs:
           done
           if [[ "${ready}" -ne 1 ]]; then
             echo "PG not ready after 30 seconds"
+            docker logs pgque-tle-test
             exit 1
           fi
 
@@ -258,7 +260,8 @@ jobs:
 
           ready=0
           for _ in $(seq 1 30); do
-            if docker exec pgque-pgcron-test pg_isready -U postgres; then
+            if docker exec -e PGPASSWORD=pgque_test pgque-pgcron-test \
+              psql -U postgres -d pgque_test -c 'select 1' >/dev/null 2>&1; then
               ready=1
               break
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Upgrade coverage uses oldest/newest supported PG endpoints; the main
+        # regression matrix above covers every supported version (14–18).
         pg_version: ['18', '14']
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
 
       - name: Start PostgreSQL ${{ matrix.pg_version }}
         run: |
+          set -Eeuo pipefail
           docker run -d --name pgque-upgrade-test \
             -e POSTGRES_PASSWORD=pgque_test \
             -e POSTGRES_DB=pgque_test \
@@ -100,14 +101,14 @@ jobs:
             postgres:${{ matrix.pg_version }}
 
           ready=0
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             if PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test -c 'select 1' >/dev/null 2>&1; then
               ready=1
               break
             fi
             sleep 1
           done
-          if [ "$ready" != "1" ]; then
+          if [[ "${ready}" -ne 1 ]]; then
             echo "PG not ready after 30 seconds"
             docker logs pgque-upgrade-test
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,13 +134,17 @@ jobs:
         run: |
           set -Eeuo pipefail
           PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
-            -v ON_ERROR_STOP=1 -f sql/pgque.sql
+            --single-transaction -v ON_ERROR_STOP=1 -f sql/pgque.sql
 
       - name: Verify upgraded state
         run: |
           set -Eeuo pipefail
           PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
             -v ON_ERROR_STOP=1 -f tests/test_upgrade_v0_1_assertions.sql
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
+            -v ON_ERROR_STOP=1 -f tests/test_security_public_execute.sql
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
+            -v ON_ERROR_STOP=1 -f tests/test_upgrade_grants.sql
 
       - name: Verify post-upgrade idempotency
         run: |

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ For sub-second ticking from an external driver, loop `pgque.ticker()` at your ta
 
 **Important:** PgQue does not deliver messages without a working ticker. Enqueueing still works, but consumers will see nothing new because no ticks are created. If you do not use `pg_cron`, run `pgque.ticker()`, `pgque.maint_retry_events()`, and `pgque.maint()` yourself. Skipping `maint_retry_events()` means nack'd events will never be redelivered.
 
-Treat installation as one-way for now — upgrade and reinstall paths are still being tightened. To uninstall: `\i sql/pgque_uninstall.sql`.
+For existing installs, follow the SQL-file upgrade procedure in [docs/upgrading.md](docs/upgrading.md). To uninstall: `\i sql/pgque_uninstall.sql`.
 
 ### Optional: install as a [`pg_tle`](https://github.com/aws/pg_tle) extension
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ The default install stays small; additional APIs live under `sql/experimental/` 
 
 - [Tutorial](docs/tutorial.md) — a hands-on walkthrough. Start here if you are new.
 - [Reference](docs/reference.md) — every shipped function and role.
+- [Upgrading](docs/upgrading.md) — SQL-file upgrade procedure for existing installs.
 - [Examples](docs/examples.md) — patterns: fan-out, exactly-once, batch loading, recurring jobs.
 - [Benchmarks](docs/benchmarks.md) — throughput measurements and methodology.
 - [Tick frequency tuning](docs/tick-frequency.md) — latency/WAL trade-offs, idle tick behavior, and pg_cron logging caveats.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,8 @@ Short docs for users, plus a contributor primer.
   retry, DLQ, observability. Start here if you are new.
 - **[Reference](reference.md)** — every function, return type, and role
   grant in the default install.
+- **[Upgrading](upgrading.md)** — supported SQL-file upgrade procedure,
+  including v0.1.0 → v0.2.0.
 - **[Examples](examples.md)** — short patterns: fan-out, exactly-once,
   batch send, recurring jobs, DLQ inspection.
 - **[Benchmarks](benchmarks.md)** — current throughput numbers and

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2,7 +2,7 @@
 
 Every function shipped in the default install (`\i sql/pgque.sql`). Each entry lists the signature, return type, the role it is granted to, and the source file. A short code example appears where the signature alone leaves the call ambiguous.
 
-If you are new to PgQue, start with [tutorial.md](tutorial.md) — it walks the end-to-end `send` / `receive` / `ack` loop. Use this as the lookup table.
+If you are new to PgQue, start with [tutorial.md](tutorial.md) — it walks the end-to-end `send` / `receive` / `ack` loop. If you are updating an existing install, see [upgrading.md](upgrading.md). Use this as the lookup table.
 
 Each entry takes this form:
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -54,7 +54,7 @@ grant pgque_writer to app_webhook;
 grant pgque_reader to metrics;
 ```
 
-See [reference.md — Roles and grants](reference.md#roles-and-grants) for the full table and rationale.
+See [reference.md — Roles and grants](reference.md#roles-and-grants) for the full table and rationale. If you already have PgQue installed, see [upgrading.md](upgrading.md) before re-running the installer on an existing schema.
 
 ## Step 2: Create the queue and the consumer
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -3,10 +3,10 @@
 PgQue upgrades are SQL-file upgrades. Install the new release over the existing
 schema by re-running `sql/pgque.sql` as the schema owner or a superuser:
 
-```sql
-begin;
-\i sql/pgque.sql
-commit;
+Run from the repository root:
+
+```bash
+psql --single-transaction -v ON_ERROR_STOP=1 -d mydb -f sql/pgque.sql
 ```
 
 The installer is idempotent: it preserves queues, consumers, subscriptions,
@@ -19,11 +19,11 @@ The supported v0.1.0 → v0.2.0 path is the same re-install procedure:
 
 ```bash
 cd /path/to/pgque
-psql -v ON_ERROR_STOP=1 -d mydb -f sql/pgque.sql
+psql --single-transaction -v ON_ERROR_STOP=1 -d mydb -f sql/pgque.sql
 ```
 
-v0.2.0 renames several public publishing argument names to the documented API
-names (`queue_name`, `type_name`, `payload`, `payloads`) so named-argument calls
+v0.2.0 renames several public API argument names to the documented API
+names (`queue_name`, `type_name`, `payload`, `payloads`, `queue`, `consumer`) so named-argument calls
 are stable going forward. PostgreSQL does not allow `CREATE OR REPLACE FUNCTION`
 to rename input arguments in-place, so the installer drops and recreates only
 those wrapper functions before defining the v0.2.0 versions. Data tables and
@@ -43,7 +43,8 @@ psql -v ON_ERROR_STOP=1 -d mydb -f tests/test_install_idempotency.sql
 
 ## CI coverage
 
-The repository CI includes a dedicated `upgrade-v0.1-to-head` job for PostgreSQL
+The repository CI includes a dedicated `upgrade v0.1.0 to HEAD` job for PostgreSQL
 14 and 18. It installs v0.1.0, creates representative queue state, reinstalls
-HEAD's `sql/pgque.sql`, verifies the state survived, and runs the install
-idempotency test after the upgrade.
+HEAD's `sql/pgque.sql` transactionally, verifies the state survived, checks the
+post-upgrade grants/security posture, and runs the install idempotency test after
+the upgrade.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -33,6 +33,7 @@ After upgrading, verify the installed version:
 
 ```sql
 select pgque.version();
+-- 0.2.0-rc.1, or the exact release you installed
 ```
 
 You can also run the idempotency smoke test from the repository:

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,49 @@
+# Upgrading PgQue
+
+PgQue upgrades are SQL-file upgrades. Install the new release over the existing
+schema by re-running `sql/pgque.sql` as the schema owner or a superuser:
+
+```sql
+begin;
+\i sql/pgque.sql
+commit;
+```
+
+The installer is idempotent: it preserves queues, consumers, subscriptions,
+retry rows, DLQ rows, and existing event tables while adding new functions,
+columns, grants, and constraints required by the target release.
+
+## v0.1.0 to v0.2.0
+
+The supported v0.1.0 → v0.2.0 path is the same re-install procedure:
+
+```bash
+cd /path/to/pgque
+psql -v ON_ERROR_STOP=1 -d mydb -f sql/pgque.sql
+```
+
+v0.2.0 renames several public publishing argument names to the documented API
+names (`queue_name`, `type_name`, `payload`, `payloads`) so named-argument calls
+are stable going forward. PostgreSQL does not allow `CREATE OR REPLACE FUNCTION`
+to rename input arguments in-place, so the installer drops and recreates only
+those wrapper functions before defining the v0.2.0 versions. Data tables and
+queue state are not dropped.
+
+After upgrading, verify the installed version:
+
+```sql
+select pgque.version();
+```
+
+You can also run the idempotency smoke test from the repository:
+
+```bash
+psql -v ON_ERROR_STOP=1 -d mydb -f tests/test_install_idempotency.sql
+```
+
+## CI coverage
+
+The repository CI includes a dedicated `upgrade-v0.1-to-head` job for PostgreSQL
+14 and 18. It installs v0.1.0, creates representative queue state, reinstalls
+HEAD's `sql/pgque.sql`, verifies the state survived, and runs the install
+idempotency test after the upgrade.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,9 +1,8 @@
 # Upgrading PgQue
 
 PgQue upgrades are SQL-file upgrades. Install the new release over the existing
-schema by re-running `sql/pgque.sql` as the schema owner or a superuser:
-
-Run from the repository root:
+schema by re-running `sql/pgque.sql` as the schema owner or a superuser, from
+the repository root:
 
 ```bash
 psql --single-transaction -v ON_ERROR_STOP=1 -d mydb -f sql/pgque.sql

--- a/sql/pgque-api/send.sql
+++ b/sql/pgque-api/send.sql
@@ -54,13 +54,23 @@ end $$;
 -- documented "re-run sql/pgque.sql to upgrade" path works from v0.1.0.
 -- Do not unconditionally drop current wrappers: users may have dependent
 -- views/functions, and normal idempotent reinstall must preserve those OIDs.
+-- Also preserve the old function owner when the upgrade is run by a superuser:
+-- dropped SECURITY DEFINER wrappers must not silently become superuser-owned.
+alter default privileges in schema pgque revoke execute on functions from public;
+
+create temporary table if not exists pgque_v01_wrapper_owners (
+    sig text primary key,
+    owner_name name not null
+);
+
 do $$
 declare
-    sig text;
+    v_sig text;
     proc regprocedure;
     args text;
+    v_owner_name name;
 begin
-    foreach sig in array array[
+    foreach v_sig in array array[
         'pgque.send(text,jsonb)',
         'pgque.send(text,text)',
         'pgque.send(text,text,jsonb)',
@@ -70,13 +80,24 @@ begin
         'pgque.subscribe(text,text)',
         'pgque.unsubscribe(text,text)'
     ] loop
-        proc := to_regprocedure(sig);
+        proc := to_regprocedure(v_sig);
         if proc is null then
             continue;
         end if;
 
         args := pg_get_function_arguments(proc);
         if args like 'i\_%' escape '\' then
+            select r.rolname
+            into v_owner_name
+            from pg_proc as p
+            join pg_roles as r on r.oid = p.proowner
+            where p.oid = proc::oid;
+
+            insert into pg_temp.pgque_v01_wrapper_owners (sig, owner_name)
+            values (v_sig, v_owner_name)
+            on conflict (sig) do update
+                set owner_name = excluded.owner_name;
+
             execute format('drop function %s', proc);
         end if;
     end loop;
@@ -259,6 +280,27 @@ begin
     return pgque.unregister_consumer(queue, consumer);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- Restore owners for wrappers that had to be dropped during v0.1.0 upgrade.
+do $$
+declare
+    rec record;
+    proc regprocedure;
+begin
+    if to_regclass('pg_temp.pgque_v01_wrapper_owners') is null then
+        return;
+    end if;
+
+    for rec in select sig, owner_name from pg_temp.pgque_v01_wrapper_owners
+    loop
+        proc := to_regprocedure(rec.sig);
+        if proc is not null then
+            execute format('alter function %s owner to %I', proc, rec.owner_name);
+        end if;
+    end loop;
+end $$;
+
+drop table if exists pg_temp.pgque_v01_wrapper_owners;
 
 -- Grants for the send* + subscribe/unsubscribe family.
 -- send* are producer-side (insert events) -> pgque_writer.

--- a/sql/pgque-api/send.sql
+++ b/sql/pgque-api/send.sql
@@ -308,7 +308,9 @@ begin
             -- Restored v0.1.0 send_batch wrappers are SECURITY DEFINER and
             -- call the new v0.2.0 internal bulk primitive. Preserve runtime
             -- behavior for non-superuser owners by granting just that owner
-            -- execute on the primitive their wrapper now needs.
+            -- execute on the primitive their wrapper now needs. The grant is
+            -- intentionally persistent: the restored wrapper keeps calling
+            -- this locked-down primitive on later idempotent reinstalls.
             if rec.sig in (
                 'pgque.send_batch(text,text,jsonb[])',
                 'pgque.send_batch(text,text,text[])'

--- a/sql/pgque-api/send.sql
+++ b/sql/pgque-api/send.sql
@@ -47,6 +47,41 @@ begin
     end if;
 end $$;
 
+-- v0.1.0 shipped these public wrappers with i_* argument names.
+-- PostgreSQL rejects CREATE OR REPLACE FUNCTION when input argument names
+-- change, even when the signature is otherwise identical. Drop only those
+-- old wrappers before recreating them with the stable v0.2 API names so the
+-- documented "re-run sql/pgque.sql to upgrade" path works from v0.1.0.
+-- Do not unconditionally drop current wrappers: users may have dependent
+-- views/functions, and normal idempotent reinstall must preserve those OIDs.
+do $$
+declare
+    sig text;
+    proc regprocedure;
+    args text;
+begin
+    foreach sig in array array[
+        'pgque.send(text,jsonb)',
+        'pgque.send(text,text)',
+        'pgque.send(text,text,jsonb)',
+        'pgque.send(text,text,text)',
+        'pgque.send_batch(text,text,jsonb[])',
+        'pgque.send_batch(text,text,text[])',
+        'pgque.subscribe(text,text)',
+        'pgque.unsubscribe(text,text)'
+    ] loop
+        proc := to_regprocedure(sig);
+        if proc is null then
+            continue;
+        end if;
+
+        args := pg_get_function_arguments(proc);
+        if args like 'i\_%' escape '\' then
+            execute format('drop function %s', proc);
+        end if;
+    end loop;
+end $$;
+
 -- pgque.send(queue, payload jsonb) -- send with default type, JSON payload
 create or replace function pgque.send(queue_name text, payload jsonb)
 returns bigint as $$

--- a/sql/pgque-api/send.sql
+++ b/sql/pgque-api/send.sql
@@ -304,6 +304,20 @@ begin
         proc := to_regprocedure(rec.sig);
         if proc is not null then
             execute format('alter function %s owner to %I', proc, rec.owner_name);
+
+            -- Restored v0.1.0 send_batch wrappers are SECURITY DEFINER and
+            -- call the new v0.2.0 internal bulk primitive. Preserve runtime
+            -- behavior for non-superuser owners by granting just that owner
+            -- execute on the primitive their wrapper now needs.
+            if rec.sig in (
+                'pgque.send_batch(text,text,jsonb[])',
+                'pgque.send_batch(text,text,text[])'
+            ) then
+                execute format(
+                    'grant execute on function pgque.insert_event_bulk(text, text, text[]) to %I',
+                    rec.owner_name
+                );
+            end if;
         end if;
     end loop;
 end $$;

--- a/sql/pgque-api/send.sql
+++ b/sql/pgque-api/send.sql
@@ -56,8 +56,6 @@ end $$;
 -- views/functions, and normal idempotent reinstall must preserve those OIDs.
 -- Also preserve the old function owner when the upgrade is run by a superuser:
 -- dropped SECURITY DEFINER wrappers must not silently become superuser-owned.
-alter default privileges in schema pgque revoke execute on functions from public;
-
 create temporary table if not exists pgque_v01_wrapper_owners (
     sig text primary key,
     owner_name name not null
@@ -110,6 +108,7 @@ begin
     return pgque.insert_event(queue_name, 'default', payload::text);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send(text, jsonb) from public;
 
 -- pgque.send(queue, payload text) -- fast path, opaque textual payload
 -- Skips the jsonb parse + canonical reserialize round-trip. Use this when
@@ -123,6 +122,7 @@ begin
     return pgque.insert_event(queue_name, 'default', payload);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send(text, text) from public;
 
 -- pgque.send(queue, type, payload jsonb) -- send with explicit type, JSON payload
 create or replace function pgque.send(queue_name text, type_name text, payload jsonb)
@@ -131,6 +131,7 @@ begin
     return pgque.insert_event(queue_name, type_name, payload::text);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send(text, text, jsonb) from public;
 
 -- pgque.send(queue, type, payload text) -- fast path with explicit type
 create or replace function pgque.send(queue_name text, type_name text, payload text)
@@ -139,6 +140,7 @@ begin
     return pgque.insert_event(queue_name, type_name, payload);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send(text, text, text) from public;
 
 -- pgque.insert_event_bulk(queue, type, payloads text[]) -- internal set-based primitive
 -- Deliberately does not call insert_event_raw(): batch send needs one table
@@ -224,6 +226,7 @@ begin
     return pgque.send_batch(queue_name, 'default', payloads);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send_batch(text, jsonb[]) from public;
 
 -- pgque.send_batch(queue, type, payloads jsonb[]) -- set-based batch send
 create or replace function pgque.send_batch(
@@ -240,6 +243,7 @@ begin
     return pgque.insert_event_bulk(queue_name, type_name, payloads::text[]);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send_batch(text, text, jsonb[]) from public;
 
 -- pgque.send_batch(queue, payloads text[]) -- default-type fast-path batch send
 create or replace function pgque.send_batch(queue_name text, payloads text[])
@@ -248,6 +252,7 @@ begin
     return pgque.send_batch(queue_name, 'default', payloads);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send_batch(text, text[]) from public;
 
 -- pgque.send_batch(queue, type, payloads text[]) -- set-based fast-path batch send
 create or replace function pgque.send_batch(
@@ -264,6 +269,7 @@ begin
     return pgque.insert_event_bulk(queue_name, type_name, payloads);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send_batch(text, text, text[]) from public;
 
 -- pgque.subscribe(queue, consumer) -- wrapper for register_consumer
 create or replace function pgque.subscribe(queue text, consumer text)
@@ -272,6 +278,7 @@ begin
     return pgque.register_consumer(queue, consumer);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.subscribe(text, text) from public;
 
 -- pgque.unsubscribe(queue, consumer) -- wrapper for unregister_consumer
 create or replace function pgque.unsubscribe(queue text, consumer text)
@@ -280,6 +287,7 @@ begin
     return pgque.unregister_consumer(queue, consumer);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.unsubscribe(text, text) from public;
 
 -- Restore owners for wrappers that had to be dropped during v0.1.0 upgrade.
 do $$

--- a/sql/pgque-tle.sql
+++ b/sql/pgque-tle.sql
@@ -7072,6 +7072,20 @@ begin
         proc := to_regprocedure(rec.sig);
         if proc is not null then
             execute format('alter function %s owner to %I', proc, rec.owner_name);
+
+            -- Restored v0.1.0 send_batch wrappers are SECURITY DEFINER and
+            -- call the new v0.2.0 internal bulk primitive. Preserve runtime
+            -- behavior for non-superuser owners by granting just that owner
+            -- execute on the primitive their wrapper now needs.
+            if rec.sig in (
+                'pgque.send_batch(text,text,jsonb[])',
+                'pgque.send_batch(text,text,text[])'
+            ) then
+                execute format(
+                    'grant execute on function pgque.insert_event_bulk(text, text, text[]) to %I',
+                    rec.owner_name
+                );
+            end if;
         end if;
     end loop;
 end $$;

--- a/sql/pgque-tle.sql
+++ b/sql/pgque-tle.sql
@@ -6822,13 +6822,23 @@ end $$;
 -- documented "re-run sql/pgque.sql to upgrade" path works from v0.1.0.
 -- Do not unconditionally drop current wrappers: users may have dependent
 -- views/functions, and normal idempotent reinstall must preserve those OIDs.
+-- Also preserve the old function owner when the upgrade is run by a superuser:
+-- dropped SECURITY DEFINER wrappers must not silently become superuser-owned.
+alter default privileges in schema pgque revoke execute on functions from public;
+
+create temporary table if not exists pgque_v01_wrapper_owners (
+    sig text primary key,
+    owner_name name not null
+);
+
 do $$
 declare
-    sig text;
+    v_sig text;
     proc regprocedure;
     args text;
+    v_owner_name name;
 begin
-    foreach sig in array array[
+    foreach v_sig in array array[
         'pgque.send(text,jsonb)',
         'pgque.send(text,text)',
         'pgque.send(text,text,jsonb)',
@@ -6838,13 +6848,24 @@ begin
         'pgque.subscribe(text,text)',
         'pgque.unsubscribe(text,text)'
     ] loop
-        proc := to_regprocedure(sig);
+        proc := to_regprocedure(v_sig);
         if proc is null then
             continue;
         end if;
 
         args := pg_get_function_arguments(proc);
         if args like 'i\_%' escape '\' then
+            select r.rolname
+            into v_owner_name
+            from pg_proc as p
+            join pg_roles as r on r.oid = p.proowner
+            where p.oid = proc::oid;
+
+            insert into pg_temp.pgque_v01_wrapper_owners (sig, owner_name)
+            values (v_sig, v_owner_name)
+            on conflict (sig) do update
+                set owner_name = excluded.owner_name;
+
             execute format('drop function %s', proc);
         end if;
     end loop;
@@ -7027,6 +7048,27 @@ begin
     return pgque.unregister_consumer(queue, consumer);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- Restore owners for wrappers that had to be dropped during v0.1.0 upgrade.
+do $$
+declare
+    rec record;
+    proc regprocedure;
+begin
+    if to_regclass('pg_temp.pgque_v01_wrapper_owners') is null then
+        return;
+    end if;
+
+    for rec in select sig, owner_name from pg_temp.pgque_v01_wrapper_owners
+    loop
+        proc := to_regprocedure(rec.sig);
+        if proc is not null then
+            execute format('alter function %s owner to %I', proc, rec.owner_name);
+        end if;
+    end loop;
+end $$;
+
+drop table if exists pg_temp.pgque_v01_wrapper_owners;
 
 -- Grants for the send* + subscribe/unsubscribe family.
 -- send* are producer-side (insert events) -> pgque_writer.

--- a/sql/pgque-tle.sql
+++ b/sql/pgque-tle.sql
@@ -6815,6 +6815,41 @@ begin
     end if;
 end $$;
 
+-- v0.1.0 shipped these public wrappers with i_* argument names.
+-- PostgreSQL rejects CREATE OR REPLACE FUNCTION when input argument names
+-- change, even when the signature is otherwise identical. Drop only those
+-- old wrappers before recreating them with the stable v0.2 API names so the
+-- documented "re-run sql/pgque.sql to upgrade" path works from v0.1.0.
+-- Do not unconditionally drop current wrappers: users may have dependent
+-- views/functions, and normal idempotent reinstall must preserve those OIDs.
+do $$
+declare
+    sig text;
+    proc regprocedure;
+    args text;
+begin
+    foreach sig in array array[
+        'pgque.send(text,jsonb)',
+        'pgque.send(text,text)',
+        'pgque.send(text,text,jsonb)',
+        'pgque.send(text,text,text)',
+        'pgque.send_batch(text,text,jsonb[])',
+        'pgque.send_batch(text,text,text[])',
+        'pgque.subscribe(text,text)',
+        'pgque.unsubscribe(text,text)'
+    ] loop
+        proc := to_regprocedure(sig);
+        if proc is null then
+            continue;
+        end if;
+
+        args := pg_get_function_arguments(proc);
+        if args like 'i\_%' escape '\' then
+            execute format('drop function %s', proc);
+        end if;
+    end loop;
+end $$;
+
 -- pgque.send(queue, payload jsonb) -- send with default type, JSON payload
 create or replace function pgque.send(queue_name text, payload jsonb)
 returns bigint as $$

--- a/sql/pgque-tle.sql
+++ b/sql/pgque-tle.sql
@@ -7076,7 +7076,9 @@ begin
             -- Restored v0.1.0 send_batch wrappers are SECURITY DEFINER and
             -- call the new v0.2.0 internal bulk primitive. Preserve runtime
             -- behavior for non-superuser owners by granting just that owner
-            -- execute on the primitive their wrapper now needs.
+            -- execute on the primitive their wrapper now needs. The grant is
+            -- intentionally persistent: the restored wrapper keeps calling
+            -- this locked-down primitive on later idempotent reinstalls.
             if rec.sig in (
                 'pgque.send_batch(text,text,jsonb[])',
                 'pgque.send_batch(text,text,text[])'

--- a/sql/pgque-tle.sql
+++ b/sql/pgque-tle.sql
@@ -6824,8 +6824,6 @@ end $$;
 -- views/functions, and normal idempotent reinstall must preserve those OIDs.
 -- Also preserve the old function owner when the upgrade is run by a superuser:
 -- dropped SECURITY DEFINER wrappers must not silently become superuser-owned.
-alter default privileges in schema pgque revoke execute on functions from public;
-
 create temporary table if not exists pgque_v01_wrapper_owners (
     sig text primary key,
     owner_name name not null
@@ -6878,6 +6876,7 @@ begin
     return pgque.insert_event(queue_name, 'default', payload::text);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send(text, jsonb) from public;
 
 -- pgque.send(queue, payload text) -- fast path, opaque textual payload
 -- Skips the jsonb parse + canonical reserialize round-trip. Use this when
@@ -6891,6 +6890,7 @@ begin
     return pgque.insert_event(queue_name, 'default', payload);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send(text, text) from public;
 
 -- pgque.send(queue, type, payload jsonb) -- send with explicit type, JSON payload
 create or replace function pgque.send(queue_name text, type_name text, payload jsonb)
@@ -6899,6 +6899,7 @@ begin
     return pgque.insert_event(queue_name, type_name, payload::text);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send(text, text, jsonb) from public;
 
 -- pgque.send(queue, type, payload text) -- fast path with explicit type
 create or replace function pgque.send(queue_name text, type_name text, payload text)
@@ -6907,6 +6908,7 @@ begin
     return pgque.insert_event(queue_name, type_name, payload);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send(text, text, text) from public;
 
 -- pgque.insert_event_bulk(queue, type, payloads text[]) -- internal set-based primitive
 -- Deliberately does not call insert_event_raw(): batch send needs one table
@@ -6992,6 +6994,7 @@ begin
     return pgque.send_batch(queue_name, 'default', payloads);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send_batch(text, jsonb[]) from public;
 
 -- pgque.send_batch(queue, type, payloads jsonb[]) -- set-based batch send
 create or replace function pgque.send_batch(
@@ -7008,6 +7011,7 @@ begin
     return pgque.insert_event_bulk(queue_name, type_name, payloads::text[]);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send_batch(text, text, jsonb[]) from public;
 
 -- pgque.send_batch(queue, payloads text[]) -- default-type fast-path batch send
 create or replace function pgque.send_batch(queue_name text, payloads text[])
@@ -7016,6 +7020,7 @@ begin
     return pgque.send_batch(queue_name, 'default', payloads);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send_batch(text, text[]) from public;
 
 -- pgque.send_batch(queue, type, payloads text[]) -- set-based fast-path batch send
 create or replace function pgque.send_batch(
@@ -7032,6 +7037,7 @@ begin
     return pgque.insert_event_bulk(queue_name, type_name, payloads);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send_batch(text, text, text[]) from public;
 
 -- pgque.subscribe(queue, consumer) -- wrapper for register_consumer
 create or replace function pgque.subscribe(queue text, consumer text)
@@ -7040,6 +7046,7 @@ begin
     return pgque.register_consumer(queue, consumer);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.subscribe(text, text) from public;
 
 -- pgque.unsubscribe(queue, consumer) -- wrapper for unregister_consumer
 create or replace function pgque.unsubscribe(queue text, consumer text)
@@ -7048,6 +7055,7 @@ begin
     return pgque.unregister_consumer(queue, consumer);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.unsubscribe(text, text) from public;
 
 -- Restore owners for wrappers that had to be dropped during v0.1.0 upgrade.
 do $$

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -6734,13 +6734,23 @@ end $$;
 -- documented "re-run sql/pgque.sql to upgrade" path works from v0.1.0.
 -- Do not unconditionally drop current wrappers: users may have dependent
 -- views/functions, and normal idempotent reinstall must preserve those OIDs.
+-- Also preserve the old function owner when the upgrade is run by a superuser:
+-- dropped SECURITY DEFINER wrappers must not silently become superuser-owned.
+alter default privileges in schema pgque revoke execute on functions from public;
+
+create temporary table if not exists pgque_v01_wrapper_owners (
+    sig text primary key,
+    owner_name name not null
+);
+
 do $$
 declare
-    sig text;
+    v_sig text;
     proc regprocedure;
     args text;
+    v_owner_name name;
 begin
-    foreach sig in array array[
+    foreach v_sig in array array[
         'pgque.send(text,jsonb)',
         'pgque.send(text,text)',
         'pgque.send(text,text,jsonb)',
@@ -6750,13 +6760,24 @@ begin
         'pgque.subscribe(text,text)',
         'pgque.unsubscribe(text,text)'
     ] loop
-        proc := to_regprocedure(sig);
+        proc := to_regprocedure(v_sig);
         if proc is null then
             continue;
         end if;
 
         args := pg_get_function_arguments(proc);
         if args like 'i\_%' escape '\' then
+            select r.rolname
+            into v_owner_name
+            from pg_proc as p
+            join pg_roles as r on r.oid = p.proowner
+            where p.oid = proc::oid;
+
+            insert into pg_temp.pgque_v01_wrapper_owners (sig, owner_name)
+            values (v_sig, v_owner_name)
+            on conflict (sig) do update
+                set owner_name = excluded.owner_name;
+
             execute format('drop function %s', proc);
         end if;
     end loop;
@@ -6939,6 +6960,27 @@ begin
     return pgque.unregister_consumer(queue, consumer);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
+-- Restore owners for wrappers that had to be dropped during v0.1.0 upgrade.
+do $$
+declare
+    rec record;
+    proc regprocedure;
+begin
+    if to_regclass('pg_temp.pgque_v01_wrapper_owners') is null then
+        return;
+    end if;
+
+    for rec in select sig, owner_name from pg_temp.pgque_v01_wrapper_owners
+    loop
+        proc := to_regprocedure(rec.sig);
+        if proc is not null then
+            execute format('alter function %s owner to %I', proc, rec.owner_name);
+        end if;
+    end loop;
+end $$;
+
+drop table if exists pg_temp.pgque_v01_wrapper_owners;
 
 -- Grants for the send* + subscribe/unsubscribe family.
 -- send* are producer-side (insert events) -> pgque_writer.

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -6984,6 +6984,20 @@ begin
         proc := to_regprocedure(rec.sig);
         if proc is not null then
             execute format('alter function %s owner to %I', proc, rec.owner_name);
+
+            -- Restored v0.1.0 send_batch wrappers are SECURITY DEFINER and
+            -- call the new v0.2.0 internal bulk primitive. Preserve runtime
+            -- behavior for non-superuser owners by granting just that owner
+            -- execute on the primitive their wrapper now needs.
+            if rec.sig in (
+                'pgque.send_batch(text,text,jsonb[])',
+                'pgque.send_batch(text,text,text[])'
+            ) then
+                execute format(
+                    'grant execute on function pgque.insert_event_bulk(text, text, text[]) to %I',
+                    rec.owner_name
+                );
+            end if;
         end if;
     end loop;
 end $$;

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -6988,7 +6988,9 @@ begin
             -- Restored v0.1.0 send_batch wrappers are SECURITY DEFINER and
             -- call the new v0.2.0 internal bulk primitive. Preserve runtime
             -- behavior for non-superuser owners by granting just that owner
-            -- execute on the primitive their wrapper now needs.
+            -- execute on the primitive their wrapper now needs. The grant is
+            -- intentionally persistent: the restored wrapper keeps calling
+            -- this locked-down primitive on later idempotent reinstalls.
             if rec.sig in (
                 'pgque.send_batch(text,text,jsonb[])',
                 'pgque.send_batch(text,text,text[])'

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -6736,8 +6736,6 @@ end $$;
 -- views/functions, and normal idempotent reinstall must preserve those OIDs.
 -- Also preserve the old function owner when the upgrade is run by a superuser:
 -- dropped SECURITY DEFINER wrappers must not silently become superuser-owned.
-alter default privileges in schema pgque revoke execute on functions from public;
-
 create temporary table if not exists pgque_v01_wrapper_owners (
     sig text primary key,
     owner_name name not null
@@ -6790,6 +6788,7 @@ begin
     return pgque.insert_event(queue_name, 'default', payload::text);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send(text, jsonb) from public;
 
 -- pgque.send(queue, payload text) -- fast path, opaque textual payload
 -- Skips the jsonb parse + canonical reserialize round-trip. Use this when
@@ -6803,6 +6802,7 @@ begin
     return pgque.insert_event(queue_name, 'default', payload);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send(text, text) from public;
 
 -- pgque.send(queue, type, payload jsonb) -- send with explicit type, JSON payload
 create or replace function pgque.send(queue_name text, type_name text, payload jsonb)
@@ -6811,6 +6811,7 @@ begin
     return pgque.insert_event(queue_name, type_name, payload::text);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send(text, text, jsonb) from public;
 
 -- pgque.send(queue, type, payload text) -- fast path with explicit type
 create or replace function pgque.send(queue_name text, type_name text, payload text)
@@ -6819,6 +6820,7 @@ begin
     return pgque.insert_event(queue_name, type_name, payload);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send(text, text, text) from public;
 
 -- pgque.insert_event_bulk(queue, type, payloads text[]) -- internal set-based primitive
 -- Deliberately does not call insert_event_raw(): batch send needs one table
@@ -6904,6 +6906,7 @@ begin
     return pgque.send_batch(queue_name, 'default', payloads);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send_batch(text, jsonb[]) from public;
 
 -- pgque.send_batch(queue, type, payloads jsonb[]) -- set-based batch send
 create or replace function pgque.send_batch(
@@ -6920,6 +6923,7 @@ begin
     return pgque.insert_event_bulk(queue_name, type_name, payloads::text[]);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send_batch(text, text, jsonb[]) from public;
 
 -- pgque.send_batch(queue, payloads text[]) -- default-type fast-path batch send
 create or replace function pgque.send_batch(queue_name text, payloads text[])
@@ -6928,6 +6932,7 @@ begin
     return pgque.send_batch(queue_name, 'default', payloads);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send_batch(text, text[]) from public;
 
 -- pgque.send_batch(queue, type, payloads text[]) -- set-based fast-path batch send
 create or replace function pgque.send_batch(
@@ -6944,6 +6949,7 @@ begin
     return pgque.insert_event_bulk(queue_name, type_name, payloads);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.send_batch(text, text, text[]) from public;
 
 -- pgque.subscribe(queue, consumer) -- wrapper for register_consumer
 create or replace function pgque.subscribe(queue text, consumer text)
@@ -6952,6 +6958,7 @@ begin
     return pgque.register_consumer(queue, consumer);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.subscribe(text, text) from public;
 
 -- pgque.unsubscribe(queue, consumer) -- wrapper for unregister_consumer
 create or replace function pgque.unsubscribe(queue text, consumer text)
@@ -6960,6 +6967,7 @@ begin
     return pgque.unregister_consumer(queue, consumer);
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.unsubscribe(text, text) from public;
 
 -- Restore owners for wrappers that had to be dropped during v0.1.0 upgrade.
 do $$

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -6727,6 +6727,41 @@ begin
     end if;
 end $$;
 
+-- v0.1.0 shipped these public wrappers with i_* argument names.
+-- PostgreSQL rejects CREATE OR REPLACE FUNCTION when input argument names
+-- change, even when the signature is otherwise identical. Drop only those
+-- old wrappers before recreating them with the stable v0.2 API names so the
+-- documented "re-run sql/pgque.sql to upgrade" path works from v0.1.0.
+-- Do not unconditionally drop current wrappers: users may have dependent
+-- views/functions, and normal idempotent reinstall must preserve those OIDs.
+do $$
+declare
+    sig text;
+    proc regprocedure;
+    args text;
+begin
+    foreach sig in array array[
+        'pgque.send(text,jsonb)',
+        'pgque.send(text,text)',
+        'pgque.send(text,text,jsonb)',
+        'pgque.send(text,text,text)',
+        'pgque.send_batch(text,text,jsonb[])',
+        'pgque.send_batch(text,text,text[])',
+        'pgque.subscribe(text,text)',
+        'pgque.unsubscribe(text,text)'
+    ] loop
+        proc := to_regprocedure(sig);
+        if proc is null then
+            continue;
+        end if;
+
+        args := pg_get_function_arguments(proc);
+        if args like 'i\_%' escape '\' then
+            execute format('drop function %s', proc);
+        end if;
+    end loop;
+end $$;
+
 -- pgque.send(queue, payload jsonb) -- send with default type, JSON payload
 create or replace function pgque.send(queue_name text, payload jsonb)
 returns bigint as $$

--- a/tests/test_upgrade_v0_1_assertions.sql
+++ b/tests/test_upgrade_v0_1_assertions.sql
@@ -1,0 +1,90 @@
+\set ON_ERROR_STOP on
+
+-- test_upgrade_v0_1_assertions.sql -- Verify v0.1.0 state after HEAD reinstall
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- Run after tests/test_upgrade_v0_1_fixture.sql and a HEAD sql/pgque.sql reinstall.
+
+do $$
+declare
+  v_version text;
+  v_scheduler text;
+  v_tick_period_ms int;
+begin
+  v_version := pgque.version();
+  assert v_version = '0.2.0-rc.1',
+    'pgque.version() should report HEAD version, got ' || v_version;
+
+  assert exists (select 1 from pgque.queue where queue_name = 'upgrade_v01_q'),
+    'pre-upgrade queue should survive';
+  assert exists (select 1 from pgque.consumer where co_name = 'upgrade_v01_c'),
+    'pre-upgrade consumer should survive';
+  assert exists (
+    select 1
+    from pgque.subscription s
+    join pgque.queue q on q.queue_id = s.sub_queue
+    join pgque.consumer c on c.co_id = s.sub_consumer
+    where q.queue_name = 'upgrade_v01_q'
+      and c.co_name = 'upgrade_v01_c'
+  ), 'pre-upgrade subscription should survive';
+  assert exists (select 1 from pgque.retry_queue),
+    'pre-upgrade retry row should survive';
+  assert exists (select 1 from pgque.dead_letter),
+    'pre-upgrade DLQ row should survive';
+
+  select scheduler, tick_period_ms
+  into v_scheduler, v_tick_period_ms
+  from pgque.config
+  where singleton;
+
+  assert v_tick_period_ms = 100,
+    'pgque.config.tick_period_ms should default to 100, got ' || coalesce(v_tick_period_ms::text, 'NULL');
+  assert v_scheduler is null or v_scheduler in ('pg_cron', 'pg_timetable'),
+    'pgque.config.scheduler should be null or known scheduler, got ' || coalesce(v_scheduler, 'NULL');
+
+  assert to_regprocedure('pgque.receive_coop(text,text,text,integer,interval)') is not null,
+    'pgque.receive_coop(text,text,text,integer,interval) should exist after upgrade';
+  assert to_regprocedure('pgque.force_next_tick(text)') is not null,
+    'pgque.force_next_tick(text) should exist after upgrade';
+  assert to_regprocedure('pgque.send_batch(text,jsonb[])') is not null,
+    'pgque.send_batch(text,jsonb[]) should exist after upgrade';
+
+  raise notice 'PASS: upgraded schema and pre-existing state verified';
+end $$;
+
+-- New publishing/consuming still works on the upgraded queue.
+do $$
+begin
+  perform pgque.send('upgrade_v01_q', 'post.upgrade', '{"ok":true}'::jsonb);
+end $$;
+
+do $$
+begin
+  perform pgque.force_next_tick('upgrade_v01_q');
+  perform pgque.ticker();
+end $$;
+
+do $$
+declare
+  v_msg pgque.message;
+  v_batch_id bigint;
+  v_count int := 0;
+begin
+  for v_msg in select * from pgque.receive('upgrade_v01_q', 'upgrade_v01_c', 100)
+  loop
+    if v_msg.type = 'post.upgrade' then
+      v_count := v_count + 1;
+      v_batch_id := v_msg.batch_id;
+      assert v_msg.payload::jsonb = '{"ok": true}'::jsonb,
+        'post-upgrade payload should round-trip';
+    end if;
+  end loop;
+
+  assert v_count = 1,
+    'post-upgrade receive should return exactly one new message, got ' || v_count;
+  assert v_batch_id is not null,
+    'post-upgrade receive should expose a batch id';
+
+  perform pgque.ack(v_batch_id);
+  raise notice 'PASS: upgraded queue can send, receive, and ack new messages';
+end $$;

--- a/tests/test_upgrade_v0_1_assertions.sql
+++ b/tests/test_upgrade_v0_1_assertions.sql
@@ -50,13 +50,45 @@ begin
     'pgque.send_batch(text,jsonb[]) should exist after upgrade';
 
   perform pgque.send(queue_name := 'upgrade_v01_q', payload := '{"named":"jsonb-default"}'::jsonb);
+  perform pgque.send(queue_name := 'upgrade_v01_q', payload := 'named-text-default');
   perform pgque.send(queue_name := 'upgrade_v01_q', type_name := 'named.jsonb', payload := '{"named":"jsonb-explicit"}'::jsonb);
+  perform pgque.send(queue_name := 'upgrade_v01_q', type_name := 'named.text', payload := 'named-text-explicit');
   perform pgque.send_batch(queue_name := 'upgrade_v01_q', payloads := array['{"named":"batch-jsonb-default"}'::jsonb]);
+  perform pgque.send_batch(queue_name := 'upgrade_v01_q', type_name := 'named.jsonb.batch', payloads := array['{"named":"batch-jsonb-explicit"}'::jsonb]);
   perform pgque.send_batch(queue_name := 'upgrade_v01_q', type_name := 'named.text.batch', payloads := array['named-batch-text']);
   perform pgque.subscribe(queue := 'upgrade_v01_q', consumer := 'upgrade_v01_named_c');
   perform pgque.unsubscribe(queue := 'upgrade_v01_q', consumer := 'upgrade_v01_named_c');
 
   raise notice 'PASS: upgraded schema, pre-existing state, and named-argument wrappers verified';
+end $$;
+
+-- Recreated v0.1.0 wrappers must preserve their pre-upgrade owner.
+do $$
+declare
+  f text;
+  v_owner name;
+begin
+  foreach f in array array[
+    'pgque.send(text,jsonb)',
+    'pgque.send(text,text)',
+    'pgque.send(text,text,jsonb)',
+    'pgque.send(text,text,text)',
+    'pgque.send_batch(text,text,jsonb[])',
+    'pgque.send_batch(text,text,text[])',
+    'pgque.subscribe(text,text)',
+    'pgque.unsubscribe(text,text)'
+  ] loop
+    select r.rolname
+    into v_owner
+    from pg_proc as p
+    join pg_roles as r on r.oid = p.proowner
+    where p.oid = f::regprocedure::oid;
+
+    assert v_owner = 'pgque_v01_wrapper_owner',
+      format('wrapper %s should preserve owner pgque_v01_wrapper_owner, got %s', f, coalesce(v_owner, 'NULL'));
+  end loop;
+
+  raise notice 'PASS: recreated v0.1.0 wrapper owners preserved';
 end $$;
 
 -- New publishing/consuming still works on the upgraded queue.

--- a/tests/test_upgrade_v0_1_assertions.sql
+++ b/tests/test_upgrade_v0_1_assertions.sql
@@ -12,8 +12,8 @@ declare
   v_tick_period_ms int;
 begin
   v_version := pgque.version();
-  assert v_version = '0.2.0-rc.1',
-    'pgque.version() should report HEAD version, got ' || v_version;
+  assert v_version is not null and v_version <> '0.1.0',
+    'pgque.version() should report upgraded HEAD version, got ' || coalesce(v_version, 'NULL');
 
   assert exists (select 1 from pgque.queue where queue_name = 'upgrade_v01_q'),
     'pre-upgrade queue should survive';

--- a/tests/test_upgrade_v0_1_assertions.sql
+++ b/tests/test_upgrade_v0_1_assertions.sql
@@ -88,7 +88,14 @@ begin
       format('wrapper %s should preserve owner pgque_v01_wrapper_owner, got %s', f, coalesce(v_owner, 'NULL'));
   end loop;
 
-  raise notice 'PASS: recreated v0.1.0 wrapper owners preserved';
+  assert has_function_privilege(
+      'pgque_v01_wrapper_owner',
+      'pgque.insert_event_bulk(text, text, text[])',
+      'EXECUTE'
+    ),
+    'pgque_v01_wrapper_owner should have execute on insert_event_bulk for restored send_batch wrappers';
+
+  raise notice 'PASS: recreated v0.1.0 wrapper owners and required send_batch primitive grant preserved';
 end $$;
 
 -- New publishing/consuming still works on the upgraded queue.

--- a/tests/test_upgrade_v0_1_assertions.sql
+++ b/tests/test_upgrade_v0_1_assertions.sql
@@ -21,9 +21,9 @@ begin
     'pre-upgrade consumer should survive';
   assert exists (
     select 1
-    from pgque.subscription s
-    join pgque.queue q on q.queue_id = s.sub_queue
-    join pgque.consumer c on c.co_id = s.sub_consumer
+    from pgque.subscription as s
+    join pgque.queue as q on q.queue_id = s.sub_queue
+    join pgque.consumer as c on c.co_id = s.sub_consumer
     where q.queue_name = 'upgrade_v01_q'
       and c.co_name = 'upgrade_v01_c'
   ), 'pre-upgrade subscription should survive';
@@ -49,13 +49,20 @@ begin
   assert to_regprocedure('pgque.send_batch(text,jsonb[])') is not null,
     'pgque.send_batch(text,jsonb[]) should exist after upgrade';
 
-  raise notice 'PASS: upgraded schema and pre-existing state verified';
+  perform pgque.send(queue_name := 'upgrade_v01_q', payload := '{"named":"jsonb-default"}'::jsonb);
+  perform pgque.send(queue_name := 'upgrade_v01_q', type_name := 'named.jsonb', payload := '{"named":"jsonb-explicit"}'::jsonb);
+  perform pgque.send_batch(queue_name := 'upgrade_v01_q', payloads := array['{"named":"batch-jsonb-default"}'::jsonb]);
+  perform pgque.send_batch(queue_name := 'upgrade_v01_q', type_name := 'named.text.batch', payloads := array['named-batch-text']);
+  perform pgque.subscribe(queue := 'upgrade_v01_q', consumer := 'upgrade_v01_named_c');
+  perform pgque.unsubscribe(queue := 'upgrade_v01_q', consumer := 'upgrade_v01_named_c');
+
+  raise notice 'PASS: upgraded schema, pre-existing state, and named-argument wrappers verified';
 end $$;
 
 -- New publishing/consuming still works on the upgraded queue.
 do $$
 begin
-  perform pgque.send('upgrade_v01_q', 'post.upgrade', '{"ok":true}'::jsonb);
+  perform pgque.send(queue_name := 'upgrade_v01_q', type_name := 'post.upgrade', payload := '{"ok":true}'::jsonb);
 end $$;
 
 do $$

--- a/tests/test_upgrade_v0_1_fixture.sql
+++ b/tests/test_upgrade_v0_1_fixture.sql
@@ -99,16 +99,19 @@ begin
 end $$;
 
 -- Owner preservation fixture: v0.1.0 wrappers must keep their old owner when a
--- superuser performs the upgrade. Use a dedicated superuser role so recreated
--- SECURITY DEFINER wrappers can still call internal PgQue primitives during the
--- post-upgrade assertions.
+-- superuser performs the upgrade. Use a dedicated non-superuser owner with the
+-- PgQue runtime roles it needs: the recreated SECURITY DEFINER wrappers execute
+-- as this owner during the post-upgrade assertions.
 do $$
 declare
   f text;
 begin
   if not exists (select 1 from pg_roles where rolname = 'pgque_v01_wrapper_owner') then
-    create role pgque_v01_wrapper_owner superuser;
+    create role pgque_v01_wrapper_owner;
   end if;
+
+  grant pgque_reader to pgque_v01_wrapper_owner;
+  grant pgque_writer to pgque_v01_wrapper_owner;
 
   foreach f in array array[
     'pgque.send(text,jsonb)',

--- a/tests/test_upgrade_v0_1_fixture.sql
+++ b/tests/test_upgrade_v0_1_fixture.sql
@@ -97,3 +97,31 @@ begin
 
   raise notice 'PASS: v0.1.0 upgrade fixture prepared';
 end $$;
+
+-- Owner preservation fixture: v0.1.0 wrappers must keep their old owner when a
+-- superuser performs the upgrade. Use a dedicated superuser role so recreated
+-- SECURITY DEFINER wrappers can still call internal PgQue primitives during the
+-- post-upgrade assertions.
+do $$
+declare
+  f text;
+begin
+  if not exists (select 1 from pg_roles where rolname = 'pgque_v01_wrapper_owner') then
+    create role pgque_v01_wrapper_owner superuser;
+  end if;
+
+  foreach f in array array[
+    'pgque.send(text,jsonb)',
+    'pgque.send(text,text)',
+    'pgque.send(text,text,jsonb)',
+    'pgque.send(text,text,text)',
+    'pgque.send_batch(text,text,jsonb[])',
+    'pgque.send_batch(text,text,text[])',
+    'pgque.subscribe(text,text)',
+    'pgque.unsubscribe(text,text)'
+  ] loop
+    execute format('alter function %s owner to pgque_v01_wrapper_owner', f::regprocedure);
+  end loop;
+
+  raise notice 'PASS: v0.1.0 wrapper owners prepared';
+end $$;

--- a/tests/test_upgrade_v0_1_fixture.sql
+++ b/tests/test_upgrade_v0_1_fixture.sql
@@ -1,0 +1,99 @@
+\set ON_ERROR_STOP on
+
+-- test_upgrade_v0_1_fixture.sql -- Build representative v0.1.0 state before upgrade
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- Run after installing v0.1.0 and before reinstalling HEAD's sql/pgque.sql.
+-- The fixture is idempotent for local reruns in the same database.
+
+do $$
+begin
+  if to_regnamespace('pgque') is null then
+    raise exception 'pgque schema is not installed';
+  end if;
+
+  if exists (select 1 from pgque.queue where queue_name = 'upgrade_v01_q') then
+    perform pgque.drop_queue('upgrade_v01_q', true);
+  end if;
+end $$;
+
+-- Queue + consumer survive the upgrade.
+do $$
+begin
+  perform pgque.create_queue('upgrade_v01_q');
+  perform pgque.subscribe('upgrade_v01_q', 'upgrade_v01_c');
+end $$;
+
+-- Mixed publish styles survive through existing queue tables.
+do $$
+begin
+  perform pgque.send('upgrade_v01_q', '{"kind":"jsonb-default","n":1}'::jsonb);
+  perform pgque.send('upgrade_v01_q', 'text.explicit', 'opaque-text-payload');
+  perform pgque.send_batch(
+    'upgrade_v01_q',
+    'batch.mixed',
+    array['{"batch":1}'::jsonb, '{"batch":2}'::jsonb]
+  );
+end $$;
+
+-- Create one retry row and one DLQ row using the v0.1.0 public API.
+do $$
+begin
+  perform pgque.force_tick('upgrade_v01_q');
+  perform pgque.ticker();
+end $$;
+
+do $$
+declare
+  v_msg pgque.message;
+  v_retry_msg pgque.message;
+  v_dlq_msg pgque.message;
+  v_seen int := 0;
+begin
+  for v_msg in select * from pgque.receive('upgrade_v01_q', 'upgrade_v01_c', 10)
+  loop
+    v_seen := v_seen + 1;
+    if v_retry_msg is null then
+      v_retry_msg := v_msg;
+    elsif v_dlq_msg is null then
+      v_dlq_msg := v_msg;
+    end if;
+  end loop;
+
+  assert v_seen >= 2, 'fixture should receive at least two messages';
+  assert v_retry_msg.batch_id is not null, 'fixture batch id should be set';
+  assert v_dlq_msg.msg_id is not null, 'fixture DLQ message should be set';
+
+  perform pgque.event_retry(v_retry_msg.batch_id, v_retry_msg.msg_id, 60);
+  perform pgque.event_dead(
+    v_dlq_msg.batch_id,
+    v_dlq_msg.msg_id,
+    'upgrade fixture dlq row',
+    v_dlq_msg.created_at,
+    null::xid8,
+    v_dlq_msg.retry_count,
+    v_dlq_msg.type,
+    v_dlq_msg.payload,
+    v_dlq_msg.extra1,
+    v_dlq_msg.extra2,
+    v_dlq_msg.extra3,
+    v_dlq_msg.extra4
+  );
+
+  perform pgque.ack(v_retry_msg.batch_id);
+end $$;
+
+-- Sanity checks before upgrade.
+do $$
+begin
+  assert exists (select 1 from pgque.queue where queue_name = 'upgrade_v01_q'),
+    'fixture queue should exist before upgrade';
+  assert exists (select 1 from pgque.consumer where co_name = 'upgrade_v01_c'),
+    'fixture consumer should exist before upgrade';
+  assert exists (select 1 from pgque.retry_queue),
+    'fixture retry row should exist before upgrade';
+  assert exists (select 1 from pgque.dead_letter),
+    'fixture DLQ row should exist before upgrade';
+
+  raise notice 'PASS: v0.1.0 upgrade fixture prepared';
+end $$;


### PR DESCRIPTION
## Summary
- drop only legacy v0.1.0 public wrappers with old `i_*` argument names before recreating the v0.2 API wrappers
- add a dedicated v0.1.0 -> HEAD upgrade CI job on PostgreSQL 14 and 18
- document the SQL-file upgrade procedure and link it from the docs index/reference/tutorial

Fixes #226

## Local verification
- `bash build/transform.sh`
- PG18: install v0.1.0 -> prepare fixture -> reinstall HEAD -> verify upgraded state -> reinstall HEAD again -> `tests/test_install_idempotency.sql`
- PG14: install v0.1.0 -> prepare fixture -> reinstall HEAD -> verify upgraded state -> reinstall HEAD again -> `tests/test_install_idempotency.sql`
- PG18: fresh install smoke; `tests/run_all.sql` passed before acceptance hit an existing path assumption in `us10_idempotent_install.sql` when copied into Docker (`sql/pgque.sql` relative include path missing)
