### PR TITLE
chore(clients): bump release candidates to rc2

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,12 +335,12 @@ Longer walkthrough in the [tutorial](docs/tutorial.md); patterns like fan-out, e
 
 ## Client libraries
 
-PgQue is SQL-first, so any Postgres driver works. First-party client libraries live in this repo for **Python**, **Go**, and **TypeScript**, all published at `v0.2.0-rc.1`.
+PgQue is SQL-first, so any Postgres driver works. First-party client libraries live in this repo for **Python**, **Go**, and **TypeScript**, all published at `v0.2.0-rc.2`.
 
 ### Python (`pgque-py`) — psycopg 3
 
 ```bash
-pip install --pre pgque-py        # or: pip install "pgque-py==0.2.0rc1"
+pip install --pre pgque-py        # or: pip install "pgque-py==0.2.0rc2"
 ```
 
 ```python
@@ -366,7 +366,7 @@ consumer.start()
 ### Go (`github.com/NikolayS/pgque-go`) — pgx/v5
 
 ```bash
-go get github.com/NikolayS/pgque-go@v0.2.0-rc.1
+go get github.com/NikolayS/pgque-go@v0.2.0-rc.2
 ```
 
 ```go

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -8,7 +8,7 @@ universal PostgreSQL queue. A thin, idiomatic wrapper over the
 ## Install
 
 ```bash
-go get github.com/NikolayS/pgque-go@v0.2.0-rc.1
+go get github.com/NikolayS/pgque-go@v0.2.0-rc.2
 ```
 
 `@latest` also resolves to the rc since the v0.2.0 line is in release-candidate. The module is mirrored from `clients/go/` of the parent repo to the public [`NikolayS/pgque-go`](https://github.com/NikolayS/pgque-go) module repo.

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -11,10 +11,10 @@ universal PostgreSQL queue. Thin wrapper over `pgque-api` SQL functions:
 pip install --pre pgque-py
 ```
 
-`--pre` is required while v0.2.0 is in release-candidate (the latest published version is `0.2.0rc1`); pip skips prereleases by default. Pin the exact version if you prefer:
+`--pre` is required while v0.2.0 is in release-candidate (the latest published version is `0.2.0rc2`); pip skips prereleases by default. Pin the exact version if you prefer:
 
 ```bash
-pip install "pgque-py==0.2.0rc1"
+pip install "pgque-py==0.2.0rc2"
 ```
 
 Requires Python 3.10+ and PostgreSQL 14+ with the PgQue schema installed

--- a/clients/python/pgque/__init__.py
+++ b/clients/python/pgque/__init__.py
@@ -27,7 +27,7 @@ from .errors import (
 )
 from .types import Event, Message
 
-__version__ = "0.2.0rc1"
+__version__ = "0.2.0rc2"
 
 __all__ = [
     "PgqueClient",

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pgque-py"
-version = "0.2.0rc1"
+version = "0.2.0rc2"
 description = "Python client for PgQue -- PgQ Universal Edition"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -14,7 +14,7 @@ npm install pgque@rc
 # or: yarn add pgque@rc
 ```
 
-The `@rc` dist-tag points at the latest v0.2.0 release candidate (currently `0.2.0-rc.1`). Drop the tag once v0.2.0 ships.
+The `@rc` dist-tag points at the latest v0.2.0 release candidate (currently `0.2.0-rc.2`). Drop the tag once v0.2.0 ships.
 
 Runtime requirements: Node.js 20+ and PostgreSQL 14+ with the PgQue schema
 installed (`\i pgque.sql` — no extension required).

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pgque",
-  "version": "0.2.0-rc.1",
+  "version": "0.2.0-rc.2",
   "description": "TypeScript client for PgQue — the PgQ-based universal PostgreSQL queue",
   "license": "Apache-2.0",
   "packageManager": "bun@1.3.8",


### PR DESCRIPTION
## Summary

Align Python, TypeScript, and docs with the Go client rc2 release.

- Python: `0.2.0rc2`
- TypeScript: `0.2.0-rc.2`
- Go docs: `v0.2.0-rc.2`
- top-level client docs: rc2

## Test

- `git diff --check`
