### PR TITLE
fix(typescript): classify legacy PgQ errors

### DIFF
--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -638,13 +638,13 @@ function mapPgError(
       : typeof err === 'object' && err !== null && 'message' in err
         ? String((err as { message?: unknown }).message ?? '')
         : String(err ?? '');
-  if (/queue not found/i.test(msg) && ctx?.queue) {
-    return new PgqueQueueNotFoundError(ctx.queue, { cause: err });
+  if (/(queue not found|no such queue|no such event queue|event queue not found|event queue not created)/i.test(msg)) {
+    return new PgqueQueueNotFoundError(ctx?.queue ?? '', { cause: err });
   }
   if (/(consumer (not registered|not found)|not subscrib(?:ed|er))/i.test(msg)) {
     return new PgqueConsumerNotFoundError(ctx?.queue ?? '', ctx?.consumer ?? '', { cause: err });
   }
-  if (/batch not found/i.test(msg)) {
+  if (/(batch not found|cannot find data for batch)/i.test(msg)) {
     return new PgqueBatchNotFoundError(ctx?.batchId, { cause: err });
   }
   return new PgqueSqlError(op, { cause: err });

--- a/clients/typescript/test/client.test.ts
+++ b/clients/typescript/test/client.test.ts
@@ -8,6 +8,7 @@ import {
   PgqueConsumerNotFoundError,
   PgqueQueueNotFoundError,
   PgqueSqlError,
+  Client,
   connect,
 } from '../src/index.js';
 import { TEST_DSN, setupTestQueue, teardownTestQueue, advanceQueue, type TestEnv } from './helpers.js';
@@ -327,4 +328,46 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
     }
     expect(total).toBe(N);
   });
+});
+
+describe('Client error classification (in-memory)', () => {
+  function clientThatRaises(message: string): Client {
+    return new Client({
+      query: async () => {
+        throw { message };
+      },
+    } as never);
+  }
+
+  it.each([
+    'queue not found: missing_q',
+    'no such queue',
+    'No such event queue',
+    'Event queue not created yet',
+    'event queue not found: missing_q',
+  ])('maps queue errors to PgqueQueueNotFoundError: %s', async (message) => {
+    await expect(clientThatRaises(message).ticker('missing_q')).rejects.toBeInstanceOf(
+      PgqueQueueNotFoundError,
+    );
+  });
+
+  it.each(['batch not found: 42', 'Cannot find data for batch 42'])(
+    'maps batch errors to PgqueBatchNotFoundError: %s',
+    async (message) => {
+      await expect(
+        clientThatRaises(message).nack(42n, {
+          msgId: 1n,
+          batchId: 42n,
+          type: 'x',
+          payload: '{}',
+          retryCount: null,
+          createdAt: new Date(),
+          extra1: null,
+          extra2: null,
+          extra3: null,
+          extra4: null,
+        }),
+      ).rejects.toBeInstanceOf(PgqueBatchNotFoundError);
+    },
+  );
 });


### PR DESCRIPTION
## Summary

Fix the REV finding from #249: TypeScript classified only the modern PgQue error strings, while Go also recognizes legacy PgQ messages emitted by the SQL layer.

- map legacy queue errors to `PgqueQueueNotFoundError`:
  - `no such queue`
  - `No such event queue`
  - `Event queue not created yet`
  - `event queue not found`
- map legacy batch errors to `PgqueBatchNotFoundError`:
  - `Cannot find data for batch ...`
- add in-memory regression tests for all fragments so this parity hole stays shut

## Test

- `cd clients/typescript && bun run check && bun run test` (30 passed, 50 skipped locally without `PGQUE_TEST_DSN`)
- `git diff --check`
