### PR TITLE
chore(release): prepare 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,12 +335,12 @@ Longer walkthrough in the [tutorial](docs/tutorial.md); patterns like fan-out, e
 
 ## Client libraries
 
-PgQue is SQL-first, so any Postgres driver works. First-party client libraries live in this repo for **Python**, **Go**, and **TypeScript**, all published at `v0.2.0-rc.2`.
+PgQue is SQL-first, so any Postgres driver works. First-party client libraries live in this repo for **Python**, **Go**, and **TypeScript**, all published at `v0.2.0`.
 
 ### Python (`pgque-py`) — psycopg 3
 
 ```bash
-pip install --pre pgque-py        # or: pip install "pgque-py==0.2.0rc2"
+pip install pgque-py
 ```
 
 ```python
@@ -366,7 +366,7 @@ consumer.start()
 ### Go (`github.com/NikolayS/pgque-go`) — pgx/v5
 
 ```bash
-go get github.com/NikolayS/pgque-go@v0.2.0-rc.2
+go get github.com/NikolayS/pgque-go@v0.2.0
 ```
 
 ```go
@@ -388,7 +388,7 @@ consumer.Start(ctx)
 ### TypeScript (`pgque`) — node-postgres
 
 ```bash
-npm install pgque@rc        # or: bun add pgque@rc
+npm install pgque        # or: bun add pgque
 ```
 
 ```ts

--- a/build/transform.sh
+++ b/build/transform.sh
@@ -646,7 +646,7 @@ apply_idempotency_guards() {
 # Start with header
 cat > "${INSTALL_FILE}" << 'HEADER'
 -- pgque.sql -- PgQ Universal Edition
--- Version: 0.2.0-rc.1
+-- Version: 0.2.0
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 -- Includes code derived from PgQ (ISC license, Marko Kreen / Skype Technologies OU).
 --

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -9,10 +9,10 @@ universal PostgreSQL queue. A thin, idiomatic wrapper over the
 ## Install
 
 ```bash
-go get github.com/NikolayS/pgque-go@v0.2.0-rc.3
+go get github.com/NikolayS/pgque-go@v0.2.0
 ```
 
-`@latest` also resolves to the rc since the v0.2.0 line is in release-candidate. The module is mirrored from `clients/go/` of the parent repo to the public [`NikolayS/pgque-go`](https://github.com/NikolayS/pgque-go) module repo.
+The module is mirrored from `clients/go/` of the parent repo to the public [`NikolayS/pgque-go`](https://github.com/NikolayS/pgque-go) module repo.
 
 Requires Go 1.21+ and PostgreSQL 14+ with the PgQue schema installed
 (`\i pgque.sql` — no extension required).

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -9,13 +9,7 @@ universal PostgreSQL queue. Thin wrapper over `pgque-api` SQL functions:
 ## Install
 
 ```bash
-pip install --pre pgque-py
-```
-
-`--pre` is required while v0.2.0 is in release-candidate (the latest published version is `0.2.0rc3`); pip skips prereleases by default. Pin the exact version if you prefer:
-
-```bash
-pip install "pgque-py==0.2.0rc3"
+pip install pgque-py
 ```
 
 Requires Python 3.10+ and PostgreSQL 14+ with the PgQue schema installed

--- a/clients/python/pgque/__init__.py
+++ b/clients/python/pgque/__init__.py
@@ -27,7 +27,7 @@ from .errors import (
 )
 from .types import Event, Message
 
-__version__ = "0.2.0rc2"
+__version__ = "0.2.0"
 
 __all__ = [
     "PgqueClient",

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pgque-py"
-version = "0.2.0rc3"
+version = "0.2.0"
 description = "Python client for PgQue -- PgQ Universal Edition"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -9,13 +9,11 @@ PgQ-based universal PostgreSQL queue. Thin, idiomatic wrapper over the
 ## Install
 
 ```bash
