### PR TITLE
feat(go): add client parity wrappers

### DIFF
--- a/clients/README.md
+++ b/clients/README.md
@@ -82,24 +82,23 @@ users to install `--pre`, `@rc`, or an `-rc` Go tag.
 | `receive` | ✓ | ✓ | ✓ |
 | `ack` returns SQL rowcount (0 stale, 1 success) | ✓ (int) | ✓ (int64) | ✓ (number) |
 | `nack` | ✓ | ✓ | ✓ |
-| `ticker` / `Ticker` / `ticker`, `ticker_all` / `TickerAll` / `tickerAll` | ✓ | ✗ | ✓ |
+| `ticker` / `Ticker` / `ticker`, `ticker_all` / `TickerAll` / `tickerAll` | ✓ | ✓ | ✓ |
 | `force_next_tick` / `ForceNextTick` / `forceNextTick` | ✓ | ✓ | ✓ |
 | `nack` retry delay + reason options | ✓ | ✓ | ✓ |
 | High-level `Consumer` | ✓ | ✓ | ✓ |
 | Consumer wakeup model | polling + optional LISTEN/NOTIFY wakeup | polling | polling |
 | `Consumer` poll interval option | ✓ | ✓ | ✓ |
 | `Consumer` max-messages option | ✓ | ✓ | ✓ |
-| `Consumer` retry delay option | ✓ | ✗ | ✗ |
+| `Consumer` retry delay option | ✓ | ✓ | ✗ |
 | Unknown-type behavior avoids silent ack | ✓ | ✓ | ✓ |
 | Configurable unknown-type policy | ✓ | ✓ | ✓ |
-| `subscribe` / `unsubscribe` wrappers | ✓ | ✗ | ✓ |
+| `subscribe` / `unsubscribe` wrappers | ✓ | ✓ | ✓ |
 | Cooperative consumers (experimental) [^coop] | ✓ | ✓ | ✓ |
 
 Legend: ✓ supported by the client API on `main`; ✗ not exposed as a
 first-class client API. Lower-level SQL primitives remain available through raw
