### PR TITLE
docs: remove stale rc version from upgrading guide

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -32,7 +32,7 @@ After upgrading, verify the installed version:
 
 ```sql
 select pgque.version();
--- 0.2.0-rc.1, or the exact release you installed
+-- 0.2.0, or the exact release you installed
 ```
 
 You can also run the idempotency smoke test from the repository:


### PR DESCRIPTION
## Summary

Remove the stale `0.2.0-rc.1` example from the upgrading guide after the `0.2.0` GA release.

## Gates

- direct diff inspection
