### PR TITLE
docs: cooperative-consumer guide + reuse death-spiral figure

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -37,9 +37,31 @@ That two-snapshot diff is the whole trick. To assemble a batch, PgQue does not s
 
 One consequence follows directly: a producer's insert and the tick that should pick it up must commit in separate transactions. An event inserted in the same transaction as the tick is still in progress at snapshot time, so it is not yet visible and is excluded from that batch. Conversely, `receive` → process → `ack` belongs in one transaction when you want exactly-once side effects on the same database. The shipped Go and TypeScript clients satisfy the producer-side rule transparently because each call runs in its own implicit transaction; the Python client needs an explicit commit between `send` and the consumer side. See [examples.md](examples.md) for the transactional pattern.
 
+## Cooperative consumers vs fan-out
+
+> **Experimental in PgQue 0.2.** The cooperative-consumer API ships in the default install but is marked experimental; treat it as subject to change.
+
+PgQue offers two different consumer shapes on top of the same shared log. They are easy to confuse because both involve "several workers on one queue", but they distribute events in opposite ways.
+
+**Native fan-out** is the default. Every registered consumer keeps its own cursor (`sub_last_tick`) and independently sees *every* event. Three consumers — say `audit`, `email`, `analytics` — each receive a full copy of the stream from their own point of view, advancing at their own pace. The event is stored once; there is no per-consumer copy. This is the right model when distinct subsystems each need all the events.
+
+**Cooperative consumers** invert that within a single consumer. One logical consumer (the cooperative *main*, `sub_role = 'coop_main'`) owns a single cursor, and a pool of *subconsumers* (`sub_role = 'coop_member'`) draw *different* batches from it. Each event is delivered to exactly one subconsumer in the pool — competing consumers sharing one fan-out cursor. This is the right model when you want to spread one subscriber's workload across a horizontally scaled pool of identical workers.
+
+The two compose: a queue can have several independent fan-out consumers, and any one of them can be a cooperative group with its own pool of subconsumers underneath.
+
+- **Use fan-out** when every consumer needs every event (different subsystems, different side effects).
+- **Use cooperative consumers** when one subscriber's events should be split across interchangeable workers for throughput, and a given event must be handled once within that pool.
+
+See [examples](examples.md#cooperative-consumers-experimental) for the cooperative recipe and [reference](reference.md#cooperative-consumers--subconsumers) for signatures.
+
 ## Why zero bloat
 
 A `SKIP LOCKED` queue stores work as rows that are inserted, locked, processed, and deleted. Every processed job leaves a dead tuple behind, and the table relies on `VACUUM` to reclaim that space. That is fine until something holds the xmin horizon — a long-running transaction, a stalled replica, a forgotten `REPEATABLE READ` session — at which point `VACUUM` cannot reclaim anything newer than the held xmin, dead tuples pile up, and the hot table bloats.
+
+<figure>
+  <img src="/images/death_spiral.gif" alt="Side-by-side run from the xmin-horizon benchmark: under a held xmin horizon a SKIP LOCKED queue's event-table dead tuples climb steeply while PgQue's stay flat at zero">
+  <figcaption>Event-table dead tuples under a held xmin horizon, from the committed <code>benchmark/xmin-horizon/</code> run: the <code>SKIP LOCKED</code> queue accumulates dead tuples it cannot vacuum, while PgQue stays flat at zero.</figcaption>
+</figure>
 
 PgQue's hot path never deletes a row. Events accumulate in the active child table; old events are reclaimed by rotation, not by `VACUUM`. Each queue is three child tables under a parent (using table **inheritance**, `INHERITS`, not declarative partitioning). When the rotation period elapses, the ticker advances to the next child and `TRUNCATE`s the one it is reusing. `TRUNCATE` drops the whole table's storage at once and leaves no dead tuples to vacuum. Inheritance is used rather than native partitioning precisely because a cheap, per-table `TRUNCATE`-and-reuse cycle is exactly what rotation needs.
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -111,7 +111,8 @@ Per-system notes:
 
 - **[PgQ](https://github.com/pgq/pgq)** is the Skype-era engine PgQue derives from — same snapshot/rotation architecture, but it requires a C extension and the external `pgqd` daemon, neither available on managed Postgres. PgQue removes both.
 - **PGMQ** retry is visibility-timeout re-delivery (`read_ct` tracking), without configurable backoff or a max-attempts cap.
-- **[Que](https://github.com/que-rb/que)** uses advisory locks rather than `SKIP LOCKED` — so claiming creates no dead tuples — but completed jobs are still `DELETE`d, which does. Ruby-only.
+- **River** is a Go background-job framework on Postgres: it claims jobs with `SKIP LOCKED` and `DELETE`s completed jobs, so its job table accumulates dead tuples under sustained load, and it needs a long-running Go worker process. Competing-consumers over a job table, not a shared log with independent cursors.
+- **Que** uses advisory locks rather than `SKIP LOCKED` — so claiming creates no dead tuples — but completed jobs are still `DELETE`d, which does. Ruby-only.
 - **pg-boss** fan-out is copy-per-queue (`publish()`/`subscribe()` inserts one row per subscriber per event), not a shared log with independent cursors.
 - **Category:** River, Que, and pg-boss are job-queue frameworks (per-job lifecycle, a worker binary in Go/Ruby/Node.js). PgQue is an event/message queue — a shared log with fan-out, closer to a Kafka topic.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -39,6 +39,85 @@ Result: all three `receive` calls return the same event, each through its own cu
 
 Late-subscriber caveat: `subscribe` (which calls `register_consumer`) starts the consumer at the most recent tick. A consumer will not see events that were sent before it subscribed. Subscribe each consumer before you start producing.
 
+## Cooperative consumers (experimental)
+
+> **Experimental in PgQue 0.2.** The cooperative-consumer functions ship in the default install but are marked experimental: names, edge-case behavior, and the client API may change before they are stable. Use idempotent handlers and test stale-worker takeover before relying on this as the only path for critical work.
+
+Goal: split *one* subscriber's events across a pool of competing workers, so each event is handled by exactly one worker in the pool — without giving up PgQue's shared-log model.
+
+Native fan-out gives every registered consumer its own cursor over the whole log, so every consumer sees every event (see [Fan-out](#fan-out--many-consumers-one-shared-log)). Cooperative consumers are the opposite split: one logical consumer (`workers`) owns a single cursor, and several *subconsumers* (`w1`, `w2`, …) draw *different* batches from it. Each event is delivered to one subconsumer, not all of them — competing consumers inside a single fan-out cursor. See [concepts](concepts.md#cooperative-consumers-vs-fan-out) for when to pick which.
+
+Register the group, then send and tick as usual:
+
+```sql
+-- a tick must already exist before registering (register starts at the latest tick)
+select pgque.force_next_tick('demo');  -- separate transaction; skip if pg_cron ticks
+select pgque.ticker('demo');           -- separate transaction; skip if pg_cron ticks
+
+-- register the cooperative group before producing, so the workers' shared
+-- cursor starts ahead of the events you are about to send
+select pgque.register_subconsumer('demo', 'workers', 'w1');
+select pgque.register_subconsumer('demo', 'workers', 'w2');
+```
+
+`register_subconsumer(queue, consumer, subconsumer)` creates the `workers` main cursor on first call and a member row per subconsumer. You can skip it entirely: `receive_coop()` auto-registers a missing consumer or subconsumer on the fly, so a cold worker can call `receive_coop()` directly. Register explicitly only when you need to control *when* the cursor starts, or to convert an existing normal consumer (`register_subconsumer(..., convert_normal => true)`).
+
+Now each worker polls with `receive_coop()`. Successive calls hand out successive batches:
+
+```sql
+-- worker w1 (its own process / connection)
+select msg_id, batch_id, payload
+from pgque.receive_coop('demo', 'workers', 'w1', 100);
+
+-- worker w2 (a different process / connection)
+select msg_id, batch_id, payload
+from pgque.receive_coop('demo', 'workers', 'w2', 100);
+```
+
+Result (two batches of three events, one tick apart):
+
+```
+ msg_id | batch_id | payload
+--------+----------+----------
+   2002 |        3 | {"n": 1}     -- w1 gets batch 3
+   2003 |        3 | {"n": 2}
+   2004 |        3 | {"n": 3}
+
+ msg_id | batch_id | payload
+--------+----------+----------
+   4006 |        4 | {"n": 4}     -- w2 gets batch 4
+   4007 |        4 | {"n": 5}
+   4008 |        4 | {"n": 6}
+```
+
+w1 and w2 drew *different* slices of the same `(demo, workers)` subscriber — no event went to both. Ack each batch under whichever worker received it, exactly as with normal `receive` / `ack`:
+
+```sql
+select pgque.ack(3);  -- w1's batch
+select pgque.ack(4);  -- w2's batch
+```
+
+Keep idle subconsumers alive and remove them when a worker shuts down:
+
+```sql
+-- heartbeat: mark a subconsumer live without opening a batch (lets stale-worker
+-- takeover via receive_coop's dead_interval leave healthy workers alone)
+select pgque.touch_subconsumer('demo', 'workers', 'w1');
+
+-- remove a subconsumer that has no open batch
+select pgque.unregister_subconsumer('demo', 'workers', 'w2');
+```
+
+Gotchas (each verified against a live install):
+
+- **A subconsumer with an open (un-acked) batch refuses to unregister.** `unregister_subconsumer` raises unless you pass `batch_handling => 1`, which routes the in-flight messages through the queue's retry/DLQ policy first.
+- **Normal `receive` / `next_batch` raise on cooperative rows.** Calling `pgque.receive('demo', 'workers', …)` on the cooperative main errors with `… is a cooperative main consumer; use cooperative receive/next_batch with a subconsumer`. Member rows are reachable only through `receive_coop()` / cooperative `next_batch()`.
+- **`finish_batch` (and `ack`) reject a `coop_main` batch.** Acks apply to the member-owned batch the subconsumer received, never to the group cursor directly.
+- **Empty tick windows are auto-finished.** When a poll lands on a tick window with no events, `receive_coop()` finishes it internally and returns no rows and no `batch_id` — unlike `receive()`, which still hands back an empty batch token to ack.
+- **One hot row.** Batch hand-out serializes on a `FOR UPDATE` of the `workers` main row, so many workers polling tiny batches contend. If you scale the pool, raise `ticker_max_count` / tick cadence so each batch is big enough to amortize the lock.
+
+`pgque.get_consumer_info('demo')` lists the group as `workers` (the main cursor) and each member as `workers.w1`, `workers.w2`. Full signatures are in the [reference](reference.md#cooperative-consumers--subconsumers).
+
 ## Exactly-once processing
 
 Goal: process a message and commit your business writes such that the message is never lost and never applied twice.


### PR DESCRIPTION
## What

Closes the cooperative-consumer documentation gap (reference covered them, but nothing explained how to *use* them) and reuses one README figure in the docs.

### Cooperative consumers
- **`docs/examples.md`** — new recipe "Cooperative consumers (experimental)": a worker pool splitting one subscriber's batches. Covers `register_subconsumer` / auto-registration via `receive_coop`, two subconsumers drawing different batches, `ack` per subconsumer, `touch_subconsumer`, `unregister_subconsumer`, and the gotchas (normal `receive`/`next_batch` raise on coop rows; `finish_batch`/`ack` reject `coop_main`; active-batch unregister needs `batch_handling => 1`; empty windows auto-finished; single hot row). Marked experimental in 0.2.
- **`docs/concepts.md`** — new section "Cooperative consumers vs fan-out": native fan-out (every consumer keeps its own cursor, sees all events) vs cooperative consumers (one cursor split across competing workers), with when-to-use guidance. Marked experimental.

### Image reuse
- Embedded `death_spiral.gif` in the concepts "why zero bloat" section. It depicts SKIP LOCKED dead-tuple growth under a held xmin horizon — **backed** by the committed `benchmark/xmin-horizon/` run. Caption avoids specific unbacked numbers.
- **Skipped** `backlog_race.gif`, `completion_latency.png`, `scaling_linearity.png`: all generated by `benchmark/subconsumer-scaling/`, which ships scripts but **no committed raw results**. Embedding them would reintroduce the unbacked subconsumer-throughput numbers we previously removed.

## Verification
- Ran the cooperative recipe end-to-end on `postgres:17` + `pg_cron` against `\i sql/pgque.sql` (version 0.2.0). Confirmed: two subconsumers split distinct batches of one `(queue, consumer)` subscriber; `ack`/`touch_subconsumer`/`unregister_subconsumer` work; normal `receive` on `coop_main` raises the documented directive; active-batch unregister requires `batch_handling => 1`; members appear as `workers.w1` in `get_consumer_info`. Container torn down afterward.
- Cross-checked every function name/signature/arg against `sql/pgque.sql` and `docs/reference.md`.
- `cd web && npm run build` is green; `death_spiral.gif` renders at `/images/death_spiral.gif` (copied to `dist/images/`), and all new cross-link anchors resolve.

Base is `feat/website` because the docs structure (`concepts.md`, `examples.md`, `latency-and-tuning.md`) and the Astro/Starlight `web/` build live only on that branch, not on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)