### PR TITLE
fix(typescript): classify connection failures

### DIFF
--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -647,5 +647,21 @@ function mapPgError(
   if (/(batch not found|cannot find data for batch)/i.test(msg)) {
     return new PgqueBatchNotFoundError(ctx?.batchId, { cause: err });
   }
+  if (isConnectionError(err, msg)) {
+    return new PgqueConnectionError(`pgque: ${op}: ${msg}`, { cause: err });
+  }
   return new PgqueSqlError(op, { cause: err });
+}
+
+function isConnectionError(err: unknown, msg: string): boolean {
+  const code =
+    typeof err === 'object' && err !== null && 'code' in err
+      ? String((err as { code?: unknown }).code ?? '')
+      : '';
+  return (
+    /^(ECONNRESET|ECONNREFUSED|EPIPE|ETIMEDOUT|ENOTFOUND|EAI_AGAIN)$/i.test(code) ||
+    /(connection terminated|connection closed|pool has ended|pool after calling end|connection timeout|timeout expired|terminating connection|server closed the connection)/i.test(
+      msg,
+    )
+  );
 }

--- a/clients/typescript/test/client.test.ts
+++ b/clients/typescript/test/client.test.ts
@@ -370,4 +370,18 @@ describe('Client error classification (in-memory)', () => {
       ).rejects.toBeInstanceOf(PgqueBatchNotFoundError);
     },
   );
+
+  it.each([
+    { message: 'Connection terminated unexpectedly' },
+    { message: 'Cannot use a pool after calling end on the pool' },
+    { message: 'query failed', code: 'ECONNRESET' },
+  ])('maps connection errors to PgqueConnectionError: $message', async (cause) => {
+    const client = new Client({
+      query: async () => {
+        throw cause;
+      },
+    } as never);
+
+    await expect(client.send('q', { payload: {} })).rejects.toBeInstanceOf(PgqueConnectionError);
+  });
 });


### PR DESCRIPTION
## Summary

Fix REV rerun finding: TypeScript classified operation-time pool/network failures as generic `PgqueSqlError`, despite `PgqueConnectionError` documenting mid-operation drops and Go tagging non-PgError operation failures as connection errors.

- classify common Node/pg connection failures as `PgqueConnectionError`
- cover closed pool, terminated connection, and `ECONNRESET` with in-memory regression tests

## Test

- `cd clients/typescript && bun run check && bun run test` (33 passed, 50 skipped locally without `PGQUE_TEST_DSN`)
- `git diff --check`

## REV

REV rerun finding from #251: https://github.com/NikolayS/PgQue/pull/251#issuecomment-4530548584
