### PR TITLE
feat(typescript): finish client parity

### DIFF
--- a/clients/README.md
+++ b/clients/README.md
@@ -89,7 +89,7 @@ users to install `--pre`, `@rc`, or an `-rc` Go tag.
 | Consumer wakeup model | polling + optional LISTEN/NOTIFY wakeup | polling | polling |
 | `Consumer` poll interval option | ✓ | ✓ | ✓ |
 | `Consumer` max-messages option | ✓ | ✓ | ✓ |
-| `Consumer` retry delay option | ✓ | ✓ | ✗ |
+| `Consumer` retry delay option | ✓ | ✓ | ✓ |
 | Unknown-type behavior avoids silent ack | ✓ | ✓ | ✓ |
 | Configurable unknown-type policy | ✓ | ✓ | ✓ |
 | `subscribe` / `unsubscribe` wrappers | ✓ | ✓ | ✓ |

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -2,8 +2,9 @@
 
 TypeScript client for [PgQue](https://github.com/NikolayS/pgque) — the
 PgQ-based universal PostgreSQL queue. Thin, idiomatic wrapper over the
-`pgque-api` SQL functions: `send`, `receive`, `ack`, `nack` (plus
-`subscribe` / `unsubscribe`).
+`pgque-api` SQL functions: `send`, `send_batch`, `subscribe`,
+`unsubscribe`, `receive`, `ack`, `nack`, `ticker`, `ticker_all`, and
+`force_next_tick`.
 
 ## Install
 
@@ -83,7 +84,7 @@ try {
 | `client.ticker(queue)` | Per-queue ticker; returns the new tick id (`bigint`) or `null` when no tick was needed. Wraps `pgque.ticker(queue text)`. |
 | `client.tickerAll()` | Global ticker across all eligible queues; returns count of queues ticked (`number`). Wraps `pgque.ticker()`. |
 | `client.forceNextTick(queue)` | Force the next `ticker(queue)` call to produce a tick; returns the last tick id (`bigint`) or `null` on a brand-new queue. Wraps `pgque.force_next_tick(queue text)`. |
-| `client.newConsumer(queue, name, opts?)` | High-level poll loop. |
+| `client.newConsumer(queue, name, opts?)` | High-level poll loop. Options include `pollInterval`, `maxMessages`, `retryAfter`, and `unknownHandlerPolicy`. |
 | `consumer.handle(eventType, fn)` | Register a handler. |
 | `consumer.start(signal?)` | Run; resolves when `AbortSignal` aborts. |
 | `client.close()` | Drain the pool. |
@@ -150,6 +151,7 @@ All errors derive from `PgqueError`:
 - `PgqueConnectionError` — connect failure
 - `PgqueQueueNotFoundError` — caller forgot `pgque.create_queue`
 - `PgqueConsumerNotFoundError` — consumer not subscribed
+- `PgqueBatchNotFoundError` — batch is stale, missing, or already finished
 - `PgqueSqlError` — generic SQL failure (with `cause`)
 
 ## Caveats

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -41,16 +41,6 @@ export const pgqueTypes: pg.CustomTypesConfig = {
   },
 };
 
-const PG_RAISE_EXCEPTION_CODE = 'P0001';
-
-interface PgError extends Error {
-  code?: string;
-}
-
-function isPgError(e: unknown): e is PgError {
-  return e instanceof Error && typeof (e as PgError).code === 'string';
-}
-
 /** Internal: row shape returned by `pgque.receive` after type parsers run. */
 interface RawMessageRow {
   msg_id: bigint;
@@ -642,11 +632,8 @@ function mapPgError(
   err: unknown,
   ctx?: { queue?: string; consumer?: string; batchId?: bigint },
 ): PgqueError {
-  if (!isPgError(err)) {
-    return new PgqueSqlError(op, { cause: err });
-  }
-  const msg = err.message ?? '';
-  if (err.code === PG_RAISE_EXCEPTION_CODE && /queue not found/i.test(msg) && ctx?.queue) {
+  const msg = err instanceof Error ? err.message : String(err ?? '');
+  if (/queue not found/i.test(msg) && ctx?.queue) {
     return new PgqueQueueNotFoundError(ctx.queue, { cause: err });
   }
   if (/(consumer (not registered|not found)|not subscribed)/i.test(msg)) {

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -632,7 +632,12 @@ function mapPgError(
   err: unknown,
   ctx?: { queue?: string; consumer?: string; batchId?: bigint },
 ): PgqueError {
-  const msg = err instanceof Error ? err.message : String(err ?? '');
+  const msg =
+    err instanceof Error
+      ? err.message
+      : typeof err === 'object' && err !== null && 'message' in err
+        ? String((err as { message?: unknown }).message ?? '')
+        : String(err ?? '');
   if (/queue not found/i.test(msg) && ctx?.queue) {
     return new PgqueQueueNotFoundError(ctx.queue, { cause: err });
   }

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -649,7 +649,7 @@ function mapPgError(
   if (err.code === PG_RAISE_EXCEPTION_CODE && /queue not found/i.test(msg) && ctx?.queue) {
     return new PgqueQueueNotFoundError(ctx.queue, { cause: err });
   }
-  if (err.code === PG_RAISE_EXCEPTION_CODE && /consumer (not registered|not found)/i.test(msg)) {
+  if (err.code === PG_RAISE_EXCEPTION_CODE && /(consumer (not registered|not found)|not subscribed)/i.test(msg)) {
     return new PgqueConsumerNotFoundError(ctx?.queue ?? '', ctx?.consumer ?? '', { cause: err });
   }
   if (err.code === PG_RAISE_EXCEPTION_CODE && /batch not found/i.test(msg)) {

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -641,7 +641,7 @@ function mapPgError(
   if (/queue not found/i.test(msg) && ctx?.queue) {
     return new PgqueQueueNotFoundError(ctx.queue, { cause: err });
   }
-  if (/(consumer (not registered|not found)|not subscribed)/i.test(msg)) {
+  if (/(consumer (not registered|not found)|not subscrib(?:ed|er))/i.test(msg)) {
     return new PgqueConsumerNotFoundError(ctx?.queue ?? '', ctx?.consumer ?? '', { cause: err });
   }
   if (/batch not found/i.test(msg)) {

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -4,7 +4,9 @@
 import pg from 'pg';
 import { Consumer } from './consumer.js';
 import {
+  PgqueBatchNotFoundError,
   PgqueConnectionError,
+  PgqueConsumerNotFoundError,
   PgqueError,
   PgqueQueueNotFoundError,
   PgqueSqlError,
@@ -186,7 +188,7 @@ export class Client {
       return result.rows.map(rowToMessage);
     } catch (err) {
       if (err instanceof PgqueError) throw err;
-      throw mapPgError('receive', err, { queue });
+      throw mapPgError('receive', err, { queue, consumer });
     }
   }
 
@@ -288,7 +290,7 @@ export class Client {
       );
     } catch (err) {
       if (err instanceof PgqueError) throw err;
-      throw mapPgError('nack', err);
+      throw mapPgError('nack', err, { batchId });
     }
   }
 
@@ -635,13 +637,23 @@ function serializePayload(payload: unknown): string {
   return encoded;
 }
 
-function mapPgError(op: string, err: unknown, ctx?: { queue?: string }): PgqueError {
+function mapPgError(
+  op: string,
+  err: unknown,
+  ctx?: { queue?: string; consumer?: string; batchId?: bigint },
+): PgqueError {
   if (!isPgError(err)) {
     return new PgqueSqlError(op, { cause: err });
   }
   const msg = err.message ?? '';
   if (err.code === PG_RAISE_EXCEPTION_CODE && /queue not found/i.test(msg) && ctx?.queue) {
     return new PgqueQueueNotFoundError(ctx.queue, { cause: err });
+  }
+  if (err.code === PG_RAISE_EXCEPTION_CODE && /consumer (not registered|not found)/i.test(msg)) {
+    return new PgqueConsumerNotFoundError(ctx?.queue ?? '', ctx?.consumer ?? '', { cause: err });
+  }
+  if (err.code === PG_RAISE_EXCEPTION_CODE && /batch not found/i.test(msg)) {
+    return new PgqueBatchNotFoundError(ctx?.batchId, { cause: err });
   }
   return new PgqueSqlError(op, { cause: err });
 }

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -649,10 +649,10 @@ function mapPgError(
   if (err.code === PG_RAISE_EXCEPTION_CODE && /queue not found/i.test(msg) && ctx?.queue) {
     return new PgqueQueueNotFoundError(ctx.queue, { cause: err });
   }
-  if (err.code === PG_RAISE_EXCEPTION_CODE && /(consumer (not registered|not found)|not subscribed)/i.test(msg)) {
+  if (/(consumer (not registered|not found)|not subscribed)/i.test(msg)) {
     return new PgqueConsumerNotFoundError(ctx?.queue ?? '', ctx?.consumer ?? '', { cause: err });
   }
-  if (err.code === PG_RAISE_EXCEPTION_CODE && /batch not found/i.test(msg)) {
+  if (/batch not found/i.test(msg)) {
     return new PgqueBatchNotFoundError(ctx?.batchId, { cause: err });
   }
   return new PgqueSqlError(op, { cause: err });

--- a/clients/typescript/src/consumer.ts
+++ b/clients/typescript/src/consumer.ts
@@ -29,6 +29,7 @@ export class Consumer {
   private readonly handlers = new Map<string, HandlerFunc>();
   private readonly pollIntervalMs: number;
   private readonly maxMessages: number;
+  private readonly retryAfter: number;
   private readonly unknownHandlerPolicy: 'ack' | 'nack';
   private readonly logger: Pick<Console, 'warn' | 'error'>;
   private readonly subconsumer: string | undefined;
@@ -43,6 +44,10 @@ export class Consumer {
   ) {
     this.pollIntervalMs = opts.pollInterval ?? 30_000;
     this.maxMessages = opts.maxMessages ?? DEFAULT_MAX_MESSAGES;
+    this.retryAfter = opts.retryAfter ?? 60;
+    if (!Number.isFinite(this.retryAfter) || this.retryAfter < 0) {
+      throw new Error('pgque: retryAfter must be a non-negative finite number of seconds');
+    }
     this.unknownHandlerPolicy = opts.unknownHandlerPolicy ?? 'nack';
     this.logger = opts.logger ?? console;
     this.subconsumer = opts.subconsumer;
@@ -150,7 +155,7 @@ export class Consumer {
   /** Returns true if the nack succeeded, false if it threw (and was logged). */
   private async tryNack(batchId: bigint, msg: Message, reason: string): Promise<boolean> {
     try {
-      await this.client.nack(batchId, msg, { reason });
+      await this.client.nack(batchId, msg, { retryAfter: this.retryAfter, reason });
       return true;
     } catch (err) {
       this.logger.error(`pgque: nack error for "${msg.type}": ${formatErr(err)}`);

--- a/clients/typescript/src/errors.ts
+++ b/clients/typescript/src/errors.ts
@@ -25,6 +25,17 @@ export class PgqueQueueNotFoundError extends PgqueError {
   }
 }
 
+/** The named batch no longer exists or is not active. */
+export class PgqueBatchNotFoundError extends PgqueError {
+  constructor(public readonly batchId?: bigint, options?: { cause?: unknown }) {
+    super(
+      batchId !== undefined ? `pgque: batch not found: ${batchId}` : 'pgque: batch not found',
+      options,
+    );
+    this.name = 'PgqueBatchNotFoundError';
+  }
+}
+
 /** The named consumer is not subscribed to the queue. */
 export class PgqueConsumerNotFoundError extends PgqueError {
   constructor(

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -4,8 +4,9 @@
 /**
  * pgque is the TypeScript client for PgQue, the PgQ-based universal
  * PostgreSQL queue. It is a thin, idiomatic wrapper over the `pgque-api`
- * SQL functions: `send`, `receive`, `ack`, `nack`, plus `subscribe` /
- * `unsubscribe`.
+ * SQL functions: `send`, `send_batch`, `subscribe`, `unsubscribe`,
+ * `receive`, `ack`, `nack`, `ticker`, `ticker_all`, and
+ * `force_next_tick`.
  *
  * Quick start:
  * ```ts
@@ -37,6 +38,7 @@
 export { Client, connect, pgqueTypes } from './client.js';
 export { Consumer, DEFAULT_MAX_MESSAGES } from './consumer.js';
 export {
+  PgqueBatchNotFoundError,
   PgqueConnectionError,
   PgqueConsumerNotFoundError,
   PgqueError,

--- a/clients/typescript/src/types.ts
+++ b/clients/typescript/src/types.ts
@@ -68,6 +68,11 @@ export interface ConsumerOptions {
    */
   maxMessages?: number;
   /**
+   * Retry delay in **seconds** used by the high-level Consumer when it
+   * nacks messages after handler failure or unknown event type. Default `60`.
+   */
+  retryAfter?: number;
+  /**
    * What to do with messages whose `type` has no registered handler:
    * - `'nack'` (default) — nack each unknown message with a reason; PgQ
    *   routes to the retry queue or DLQ per the queue's `queue_max_retries`.

--- a/clients/typescript/test/client.test.ts
+++ b/clients/typescript/test/client.test.ts
@@ -3,7 +3,9 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  PgqueBatchNotFoundError,
   PgqueConnectionError,
+  PgqueConsumerNotFoundError,
   PgqueQueueNotFoundError,
   PgqueSqlError,
   connect,
@@ -161,6 +163,29 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
     await expect(
       env.client.sendBatch('does_not_exist_xyz', 'x', [{}]),
     ).rejects.toBeInstanceOf(PgqueQueueNotFoundError);
+  });
+
+  skipIfNoDb('receive with nonexistent consumer raises PgqueConsumerNotFoundError', async () => {
+    await expect(env.client.receive(env.queue, 'missing_consumer_xyz', 10)).rejects.toBeInstanceOf(
+      PgqueConsumerNotFoundError,
+    );
+  });
+
+  skipIfNoDb('nack with nonexistent batch raises PgqueBatchNotFoundError', async () => {
+    await expect(
+      env.client.nack(999999999999n, {
+        msgId: 1n,
+        batchId: 999999999999n,
+        type: 'missing.batch',
+        payload: '{}',
+        retryCount: null,
+        createdAt: new Date(),
+        extra1: null,
+        extra2: null,
+        extra3: null,
+        extra4: null,
+      }),
+    ).rejects.toBeInstanceOf(PgqueBatchNotFoundError);
   });
 
   skipIfNoDb('sendBatch rejects non-serializable payloads', async () => {

--- a/clients/typescript/test/consumer.test.ts
+++ b/clients/typescript/test/consumer.test.ts
@@ -398,6 +398,64 @@ describe('Consumer (in-memory mocks)', () => {
     expect(fakeClient.receive.mock.calls[0]).toEqual(['q', 'c', 123]);
   });
 
+  it('passes configured retryAfter to consumer-issued nack', async () => {
+    const msg: Message = {
+      msgId: 3n,
+      batchId: 101n,
+      type: 'unknown_type',
+      payload: '{}',
+      retryCount: null,
+      createdAt: new Date(),
+      extra1: null,
+      extra2: null,
+      extra3: null,
+      extra4: null,
+    };
+
+    let receiveCalls = 0;
+    const fakeClient = {
+      receive: vi.fn(async () => {
+        receiveCalls += 1;
+        return receiveCalls === 1 ? [msg] : [];
+      }),
+      ack: vi.fn(async () => undefined),
+      nack: vi.fn(async (_batchId: bigint, _msg: Message, _opts?: unknown) => undefined),
+    };
+
+    const consumer = new Consumer(fakeClient as unknown as Client, 'q', 'c', {
+      pollInterval: 10,
+      retryAfter: 5,
+      logger: { warn: () => undefined, error: () => undefined },
+    });
+
+    const ac = new AbortController();
+    const startPromise = consumer.start(ac.signal);
+    const deadline = Date.now() + 4000;
+    while (Date.now() < deadline && fakeClient.nack.mock.calls.length === 0) {
+      await sleep(10);
+    }
+    ac.abort();
+    await startPromise;
+
+    expect(fakeClient.nack).toHaveBeenCalledTimes(1);
+    expect(fakeClient.nack.mock.calls[0]?.[2]).toMatchObject({ retryAfter: 5 });
+  });
+
+  it('rejects negative retryAfter at construction', () => {
+    const fakeClient = {
+      receive: vi.fn(async () => []),
+      ack: vi.fn(async () => undefined),
+      nack: vi.fn(async () => undefined),
+    };
+
+    expect(
+      () =>
+        new Consumer(fakeClient as unknown as Client, 'q', 'c', {
+          retryAfter: -1,
+        }),
+    ).toThrow(/retryAfter/);
+  });
+
   it('does not call ack when nack fails for an unknown event type', async () => {
     const msg: Message = {
       msgId: 2n,


### PR DESCRIPTION
## Summary

Close the remaining TypeScript 0.2.0 client parity gaps:

- add exported `PgqueBatchNotFoundError` and map SQL `batch not found`
- map SQL consumer-not-registered/not-found errors to `PgqueConsumerNotFoundError`
- add high-level Consumer `retryAfter` option for Consumer-issued nacks
- add integration/mocked tests for classified errors and retry delay
- update TypeScript README and parity matrix

## Test

- `cd clients/typescript && bun install --frozen-lockfile`
- `cd clients/typescript && bun run check`
- `cd clients/typescript && bun run test` (23 passed, 50 skipped locally without `PGQUE_TEST_DSN`)
- `git diff --check`
