### PR TITLE
docs(clients): document release quality rules

### DIFF
--- a/clients/README.md
+++ b/clients/README.md
@@ -4,6 +4,71 @@ PgQue ships three first-party clients. They are thin wrappers over `pgque.*`
 SQL primitives. The matrix below tracks the public client API on current
 `main`.
 
+## Release quality rules
+
+These rules are part of the client release process. Do not cut a final client
+release until they are satisfied or explicitly documented as intentionally
+out-of-scope for that release.
+
+### API parity is required
+
+First-party clients must expose the same public PgQue capabilities in idiomatic
+language shape. If Python exposes a normal consumer primitive, Go and
+TypeScript should expose it too; if TypeScript has a ticker helper, Python and
+Go should have equivalent helpers. Drift is acceptable only when it is a
+conscious product decision and recorded here or in the release issue.
+
+Implementation details may differ. For example, Python can use LISTEN/NOTIFY as
+a wakeup optimization while Go and TypeScript poll, but the public behavior and
+failure semantics must remain equivalent.
+
+Before a final release:
+
+- update the parity matrix below;
+- remove every accidental `✗` or convert it into a documented, intentional
+  exception;
+- verify each new or changed public method has tests in every affected client;
+- keep experimental features, especially cooperative consumers, clearly marked
+  experimental in all client READMEs.
+
+### Benchmarks must be current before final
+
+Do not quote old client performance numbers in release notes or docs. Before a
+final release, rerun the producer benchmarks against current SQL and client
+code, especially after changes to `send_batch`, payload encoding, transaction
+handling, or driver setup.
+
+Benchmark entry points:
+
+- Python: `clients/python/bench_producer.py`
+- Go: `clients/go/producer_benchmark_test.go`
+- TypeScript: `clients/typescript/src/producer_bench.ts`
+
+If benchmark results are published, update the chart and state the environment
+used for the run. Stale charts are worse than no charts; they give users false
+confidence, which is how benchmarks become marketing-shaped lies.
+
+### Testing gates
+
+For any client release candidate or final release:
+
+- run the repo CI client jobs for all first-party clients;
+- run package build / pack smoke tests for each ecosystem;
+- verify install from the real package index for published RCs before final;
+- run at least one clean smoke install for final packages:
+  - `pip install pgque-py`
+  - `npm install pgque`
+  - `go get github.com/NikolayS/pgque-go@vX.Y.Z`
+- verify pkg.go.dev renders Go docs and recognizes the license;
+- verify npm dist-tags: prereleases use `rc`/`next`, final uses `latest`;
+- verify PyPI/TestPyPI and npm/GitHub release automation before relying on it.
+
+### Release documentation
+
+Release prep PRs must update user-facing install commands and remove stale
+prerelease wording. When publishing a final release, docs must stop telling
+users to install `--pre`, `@rc`, or an `-rc` Go tag.
+
 ## Current parity matrix
 
 | Capability | Python | Go | TypeScript |


### PR DESCRIPTION
## Summary

Document client release quality rules in `clients/README.md`:

- API parity is required before final releases
- benchmarks must be current before final
- testing/install/package-index smoke gates
- release docs must remove stale prerelease wording

## Test

- `git diff --check`
