### PR TITLE
chore(release): prepare 0.2.0 rc3

### DIFF
--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -9,7 +9,7 @@ universal PostgreSQL queue. A thin, idiomatic wrapper over the
 ## Install
 
 ```bash
-go get github.com/NikolayS/pgque-go@v0.2.0-rc.2
+go get github.com/NikolayS/pgque-go@v0.2.0-rc.3
 ```
 
 `@latest` also resolves to the rc since the v0.2.0 line is in release-candidate. The module is mirrored from `clients/go/` of the parent repo to the public [`NikolayS/pgque-go`](https://github.com/NikolayS/pgque-go) module repo.

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -12,10 +12,10 @@ universal PostgreSQL queue. Thin wrapper over `pgque-api` SQL functions:
 pip install --pre pgque-py
 ```
 
-`--pre` is required while v0.2.0 is in release-candidate (the latest published version is `0.2.0rc2`); pip skips prereleases by default. Pin the exact version if you prefer:
+`--pre` is required while v0.2.0 is in release-candidate (the latest published version is `0.2.0rc3`); pip skips prereleases by default. Pin the exact version if you prefer:
 
 ```bash
-pip install "pgque-py==0.2.0rc2"
+pip install "pgque-py==0.2.0rc3"
 ```
 
 Requires Python 3.10+ and PostgreSQL 14+ with the PgQue schema installed

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pgque-py"
-version = "0.2.0rc2"
+version = "0.2.0rc3"
 description = "Python client for PgQue -- PgQ Universal Edition"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -15,7 +15,7 @@ npm install pgque@rc
 # or: yarn add pgque@rc
 ```
 
-The `@rc` dist-tag points at the latest v0.2.0 release candidate (currently `0.2.0-rc.2`). Drop the tag once v0.2.0 ships.
+The `@rc` dist-tag points at the latest v0.2.0 release candidate (currently `0.2.0-rc.3`). Drop the tag once v0.2.0 ships.
 
 Runtime requirements: Node.js 20+ and PostgreSQL 14+ with the PgQue schema
 installed (`\i pgque.sql` — no extension required).

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pgque",
-  "version": "0.2.0-rc.2",
+  "version": "0.2.0-rc.3",
   "description": "TypeScript client for PgQue — the PgQ-based universal PostgreSQL queue",
   "license": "Apache-2.0",
   "packageManager": "bun@1.3.8",


### PR DESCRIPTION
## Summary

Prepare the rc3 train after first-party client parity landed:

- Python: `0.2.0rc3`
- TypeScript: `0.2.0-rc.3`
- Go README install pin: `v0.2.0-rc.3`
- update rc install docs

## Test

- `python3 -m compileall -q clients/python/pgque clients/python/tests`
- `cd clients/typescript && bun run check && bun run test` (23 passed, 50 skipped locally without `PGQUE_TEST_DSN`)
- `docker run --rm -v /tmp/PgQue/clients/go:/work -w /work golang:1.21 go test ./...`
- `git diff --check`

Note: local `python3 -m pytest clients/python/tests -q` is blocked because this host lacks pytest; CI runs it with dependencies.