### PR TITLE
feat(python): add client parity wrappers

### DIFF
--- a/clients/README.md
+++ b/clients/README.md
@@ -75,29 +75,31 @@ users to install `--pre`, `@rc`, or an `-rc` Go tag.
 | --- | :---: | :---: | :---: |
 | `connect` / `close` | ✓ | ✓ | ✓ |
 | Raw SQL escape hatch | ✓ (`conn`) | ✓ (`Pool()`) | ✓ (`rawPool`) |
-| PgQue-classified errors | ✓ | ✗ | ✓ |
+| PgQue-classified errors | ✓ | ✓ | ✓ |
 | Lossless PostgreSQL `bigint` IDs | ✓ (`int`) | ✓ (`int64`) | ✓ (`bigint`) |
 | `send` | ✓ | ✓ | ✓ |
 | `send_batch` / `SendBatch` / `sendBatch` | ✓ | ✓ | ✓ |
 | `receive` | ✓ | ✓ | ✓ |
 | `ack` returns SQL rowcount (0 stale, 1 success) | ✓ (int) | ✓ (int64) | ✓ (number) |
 | `nack` | ✓ | ✓ | ✓ |
+| `ticker` / `Ticker` / `ticker`, `ticker_all` / `TickerAll` / `tickerAll` | ✓ | ✗ | ✓ |
 | `force_next_tick` / `ForceNextTick` / `forceNextTick` | ✓ | ✓ | ✓ |
-| `nack` retry delay + reason options | ✓ | ✗ | ✓ |
+| `nack` retry delay + reason options | ✓ | ✓ | ✓ |
 | High-level `Consumer` | ✓ | ✓ | ✓ |
 | Consumer wakeup model | polling + optional LISTEN/NOTIFY wakeup | polling | polling |
 | `Consumer` poll interval option | ✓ | ✓ | ✓ |
-| `Consumer` max-messages option | ✓ | ✗ | ✓ |
+| `Consumer` max-messages option | ✓ | ✓ | ✓ |
 | `Consumer` retry delay option | ✓ | ✗ | ✗ |
-| Unknown-type behavior avoids silent ack | ✗ | ✓ | ✓ |
-| Configurable unknown-type policy | ✗ | ✗ | ✗ |
-| `subscribe` / `unsubscribe` wrappers | ✗ | ✗ | ✓ |
+| Unknown-type behavior avoids silent ack | ✓ | ✓ | ✓ |
+| Configurable unknown-type policy | ✓ | ✓ | ✓ |
+| `subscribe` / `unsubscribe` wrappers | ✓ | ✗ | ✓ |
 | Cooperative consumers (experimental) [^coop] | ✓ | ✓ | ✓ |
 
 Legend: ✓ supported by the client API on `main`; ✗ not exposed as a
 first-class client API. Lower-level SQL primitives remain available through raw
