### PR TITLE
ci: allow Go release dry-run for existing tags

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -58,6 +58,7 @@ jobs:
           echo "mirror commit: $split_sha"
 
       - name: Check public mirror tag does not exist
+        if: ${{ !inputs.dry_run }}
         run: |
           set -Eeuo pipefail
           remote="https://github.com/${MIRROR_REPO}.git"


### PR DESCRIPTION
## Summary

Allow the Go release workflow dry-run to validate an already-published version.

Before this, `dry_run=true` still failed if the mirror tag already existed, which makes post-release validation for `v0.2.0` impossible. Real publish still refuses existing tags in the publish job.

## Gates

- `git diff --check`
