### PR TITLE
docs: cover more platforms in pg_cron section

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -199,6 +199,27 @@ preload step. `cron.database_name` is not configurable on this platform, so
 `pg_cron` (and therefore the auto-ticker) only operates in the `defaultdb`
 database; install PgQue there if you want the in-database ticker.
 
+**Crunchy Bridge.** `pg_cron` is preloadable on Bridge; just
+`create extension pg_cron;` in the target database. Set `cron.database_name` if
+you want cron in a non-default database.
+
+**Tiger Data (Tiger Cloud).** Connect as the `tsdbadmin` user and run
+`create extension if not exists pg_cron;`.
+
+**ClickHouse Cloud (Managed Postgres).** Connect and run
+`create extension pg_cron;` — `pg_cron` 1.6 is available, no preload step.
+
+**IBM Cloud Databases for PostgreSQL.** `create extension pg_cron;`, then
+schedule jobs with `cron.schedule()` against the target database.
+
+**Oracle OCI Database with PostgreSQL.** Enable `pg_cron` in a custom database
+configuration (via the OCI Extension Manager in the Console), apply it to the
+database system, then `create extension pg_cron;`. `pg_cron` runs in the
+`postgres` database by default; set `pg_cron.database_name` to target another.
+
+**Ubicloud Managed PostgreSQL.** `create extension pg_cron;` — `pg_cron` 1.6
+ships in the managed image, no preload step.
+
 ### Postgres-compatible platforms
 
 **PlanetScale for Postgres.** Enable `pg_cron` from the dashboard
@@ -213,6 +234,20 @@ single elected `pg_cron` leader; expect a worst-case ~60 s gap on leader
 failover or job changes — acceptable for the rotation ticker.
 
 ### Kubernetes operators
+
+**Zalando postgres-operator.** `pg_cron` ships in the Spilo image but is not
+preloaded by default. Add it to `shared_preload_libraries` in the cluster
+manifest, then `create extension pg_cron;`:
+
+```yaml
+spec:
+  postgresql:
+    parameters:
+      shared_preload_libraries: "bg_mon,pg_stat_statements,pg_cron"
+```
+
+Applying the manifest triggers the restart the `shared_preload_libraries` change
+needs; default DB is `postgres`, or set `cron.database_name`.
 
 **StackGres.** Declare `pg_cron` in the `SGCluster` extensions list (StackGres
 downloads it into the container — no custom image), add


### PR DESCRIPTION
Extends the "Enabling pg_cron on managed platforms" section in `docs/installation.md` to cover newly-added platforms. Each entry uses the documented enablement mechanism plus the shared `create extension`/`pgque.start()` pattern. Where the official docs do not publish an exact `pg_cron` version (Crunchy Bridge, Tiger Data, IBM, Oracle OCI), no version is asserted in prose.

Managed clouds:
- Crunchy Bridge — preloadable, `create extension pg_cron;`
- Tiger Data (Tiger Cloud) — `tsdbadmin` runs `create extension`
- ClickHouse Cloud (Managed Postgres) — `create extension pg_cron;` (1.6)
- IBM Cloud Databases for PostgreSQL — `create extension` + `cron.schedule()`
- Oracle OCI Database with PostgreSQL — enable via custom config / Extension Manager, then `create extension`
- Ubicloud Managed PostgreSQL — `create extension pg_cron;` (1.6)

Kubernetes operators:
- Zalando postgres-operator — add `pg_cron` to `shared_preload_libraries` in the cluster manifest, then `create extension`

Source of truth: evidence comments on issue https://github.com/NikolayS/pgque/issues/270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)