### PR TITLE
docs: clarify PGMQ fan-out comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ See [docs/three-latencies.md](docs/three-latencies.md) for the breakdown, tick-c
 | No external daemon or worker binary | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
 | Pure SQL install, managed Postgres ready | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Language-agnostic SQL API | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
-| Multiple independent consumers (fan-out) | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| Shared-log fan-out: each consumer sees every event | ✅ | ✅ | ❌ | ❌ | ❌ | ⚠️ |
 | Built-in retry with backoff | ✅ | ✅ | ⚠️ | ✅ | ✅ | ✅ |
 | Built-in dead letter queue | ✅ | ❌ | ⚠️ | ⚠️ | ❌ | ✅ |
 
@@ -111,6 +111,7 @@ See [docs/three-latencies.md](docs/three-latencies.md) for the breakdown, tick-c
 - **No external daemon:** PgQue uses pg_cron (or your own scheduler) for ticking; PGMQ uses visibility timeouts. River, Que, and pg-boss require a Go / Ruby / Node.js worker binary.
 - **[Que](https://github.com/que-rb/que)** uses advisory locks (not SKIP LOCKED) — no dead tuples from *claiming*, but completed jobs are still DELETEd. Brandur's [bloat post](https://brandur.org/postgres-queues) was about Que at Heroku. Ruby-only.
 - **PGMQ retry** is visibility-timeout re-delivery (`read_ct` tracking) — no configurable backoff or max attempts.
+- **PGMQ consumers:** PGMQ supports multiple producers and multiple competing consumers/workers. The `❌` in the fan-out row means it does not provide PgQ-style independent consumer cursors where every registered consumer receives every event from a shared log.
 - **pg-boss fan-out** is copy-per-queue `publish()`/`subscribe()`, not a shared event log with independent cursors.
 - **Category:** River, Que, and pg-boss (and Oban, graphile-worker, solid_queue, good_job) are **job queue frameworks**. PgQue is an **event/message queue** optimized for high-throughput streaming with fan-out.
 


### PR DESCRIPTION
## Summary

Clarify the README comparison row for PGMQ consumers.

The old row said `Multiple independent consumers (fan-out)` with PGMQ marked `❌`, which was easy to read as "PGMQ cannot have multiple consumers". That is not what we meant and is false.

This changes the row to the narrower claim:

- shared-log fan-out: each consumer sees every event

And adds a note that PGMQ supports multiple producers and competing consumers/workers; the `❌` only means it does not provide PgQ-style independent consumer cursors on a shared event log.

## Testing

- `git diff --check`
