### PR TITLE
chore(ci): wire NPM_TOKEN into typescript publish step

### DIFF
--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -152,4 +152,6 @@ jobs:
           echo "resolved npm dist-tag: $NPM_TAG (version=$VERSION)"
 
       - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance --tag "$NPM_TAG"


### PR DESCRIPTION
Adds `NODE_AUTH_TOKEN` to the publish step so `npm publish` can authenticate with the `NPM_TOKEN` secret.

The secret has been added to the repo. The `.env` file (which was never tracked by git) has been deleted locally.

## Test plan
- [ ] Merge and trigger the workflow via workflow_dispatch with `version=0.2.0-rc.2` and `dry_run=false`