### PR TITLE
fix(go): scan nullable type/payload in receive

### DIFF
--- a/clients/go/message.go
+++ b/clients/go/message.go
@@ -8,6 +8,11 @@ import "time"
 // Message is a single event delivered as part of a batch. The BatchID
 // must be passed to Client.Ack once every message in the batch has
 // been processed.
+//
+// Type and Payload are nullable on the SQL side (PgQ allows NULL
+// ev_type and ev_data); a NULL value is delivered as the empty string.
+// A message with an empty Type has no registered handler, so the
+// Consumer routes it per its UnknownHandlerPolicy.
 type Message struct {
 	MsgID      int64     `json:"msg_id"`
 	BatchID    int64     `json:"batch_id"`

--- a/clients/go/null_event_test.go
+++ b/clients/go/null_event_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+package pgque_test
+
+import (
+	"context"
+	"testing"
+)
+
+// TestReceive_NullTypeAndPayload verifies that a stored event with NULL
+// ev_type and ev_data (legal in PgQ: direct pgque.insert_event calls,
+// trigger-based producers) does not error the whole batch. A scan
+// failure here is a poison-message livelock: the batch is never acked
+// and next_batch redelivers it forever.
+func TestReceive_NullTypeAndPayload(t *testing.T) {
+	client := connectOrSkip(t)
+	defer client.Close()
+	queue, consumer := setupFreshQueue(t, client)
+	ctx := context.Background()
+
+	var evID int64
+	if err := client.Pool().QueryRow(ctx,
+		"select pgque.insert_event($1, null, null)", queue).Scan(&evID); err != nil {
+		t.Fatal("insert_event:", err)
+	}
+	tick(t, client, queue)
+
+	msgs, err := client.Receive(ctx, queue, consumer, 10)
+	if err != nil {
+		t.Fatal("receive with NULL type/payload:", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if msgs[0].MsgID != evID {
+		t.Fatalf("expected msg_id %d, got %d", evID, msgs[0].MsgID)
+	}
+	if msgs[0].Type != "" {
+		t.Fatalf("expected NULL type mapped to empty string, got %q", msgs[0].Type)
+	}
+	if msgs[0].Payload != "" {
+		t.Fatalf("expected NULL payload mapped to empty string, got %q", msgs[0].Payload)
+	}
+
+	// The batch must be ackable so the consumer cursor advances.
+	n, err := client.Ack(ctx, msgs[0].BatchID)
+	if err != nil {
+		t.Fatal("ack:", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected ack row-count 1, got %d", n)
+	}
+}
+
+// TestReceiveCoop_NullTypeAndPayload covers the same NULL-safety for the
+// cooperative-consumer scan path.
+func TestReceiveCoop_NullTypeAndPayload(t *testing.T) {
+	client := connectOrSkip(t)
+	defer client.Close()
+	queue, consumer := setupFreshCoopGroup(t, client)
+	ctx := context.Background()
+
+	if _, err := client.SubscribeSubconsumer(ctx, queue, consumer, "worker-1"); err != nil {
+		t.Fatal("subscribe subconsumer:", err)
+	}
+
+	var evID int64
+	if err := client.Pool().QueryRow(ctx,
+		"select pgque.insert_event($1, null, null)", queue).Scan(&evID); err != nil {
+		t.Fatal("insert_event:", err)
+	}
+	tick(t, client, queue)
+
+	msgs, err := client.ReceiveCoop(ctx, queue, consumer, "worker-1")
+	if err != nil {
+		t.Fatal("receive_coop with NULL type/payload:", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if msgs[0].MsgID != evID {
+		t.Fatalf("expected msg_id %d, got %d", evID, msgs[0].MsgID)
+	}
+	if msgs[0].Type != "" {
+		t.Fatalf("expected NULL type mapped to empty string, got %q", msgs[0].Type)
+	}
+	if msgs[0].Payload != "" {
+		t.Fatalf("expected NULL payload mapped to empty string, got %q", msgs[0].Payload)
+	}
+
+	if _, err := client.Ack(ctx, msgs[0].BatchID); err != nil {
+		t.Fatal("ack:", err)
+	}
+}

--- a/clients/go/pgque.go
+++ b/clients/go/pgque.go
@@ -10,9 +10,40 @@ import (
 	"math"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+// scanMessage scans one pgque.message row into a Message. The SQL type
+// declares type and payload as nullable text -- PgQ legally stores NULL
+// ev_type and ev_data (direct pgque.insert_event calls, trigger-based
+// producers) -- so both are scanned through nullable temporaries and
+// NULL is mapped to "". Scanning NULL directly into string would error
+// the whole batch, leaving it unacked and redelivered forever.
+func scanMessage(rows pgx.Rows) (Message, error) {
+	var (
+		m            Message
+		typ, payload *string
+		createdAt    time.Time
+	)
+	err := rows.Scan(
+		&m.MsgID, &m.BatchID, &typ, &payload,
+		&m.RetryCount, &createdAt,
+		&m.Extra1, &m.Extra2, &m.Extra3, &m.Extra4,
+	)
+	if err != nil {
+		return Message{}, fmt.Errorf("pgque: scan message: %w", err)
+	}
+	if typ != nil {
+		m.Type = *typ
+	}
+	if payload != nil {
+		m.Payload = *payload
+	}
+	m.CreatedAt = createdAt
+	return m, nil
+}
 
 // Client is the PgQue client. It is safe for concurrent use; the
 // underlying pgx pool handles connection multiplexing.
@@ -134,17 +165,10 @@ func (c *Client) Receive(ctx context.Context, queue, consumer string, maxMessage
 
 	var msgs []Message
 	for rows.Next() {
-		var m Message
-		var createdAt time.Time
-		err := rows.Scan(
-			&m.MsgID, &m.BatchID, &m.Type, &m.Payload,
-			&m.RetryCount, &createdAt,
-			&m.Extra1, &m.Extra2, &m.Extra3, &m.Extra4,
-		)
+		m, err := scanMessage(rows)
 		if err != nil {
-			return nil, fmt.Errorf("pgque: scan message: %w", err)
+			return nil, err
 		}
-		m.CreatedAt = createdAt
 		msgs = append(msgs, m)
 	}
 	if err := rows.Err(); err != nil {
@@ -322,17 +346,10 @@ func (c *Client) ReceiveCoop(ctx context.Context, queue, consumer, subconsumer s
 
 	var msgs []Message
 	for rows.Next() {
-		var m Message
-		var createdAt time.Time
-		err := rows.Scan(
-			&m.MsgID, &m.BatchID, &m.Type, &m.Payload,
-			&m.RetryCount, &createdAt,
-			&m.Extra1, &m.Extra2, &m.Extra3, &m.Extra4,
-		)
+		m, err := scanMessage(rows)
 		if err != nil {
-			return nil, fmt.Errorf("pgque: scan message: %w", err)
+			return nil, err
 		}
-		m.CreatedAt = createdAt
 		msgs = append(msgs, m)
 	}
 	if err := rows.Err(); err != nil {


### PR DESCRIPTION
## Bug

`pgque.message.type` and `.payload` are nullable text (`sql/pgque-api/receive.sql`), and PgQ legally stores NULL `ev_type`/`ev_data` (direct `pgque.insert_event` calls, trigger-based producers). The Go client declared `Message.Type` and `Message.Payload` as non-nullable `string` and scanned the columns directly into them in both `Receive` and `ReceiveCoop`.

Scanning a NULL into Go `string` errors (`cannot scan NULL into *string`), which fails the WHOLE batch: `Receive` returns an error, the batch is never acked, and `next_batch` returns the same batch on every poll — a poison-message livelock from a single NULL event.

## Fix

Both scan loops now go through a shared `scanMessage` helper that scans `type`/`payload` into nullable `*string` temporaries and maps NULL to `""`.

Approach rationale (over switching the fields to `*string` like `Extra1..4`):

- The public API is firmly built around plain `string`: consumer handler dispatch is keyed by `msg.Type` (map lookup, string concat in nack reasons), and the documented payload pattern is `json.Unmarshal([]byte(msg.Payload), ...)`. Pointer fields would break every caller for a rare edge case.
- A NULL type maps to `""`, which has no registered handler, so the `Consumer` routes it through the existing unknown-handler policy path (Nack by default, or skip with `AckUnknown`) — no crash, no `consumer.go` changes needed.
- Server-side `pgque.nack` re-queries the canonical event row by `msg_id` from the active batch, so the client-side `NULL -> ""` mapping cannot corrupt retry/DLQ data.

The mapping is documented on the `Message` struct and on `scanMessage`.

## Verification

TDD: the two new integration tests (`clients/go/null_event_test.go`) were written first and confirmed red on unfixed code, failing exactly on the bug:

```
$ PGQUE_TEST_DSN="postgresql:///pgque_gonull?host=/var/run/postgresql" go test -run 'NullTypeAndPayload' -v .
--- FAIL: TestReceive_NullTypeAndPayload
    receive with NULL type/payload: pgque: scan message: can't scan into dest[2] (col: type): cannot scan NULL into *string
--- FAIL: TestReceiveCoop_NullTypeAndPayload
    receive_coop with NULL type/payload: pgque: scan message: can't scan into dest[2] (col: type): cannot scan NULL into *string
```

The tests install an event with NULL type/data via `select pgque.insert_event(queue, null, null)`, tick, then assert `Receive`/`ReceiveCoop` succeed, return the message with `Type == ""` and `Payload == ""`, and the batch is ackable.

After the fix (scratch DB `pgque_gonull`, fresh install of `sql/pgque.sql` on local PostgreSQL 16):

```
$ cd clients/go
$ PGQUE_TEST_DSN="postgresql:///pgque_gonull?host=/var/run/postgresql" go test -run 'NullTypeAndPayload' -v .
--- PASS: TestReceive_NullTypeAndPayload (0.06s)
--- PASS: TestReceiveCoop_NullTypeAndPayload (0.07s)

$ PGQUE_TEST_DSN="postgresql:///pgque_gonull?host=/var/run/postgresql" go test ./...
ok  	github.com/NikolayS/pgque-go	16.089s

$ go vet ./...
(clean)
```

Addresses finding B4 of #283

https://claude.ai/code/session_01KAaEGkQZmey1D1xCsVGmqv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAaEGkQZmey1D1xCsVGmqv)_