### PR TITLE
fix: make get_queue_info reader-callable

### DIFF
--- a/build/transform.sh
+++ b/build/transform.sh
@@ -607,6 +607,31 @@ END {
 
 echo "PASS: get_batch_cursor SECURITY header injected (extra_where is trusted SQL)"
 
+# Promote get_queue_info() / get_queue_info(text) to SECURITY DEFINER.
+# Upstream PgQ ships these as SECURITY INVOKER, but get_queue_info(text)
+# internally calls pgque.seq_getval(text), whose ACL is admin-only. Both
+# overloads are granted to pgque_reader and documented as reader-usable
+# monitoring functions, so a reader session would hit
+#   ERROR: permission denied for function seq_getval
+# at runtime. The sibling get_consumer_info / get_batch_info are already
+# SECURITY DEFINER for exactly this reason; mirror that pattern here.
+# SECURITY DEFINER MUST pin search_path (CLAUDE.md), so attach
+# "set search_path = pgque, pg_catalog" in the same step. This grants no
+# privilege beyond reading queue metadata + the queue event sequence.
+GET_QUEUE_INFO_FILE="${OUTPUT_DIR}/functions/pgque.get_queue_info.sql"
+sedi -E \
+  's/^(\$\$ language plpgsql);$/\1 security definer set search_path = pgque, pg_catalog;/' \
+  "${GET_QUEUE_INFO_FILE}"
+
+defcount=$(grep -c 'language plpgsql security definer set search_path = pgque, pg_catalog;' \
+  "${GET_QUEUE_INFO_FILE}")
+if [[ "${defcount}" -ne 2 ]]; then
+  echo "ERROR: expected 2 SECURITY DEFINER get_queue_info overloads, got ${defcount}" >&2
+  exit 1
+fi
+
+echo "PASS: get_queue_info promoted to SECURITY DEFINER (reader-safe seq_getval)"
+
 # -- Assembly: build sql/pgque.sql ------------------------------------
 
 echo ""

--- a/sql/pgque-tle.sql
+++ b/sql/pgque-tle.sql
@@ -2656,7 +2656,7 @@ begin
     end loop;
     return;
 end;
-$$ language plpgsql;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
 create or replace function pgque.get_queue_info(
     in i_queue_name                 text,
@@ -2737,7 +2737,7 @@ begin
     end loop;
     return;
 end;
-$$ language plpgsql;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
 
 create or replace function pgque.get_consumer_info(

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -2568,7 +2568,7 @@ begin
     end loop;
     return;
 end;
-$$ language plpgsql;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
 create or replace function pgque.get_queue_info(
     in i_queue_name                 text,
@@ -2649,7 +2649,7 @@ begin
     end loop;
     return;
 end;
-$$ language plpgsql;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
 
 create or replace function pgque.get_consumer_info(

--- a/tests/run_all.sql
+++ b/tests/run_all.sql
@@ -118,6 +118,9 @@
 \echo 'Running: test_e2e_role_split'
 \i tests/test_e2e_role_split.sql
 
+\echo 'Running: test_get_queue_info_reader'
+\i tests/test_get_queue_info_reader.sql
+
 \echo 'Running: test_cooperative_consumers'
 \i tests/test_cooperative_consumers.sql
 

--- a/tests/test_get_queue_info_reader.sql
+++ b/tests/test_get_queue_info_reader.sql
@@ -1,0 +1,57 @@
+-- test_get_queue_info_reader.sql -- pgque_reader can call get_queue_info
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- get_queue_info() and get_queue_info(text) are granted to pgque_reader and
+-- documented as reader-usable monitoring functions. They internally call
+-- pgque.seq_getval(text), whose ACL is admin-only, so a SECURITY INVOKER
+-- get_queue_info fails at runtime for a reader with:
+--   ERROR: permission denied for function seq_getval
+-- This pins the fix: get_queue_info must be callable by pgque_reader, the
+-- exact role it is granted to. See
+-- https://github.com/NikolayS/pgque/issues/265
+
+\set ON_ERROR_STOP on
+
+-- Idempotent preamble.
+do $$ begin
+  if exists (select 1 from pgque.queue where queue_name = 'gqi_reader_q') then
+    perform pgque.drop_queue('gqi_reader_q', true);
+  end if;
+end $$;
+
+select pgque.create_queue('gqi_reader_q');
+
+-- A tick must exist so the function exercises the seq_getval() code path.
+select pgque.subscribe('gqi_reader_q', 'gqi_consumer');
+select pgque.send('gqi_reader_q', 'gqi.msg', '{"n":1}'::jsonb);
+select pgque.ticker();
+
+-- Exercise both overloads under the role they are granted to.
+set role pgque_reader;
+
+do $$
+declare
+  v_count integer;
+  v_name  text;
+  v_ev    bigint;
+begin
+  -- get_queue_info(text): the overload that calls seq_getval().
+  select queue_name, ev_new
+    into v_name, v_ev
+    from pgque.get_queue_info('gqi_reader_q');
+  assert v_name = 'gqi_reader_q', 'get_queue_info(text) must return the queue row';
+  assert v_ev is not null, 'get_queue_info(text) ev_new must be populated';
+  raise notice 'PASS: pgque_reader can call get_queue_info(text), ev_new=%', v_ev;
+
+  -- get_queue_info(): the zero-arg overload fans out to the text overload.
+  select count(*) into v_count from pgque.get_queue_info();
+  assert v_count >= 1, 'get_queue_info() must return at least the one queue';
+  raise notice 'PASS: pgque_reader can call get_queue_info(), rows=%', v_count;
+end $$;
+
+reset role;
+
+-- Cleanup.
+select pgque.drop_queue('gqi_reader_q', true);
+
+\echo 'PASS: test_get_queue_info_reader'


### PR DESCRIPTION
## Bug

`pgque.get_queue_info()` and `pgque.get_queue_info(text)` are granted to `pgque_reader` and documented in `docs/reference.md` / `docs/monitoring.md` as reader-usable monitoring functions, but a `pgque_reader` session fails at runtime:

```
ERROR:  permission denied for function seq_getval
CONTEXT:  PL/pgSQL function pgque.get_queue_info(text) line 58 at assignment
PL/pgSQL function pgque.get_queue_info() line 26 at FOR over SELECT rows
```

## Root cause

`get_queue_info` is inherited from upstream PgQ as `SECURITY INVOKER`. The 1-arg overload internally calls `pgque.seq_getval(text)` to compute `ev_new`, and that helper's ACL is admin-only (`{postgres, pgque_admin}`). A reader therefore cannot execute it. The sibling functions `get_consumer_info` and `get_batch_info` are `SECURITY DEFINER` for exactly this reason and work fine for readers — `get_queue_info` was the odd one out.

## Fix

Promote both `get_queue_info` overloads to `SECURITY DEFINER` with `SET search_path = pgque, pg_catalog` (mandatory for all `SECURITY DEFINER` per CLAUDE.md), mirroring the existing `get_consumer_info` / `get_batch_info` pattern. This grants no privilege beyond reading queue metadata plus the queue event sequence — the same surface the function already exposes to its (intended) readers.

- Patch added to `build/transform.sh` (the source of truth for the generated installs), with a guard asserting exactly 2 overloads are promoted.
- Regenerated `sql/pgque.sql` and `sql/pgque-tle.sql` so generated and source stay consistent. Rebuild is reproducible (re-running `transform.sh` yields no diff).

Audited the other reader-granted observability functions for the same trap: only `get_queue_info` calls `seq_getval` under `SECURITY INVOKER`. `get_batch_info` / `get_consumer_info` are already DEFINER; `status()` is admin-only by design and left as-is.

## Test (red/green TDD)

New regression `tests/test_get_queue_info_reader.sql` (registered in `tests/run_all.sql`) creates a queue, ticks it, then under `set role pgque_reader` calls both overloads and asserts success + populated `ev_new`.

- Against pre-fix SQL: fails with `permission denied for function seq_getval` (verified).
- Against the fix: passes. Full `tests/run_all.sql` suite passes on PostgreSQL 18.

## Manual verification

```sql
select pgque.create_queue('bug_q');
set role pgque_reader;
select count(*) from pgque.get_queue_info();        -- was: permission denied; now: succeeds
select queue_name, ev_new from pgque.get_queue_info('bug_q');
reset role;
```

Fixes https://github.com/NikolayS/pgque/issues/265