-npm install pgque@rc
-# or: bun add pgque@rc
-# or: pnpm add pgque@rc
-# or: yarn add pgque@rc
+npm install pgque
+# or: bun add pgque
+# or: pnpm add pgque
+# or: yarn add pgque
 ```
-
-The `@rc` dist-tag points at the latest v0.2.0 release candidate (currently `0.2.0-rc.3`). Drop the tag once v0.2.0 ships.
 
 Runtime requirements: Node.js 20+ and PostgreSQL 14+ with the PgQue schema
 installed (`\i pgque.sql` — no extension required).

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pgque",
-  "version": "0.2.0-rc.3",
+  "version": "0.2.0",
   "description": "TypeScript client for PgQue — the PgQ-based universal PostgreSQL queue",
   "license": "Apache-2.0",
   "packageManager": "bun@1.3.8",

--- a/sql/pgque-additions/lifecycle.sql
+++ b/sql/pgque-additions/lifecycle.sql
@@ -438,7 +438,7 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 create or replace function pgque.version()
 returns text as $$
 begin
-    return '0.2.0-rc.1';
+    return '0.2.0';
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 

--- a/sql/pgque-tle.sql
+++ b/sql/pgque-tle.sql
@@ -68,8 +68,8 @@ begin
     from pgtle.available_extensions()
     where name = 'pgque';
 
-    if existing_version = '0.2.0-rc.1' then
-        raise notice 'pgque 0.2.0-rc.1 already registered with pg_tle; skipping install_extension().';
+    if existing_version = '0.2.0' then
+        raise notice 'pgque 0.2.0 already registered with pg_tle; skipping install_extension().';
         return;
     end if;
 
@@ -78,16 +78,16 @@ begin
             'but this script registers version %. Run '
             'sql/pgque-tle-uninstall.sql first to remove the existing '
             'registration, then re-run this script.',
-            existing_version, '0.2.0-rc.1';
+            existing_version, '0.2.0';
     end if;
 
     perform pgtle.install_extension(
         'pgque',
-        '0.2.0-rc.1',
+        '0.2.0',
         'PgQue — PgQ Universal Edition (zero-bloat Postgres queue)',
 $pgque_extension_body$
 -- pgque.sql -- PgQ Universal Edition
--- Version: 0.2.0-rc.1
+-- Version: 0.2.0
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 -- Includes code derived from PgQ (ISC license, Marko Kreen / Skype Technologies OU).
 --
@@ -4658,7 +4658,7 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 create or replace function pgque.version()
 returns text as $$
 begin
-    return '0.2.0-rc.1';
+    return '0.2.0';
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
@@ -7135,5 +7135,5 @@ $pgque_extension_body$
 end $wrapper$;
 
 \echo ''
-\echo 'PgQue 0.2.0-rc.1 registered with pg_tle.'
+\echo 'PgQue 0.2.0 registered with pg_tle.'
 \echo 'Run create extension pgque; to materialise the schema in this database.'

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -1,5 +1,5 @@
 -- pgque.sql -- PgQ Universal Edition
--- Version: 0.2.0-rc.1
+-- Version: 0.2.0
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 -- Includes code derived from PgQ (ISC license, Marko Kreen / Skype Technologies OU).
 --
@@ -4570,7 +4570,7 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 create or replace function pgque.version()
 returns text as $$
 begin
-    return '0.2.0-rc.1';
+    return '0.2.0';
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 

--- a/tests/test_pgque_config.sql
+++ b/tests/test_pgque_config.sql
@@ -15,8 +15,8 @@ begin
   end;
 
   -- Version function works
-  assert pgque.version() = '0.2.0-rc.1',
-    'version should be 0.2.0-rc.1, got ' || pgque.version();
+  assert pgque.version() = '0.2.0',
+    'version should be 0.2.0, got ' || pgque.version();
 
   raise notice 'PASS: pgque_config';
 end $$;


### PR DESCRIPTION
## Summary

Prepare the final 0.2.0 GA release:

- bump SQL/TLE `pgque.version()` and generated install headers to `0.2.0`
- bump Python package metadata/import version to `0.2.0`
- bump TypeScript package version to `0.2.0`
- update README/client install commands to final packages (`pip install pgque-py`, `npm install pgque`, `go get ...@v0.2.0`)
- remove release-candidate install wording from user-facing client docs

Issue: #242

## Gates

- `bash build/transform.sh`
- Python `pyproject.toml` version parse: `0.2.0`
- TypeScript `package.json` version parse: `0.2.0`
- grep check: no stale `0.2.0-rc.2`, `0.2.0-rc.3`, `0.2.0rc2`, `0.2.0rc3`, `@rc`, or `--pre` in user-facing install/version files touched here

## Known remaining blocker before publish

Go release automation still needs the mirror credential fixed. The rc3 publish workflow failed with 403 when pushing `NikolayS/pgque-go`; this PR does not solve that secret/permission issue.