-connection/pool escape hatches. TypeScript currently exposes an extra
-convenience wrapper for `ticker`; Python and Go can call it via raw SQL.
+connection/pool escape hatches. Python and TypeScript currently expose ticker
+convenience wrappers; Go can call ticker functions via raw SQL until parity is
+complete.
 
 [^coop]: Experimental. Each supporting client exposes
     `subscribe_subconsumer` / `unsubscribe_subconsumer` / `receive_coop` /

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -2,7 +2,8 @@
 
 Python client for [PgQue](https://github.com/NikolayS/pgque) — the PgQ-based
 universal PostgreSQL queue. Thin wrapper over `pgque-api` SQL functions:
-`send`, `receive`, `ack`, `nack`, `force_next_tick`, plus a polling
+`send`, `send_batch`, `subscribe`, `unsubscribe`, `receive`, `ack`,
+`nack`, `ticker`, `ticker_all`, `force_next_tick`, plus a polling
 `Consumer` with `LISTEN`/`NOTIFY` wakeup.
 
 ## Install
@@ -38,7 +39,7 @@ import pgque
 
 with pgque.connect("postgresql://localhost/mydb") as client:
     # one-time setup (typically in a migration)
-    client.conn.execute("select pgque.subscribe('orders', 'order_worker')")
+    client.subscribe("orders", "order_worker")
     client.conn.commit()
 
     # producer: commit once to publish both calls atomically
@@ -167,12 +168,12 @@ database with `PGQUE_TEST_DSN` set.
 ## Manual ticking
 
 For tests, demos, or manual operation without `pg_cron`, use
-`client.force_next_tick(queue)` to force the **next** `pgque.ticker()` call to
+`client.force_next_tick(queue)` to force the **next** ticker call to
 materialize a tick. It does not insert the tick itself:
 
 ```python
 client.force_next_tick("orders")
-client.conn.execute("select pgque.ticker()")
+client.ticker("orders")
 client.conn.commit()
 ```
 

--- a/clients/python/pgque/client.py
+++ b/clients/python/pgque/client.py
@@ -12,6 +12,7 @@ import psycopg
 from .errors import (
     PgqueBatchNotFound,
     PgqueConnectionError,
+    PgqueConsumerNotFound,
     PgqueError,
     PgqueQueueNotFound,
 )
@@ -46,7 +47,13 @@ def _wrap_sql_error(e: Exception) -> PgqueError:
     low = msg.lower()
     if "queue not found" in low:
         return PgqueQueueNotFound(msg)
-    if "batch not found" in low:
+    if (
+        "consumer not registered" in low
+        or "consumer not found" in low
+        or "not subscriber to queue" in low
+    ):
+        return PgqueConsumerNotFound(msg)
+    if "batch not found" in low or "cannot find data for batch" in low:
         return PgqueBatchNotFound(msg)
     return PgqueError(msg)
 
@@ -180,6 +187,34 @@ class PgqueClient:
 
     # --- consumer -------------------------------------------------------
 
+    def subscribe(self, queue: str, consumer: str) -> int:
+        """Subscribe ``consumer`` to ``queue``.
+
+        Maps to ``pgque.subscribe(queue, consumer)``. Returns ``1`` when a
+        subscription row was created and ``0`` when it already existed.
+        """
+        try:
+            row = self.conn.execute(
+                "select pgque.subscribe(%s, %s)", (queue, consumer)
+            ).fetchone()
+        except psycopg.Error as e:
+            raise _wrap_sql_error(e) from e
+        return row[0]
+
+    def unsubscribe(self, queue: str, consumer: str) -> int:
+        """Unsubscribe ``consumer`` from ``queue``.
+
+        Maps to ``pgque.unsubscribe(queue, consumer)``. Returns ``1`` when a
+        subscription row was removed and ``0`` when no row existed.
+        """
+        try:
+            row = self.conn.execute(
+                "select pgque.unsubscribe(%s, %s)", (queue, consumer)
+            ).fetchone()
+        except psycopg.Error as e:
+            raise _wrap_sql_error(e) from e
+        return row[0]
+
     def receive(
         self,
         queue: str,
@@ -272,6 +307,32 @@ class PgqueClient:
     def force_tick(self, queue: str) -> Optional[int]:
         """Deprecated compatibility alias for ``force_next_tick``."""
         return self.force_next_tick(queue)
+
+    def ticker(self, queue: str) -> Optional[int]:
+        """Run the per-queue ticker for ``queue``.
+
+        Maps to ``pgque.ticker(queue)``. Returns the new tick ID when a tick
+        was inserted, or ``None`` when no tick was needed.
+        """
+        try:
+            row = self.conn.execute(
+                "select pgque.ticker(%s)", (queue,)
+            ).fetchone()
+        except psycopg.Error as e:
+            raise _wrap_sql_error(e) from e
+        return row[0]
+
+    def ticker_all(self) -> int:
+        """Run the global ticker across all eligible queues.
+
+        Maps to zero-argument ``pgque.ticker()`` and returns the number of
+        queues that received a tick.
+        """
+        try:
+            row = self.conn.execute("select pgque.ticker()").fetchone()
+        except psycopg.Error as e:
+            raise _wrap_sql_error(e) from e
+        return row[0]
 
     # --- experimental cooperative consumers -----------------------------
     #

--- a/clients/python/tests/test_parity.py
+++ b/clients/python/tests/test_parity.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+"""Parity wrappers that should exist across all first-party clients."""
+
+import pytest
+
+import pgque
+
+
+def test_subscribe_unsubscribe_wrappers(conn, queue_name, consumer_name):
+    client = pgque.PgqueClient(conn)
+    conn.execute("select pgque.create_queue(%s)", (queue_name,))
+    conn.commit()
+    try:
+        assert client.subscribe(queue_name, consumer_name) == 1
+        assert client.subscribe(queue_name, consumer_name) == 0
+        conn.commit()
+
+        assert client.unsubscribe(queue_name, consumer_name) == 1
+        assert client.unsubscribe(queue_name, consumer_name) == 0
+        conn.commit()
+    finally:
+        conn.rollback()
+        conn.execute("select pgque.drop_queue(%s, true)", (queue_name,))
+        conn.commit()
+
+
+def test_ticker_wrapper_returns_tick_id(conn, setup_queue):
+    queue, _consumer = setup_queue
+    client = pgque.PgqueClient(conn)
+
+    client.send(queue, {"k": "v"})
+    conn.commit()
+    client.force_next_tick(queue)
+    tick_id = client.ticker(queue)
+    conn.commit()
+
+    assert isinstance(tick_id, int)
+
+
+def test_ticker_all_wrapper_returns_queue_count(conn, setup_queue):
+    queue, _consumer = setup_queue
+    client = pgque.PgqueClient(conn)
+
+    client.send(queue, {"k": "v"})
+    conn.commit()
+    client.force_next_tick(queue)
+    count = client.ticker_all()
+    conn.commit()
+
+    assert isinstance(count, int)
+    assert count >= 1
+
+
+def test_consumer_not_found_maps_to_typed_error(conn, queue_name):
+    client = pgque.PgqueClient(conn)
+    conn.execute("select pgque.create_queue(%s)", (queue_name,))
+    conn.commit()
+    try:
+        with pytest.raises(pgque.PgqueConsumerNotFound):
+            client.receive(queue_name, "missing_consumer", max_messages=1)
+    finally:
+        conn.rollback()
+        conn.execute("select pgque.drop_queue(%s, true)", (queue_name,))
+        conn.commit()


### PR DESCRIPTION
## Summary

Move Python closer to the 0.2.0 client parity contract:

- add `PgqueClient.subscribe()` / `unsubscribe()` wrappers
- add `PgqueClient.ticker()` / `ticker_all()` wrappers
- map missing-consumer SQL errors to `PgqueConsumerNotFound`
- add parity tests
- update Python README and client parity matrix

## Test

- `python -m compileall -q clients/python/pgque clients/python/tests`
- `python -m pytest clients/python/tests -q` (5 passed, 66 skipped locally without `PGQUE_TEST_DSN`)
- `git diff --check`