-connection/pool escape hatches. Python and TypeScript currently expose ticker
-convenience wrappers; Go can call ticker functions via raw SQL until parity is
-complete.
+connection/pool escape hatches. Python, Go, and TypeScript expose ticker
+convenience wrappers.
 
 [^coop]: Experimental. Each supporting client exposes
     `subscribe_subconsumer` / `unsubscribe_subconsumer` / `receive_coop` /

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -2,7 +2,8 @@
 
 Go client for [PgQue](https://github.com/NikolayS/pgque) — the PgQ-based
 universal PostgreSQL queue. A thin, idiomatic wrapper over the
-`pgque-api` SQL functions: `send`, `receive`, `ack`, `nack`,
+`pgque-api` SQL functions: `send`, `send_batch`, `subscribe`,
+`unsubscribe`, `receive`, `ack`, `nack`, `ticker`, `ticker_all`, and
 `force_next_tick`.
 
 ## Install
@@ -50,7 +51,9 @@ func main() {
 
     // One-time queue + consumer setup (run once, e.g. in a migration):
     //   select pgque.create_queue('orders');
-    //   select pgque.register_consumer('orders', 'order_worker');
+    if _, err := client.Subscribe(ctx, "orders", "order_worker"); err != nil {
+        log.Fatal(err)
+    }
 
     // Producer side -- single event
     _, err = client.Send(ctx, "orders", pgque.Event{
@@ -92,6 +95,7 @@ func main() {
 | `WithPollInterval(d time.Duration)`     | `30s`          | Idle backoff between polls when the queue is empty.                   |
 | `WithMaxMessages(n int)`                | `math.MaxInt32` | Per-Receive limit. The default requests the whole PgQ batch before `Ack`. If you lower it below the real batch size, `Ack` still finishes the batch and unreturned rows are skipped. |
 | `WithUnknownHandlerPolicy(p)`           | `NackUnknown`  | `AckUnknown` logs and skips messages with no registered handler.      |
+| `WithRetryAfter(d time.Duration)`       | `60s`          | Retry delay for Consumer-issued `Nack` calls on handler failure or unknown type. |
 
 ## Manual ticking
 
@@ -104,7 +108,7 @@ _, err := client.ForceNextTick(ctx, "orders")
 if err != nil {
     log.Fatal(err)
 }
-_, err = client.Pool().Exec(ctx, "select pgque.ticker()")
+_, err = client.Ticker(ctx, "orders")
 ```
 
 `Client.ForceTick(ctx, queue)` remains as a deprecated compatibility alias.

--- a/clients/go/consumer.go
+++ b/clients/go/consumer.go
@@ -50,6 +50,7 @@ type Consumer struct {
 	maxMessages   int
 	handlers      map[string]HandlerFunc
 	unknownPolicy UnknownHandlerPolicy
+	retryAfter    *time.Duration
 
 	// Cooperative mode (experimental). When subconsumer is non-empty,
 	// the poll loop calls ReceiveCoop instead of Receive and passes
@@ -156,7 +157,8 @@ func (c *Consumer) Start(ctx context.Context) error {
 				}
 				log.Printf("pgque: no handler registered for event type %q, nacking message %d", msg.Type, msg.MsgID)
 				if nackErr := c.backend.Nack(ctx, batchID, msg, NackOptions{
-					Reason: strPtr("unknown event type: " + msg.Type),
+					RetryAfter: c.retryAfter,
+					Reason:     strPtr("unknown event type: " + msg.Type),
 				}); nackErr != nil {
 					log.Printf("pgque: nack error for unhandled type %s: %v", msg.Type, nackErr)
 					nackFailed = true
@@ -166,7 +168,8 @@ func (c *Consumer) Start(ctx context.Context) error {
 			if handlerErr := c.dispatchWithRecover(ctx, handler, msg); handlerErr != nil {
 				log.Printf("pgque: handler error for %s: %v", msg.Type, handlerErr)
 				if nackErr := c.backend.Nack(ctx, batchID, msg, NackOptions{
-					Reason: strPtr("handler error: " + handlerErr.Error()),
+					RetryAfter: c.retryAfter,
+					Reason:     strPtr("handler error: " + handlerErr.Error()),
 				}); nackErr != nil {
 					log.Printf("pgque: nack error for %s: %v", msg.Type, nackErr)
 					nackFailed = true

--- a/clients/go/consumer_internal_test.go
+++ b/clients/go/consumer_internal_test.go
@@ -25,8 +25,9 @@ type stubBackend struct {
 	nackCount int32
 	ackCount  int32
 
-	nackErr error
-	lastMax int32
+	nackErr         error
+	lastMax         int32
+	lastNackOptions NackOptions
 }
 
 func (s *stubBackend) Receive(_ context.Context, _, _ string, maxMessages int) ([]Message, error) {
@@ -45,7 +46,10 @@ func (s *stubBackend) Ack(_ context.Context, _ int64) (int64, error) {
 	return 1, nil
 }
 
-func (s *stubBackend) Nack(_ context.Context, _ int64, _ Message, _ NackOptions) error {
+func (s *stubBackend) Nack(_ context.Context, _ int64, _ Message, opts NackOptions) error {
+	s.mu.Lock()
+	s.lastNackOptions = opts
+	s.mu.Unlock()
 	atomic.AddInt32(&s.nackCount, 1)
 	return s.nackErr
 }
@@ -183,4 +187,45 @@ func TestConsumer_WithMaxMessagesPassesReceiveLimit(t *testing.T) {
 	if got := atomic.LoadInt32(&stub.lastMax); got != 123 {
 		t.Fatalf("configured maxMessages = %d, want 123", got)
 	}
+}
+
+func TestConsumer_WithRetryAfterPassesNackOption(t *testing.T) {
+	client := &Client{}
+	retryAfter := 7 * time.Second
+	stub := &stubBackend{
+		msg: Message{
+			MsgID:   1,
+			BatchID: 42,
+			Type:    "no.handler.registered",
+			Payload: `{}`,
+		},
+	}
+
+	c := client.NewConsumer("dummy_queue", "dummy_consumer",
+		WithPollInterval(50*time.Millisecond),
+		WithRetryAfter(retryAfter))
+	c.backend = stub
+
+	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Millisecond)
+	defer cancel()
+	_ = c.Start(ctx)
+
+	if got := atomic.LoadInt32(&stub.nackCount); got == 0 {
+		t.Fatal("expected Nack to be attempted")
+	}
+	stub.mu.Lock()
+	got := stub.lastNackOptions.RetryAfter
+	stub.mu.Unlock()
+	if got == nil || *got != retryAfter {
+		t.Fatalf("RetryAfter = %v, want %s", got, retryAfter)
+	}
+}
+
+func TestWithRetryAfterPanicsOnNegative(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic")
+		}
+	}()
+	WithRetryAfter(-time.Second)
 }

--- a/clients/go/options.go
+++ b/clients/go/options.go
@@ -59,6 +59,16 @@ func WithUnknownHandlerPolicy(p UnknownHandlerPolicy) ConsumerOption {
 	return func(c *Consumer) { c.unknownPolicy = p }
 }
 
+// WithRetryAfter sets the redelivery delay used by the high-level Consumer
+// when it nacks messages whose handler failed or whose type is unknown.
+// Default is the SQL/client Nack default of 60 seconds. Panics if d < 0.
+func WithRetryAfter(d time.Duration) ConsumerOption {
+	if d < 0 {
+		panic("pgque: WithRetryAfter requires d >= 0")
+	}
+	return func(c *Consumer) { c.retryAfter = &d }
+}
+
 // NackOptions tunes a single Client.Nack call. A zero-value NackOptions
 // uses the SQL-side defaults: 60s retry delay, NULL reason.
 type NackOptions struct {

--- a/clients/go/parity_test.go
+++ b/clients/go/parity_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+package pgque_test
+
+import (
+	"context"
+	"testing"
+
+	pgque "github.com/NikolayS/pgque-go"
+)
+
+func TestSubscribeUnsubscribeWrappers(t *testing.T) {
+	ctx := context.Background()
+	client := connectOrSkip(t)
+	defer client.Close()
+	queue := "gotest_q_" + randSuffix(t)
+	consumer := "gotest_c_" + randSuffix(t)
+
+	if _, err := client.Pool().Exec(ctx, "select pgque.create_queue($1)", queue); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		client.Pool().Exec(ctx, "select pgque.drop_queue($1)", queue)
+	})
+
+	n, err := client.Subscribe(ctx, queue, consumer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("Subscribe first call = %d, want 1", n)
+	}
+	n, err = client.Subscribe(ctx, queue, consumer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("Subscribe duplicate = %d, want 0", n)
+	}
+	n, err = client.Unsubscribe(ctx, queue, consumer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("Unsubscribe existing = %d, want 1", n)
+	}
+	n, err = client.Unsubscribe(ctx, queue, consumer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("Unsubscribe missing = %d, want 0", n)
+	}
+}
+
+func TestTickerWrappers(t *testing.T) {
+	ctx := context.Background()
+	client := connectOrSkip(t)
+	defer client.Close()
+	queue, _ := setupFreshQueue(t, client)
+
+	if _, err := client.Send(ctx, queue, pgque.Event{Payload: map[string]any{"x": 1}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.ForceNextTick(ctx, queue); err != nil {
+		t.Fatal(err)
+	}
+	tickID, err := client.Ticker(ctx, queue)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tickID == nil || *tickID == 0 {
+		t.Fatalf("Ticker tickID = %v, want non-zero", tickID)
+	}
+
+	if _, err := client.Send(ctx, queue, pgque.Event{Payload: map[string]any{"x": 2}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.ForceNextTick(ctx, queue); err != nil {
+		t.Fatal(err)
+	}
+	n, err := client.TickerAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n < 1 {
+		t.Fatalf("TickerAll = %d, want >= 1", n)
+	}
+}

--- a/clients/go/pgque.go
+++ b/clients/go/pgque.go
@@ -95,6 +95,30 @@ func (c *Client) SendBatch(ctx context.Context, queue, typ string, payloads []an
 	return ids, nil
 }
 
+// Subscribe registers consumer on queue, wrapping pgque.subscribe. The
+// returned int64 is the SQL row-count: 1 for a new subscription and 0
+// when the consumer was already subscribed.
+func (c *Client) Subscribe(ctx context.Context, queue, consumer string) (int64, error) {
+	var n int64
+	err := c.pool.QueryRow(ctx, "select pgque.subscribe($1, $2)", queue, consumer).Scan(&n)
+	if err != nil {
+		return 0, wrapSQLError("subscribe", err)
+	}
+	return n, nil
+}
+
+// Unsubscribe removes consumer from queue, wrapping pgque.unsubscribe. The
+// returned int64 is the SQL row-count: 1 when a subscription was removed and
+// 0 when no row existed.
+func (c *Client) Unsubscribe(ctx context.Context, queue, consumer string) (int64, error) {
+	var n int64
+	err := c.pool.QueryRow(ctx, "select pgque.unsubscribe($1, $2)", queue, consumer).Scan(&n)
+	if err != nil {
+		return 0, wrapSQLError("unsubscribe", err)
+	}
+	return n, nil
+}
+
 // Receive fetches up to maxMessages from the next batch for the named
 // consumer. Returns an empty slice when no batch is available; in that
 // case the caller should sleep before polling again. Each returned
@@ -144,6 +168,30 @@ func (c *Client) Ack(ctx context.Context, batchID int64) (int64, error) {
 	err := c.pool.QueryRow(ctx, "SELECT pgque.ack($1)", batchID).Scan(&n)
 	if err != nil {
 		return 0, wrapSQLError("ack", err)
+	}
+	return n, nil
+}
+
+// Ticker runs the per-queue ticker for queue, wrapping pgque.ticker(queue).
+// It returns the new tick id when a tick was inserted, or nil when no tick
+// was needed.
+func (c *Client) Ticker(ctx context.Context, queue string) (*int64, error) {
+	var tickID *int64
+	err := c.pool.QueryRow(ctx, "select pgque.ticker($1)", queue).Scan(&tickID)
+	if err != nil {
+		return nil, wrapSQLError("ticker", err)
+	}
+	return tickID, nil
+}
+
+// TickerAll runs the global ticker across all eligible queues, wrapping
+// zero-argument pgque.ticker(). It returns the number of queues that received
+// a tick during this call.
+func (c *Client) TickerAll(ctx context.Context) (int64, error) {
+	var n int64
+	err := c.pool.QueryRow(ctx, "select pgque.ticker()").Scan(&n)
+	if err != nil {
+		return 0, wrapSQLError("ticker all", err)
 	}
 	return n, nil
 }
@@ -323,6 +371,7 @@ func (c *Client) TouchSubconsumer(ctx context.Context, queue, consumer, subconsu
 //   - poll interval: 30s   (WithPollInterval)
 //   - max messages:  MaxInt32 (WithMaxMessages; drains the whole batch by default)
 //   - unknown type:  Nack  (WithUnknownHandlerPolicy)
+//   - retry delay:   60s   (WithRetryAfter; used for consumer-issued Nacks)
 func (c *Client) NewConsumer(queue, name string, opts ...ConsumerOption) *Consumer {
 	consumer := &Consumer{
 		backend:       c,


### PR DESCRIPTION
## Summary

Move the Go client to the same 0.2.0 parity surface as Python/TypeScript:

- add `Client.Subscribe` / `Client.Unsubscribe` wrappers
- add `Client.Ticker` / `Client.TickerAll` wrappers
- add `WithRetryAfter` for high-level Consumer-issued nacks
- add Go parity tests and Consumer option tests
- update Go README and client parity matrix

## Test

- `docker run --rm -v /tmp/PgQue/clients/go:/work -w /work golang:1.21 gofmt -w pgque.go options.go consumer.go consumer_internal_test.go parity_test.go`
- `docker run --rm -v /tmp/PgQue/clients/go:/work -w /work golang:1.21 go test ./...`
- `git diff --check`
