### PR TITLE
fix: lock dead_letter rows in dlq_replay

### DIFF
--- a/sql/pgque-additions/dlq.sql
+++ b/sql/pgque-additions/dlq.sql
@@ -119,6 +119,12 @@ end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
 -- pgque.dlq_replay() -- replay a single dead letter event back into the queue
+--
+-- The initial select locks the dead_letter row (`for update of dl`) so that
+-- two concurrent dlq_replay() calls for the same dl_id cannot both pass the
+-- existence check and re-enqueue the event twice. The second caller blocks on
+-- the row lock; after the first commits its delete, the second's select
+-- re-evaluates, finds no row, and raises 'dead letter entry not found'.
 create or replace function pgque.dlq_replay(i_dead_letter_id bigint)
 returns bigint as $$
 declare
@@ -129,7 +135,8 @@ begin
     select dl.*, q.queue_name into v_dl
     from pgque.dead_letter dl
     join pgque.queue q on q.queue_id = dl.dl_queue_id
-    where dl.dl_id = i_dead_letter_id;
+    where dl.dl_id = i_dead_letter_id
+    for update of dl;
 
     if not found then
         raise exception 'dead letter entry not found: %', i_dead_letter_id;
@@ -153,6 +160,13 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 -- warning (visible at the default log_min_messages = warning, unlike notice
 -- which is hidden under many production configs). Callers can check
 -- failed > 0 to detect partial success programmatically.
+--
+-- The loop's select locks each dead_letter row (`for update of dl skip
+-- locked`) before replaying it. `skip locked` (rather than blocking) fits the
+-- replay-everything semantics: a row locked by a concurrent dlq_replay() or
+-- dlq_replay_all() is already being handled by that session, so this call
+-- skips it instead of waiting only to replay it twice (the pre-lock race) or
+-- to count a guaranteed failure.
 --
 -- Return-type change from v0.1's bare integer count to a record is a breaking
 -- API change accepted at the v0.2 cut. Callers previously doing
@@ -180,6 +194,7 @@ begin
         from pgque.dead_letter dl
         join pgque.queue q on q.queue_id = dl.dl_queue_id
         where q.queue_name = i_queue_name
+        for update of dl skip locked
     loop
         begin
             perform pgque.insert_event(v_dl.queue_name, v_dl.ev_type, v_dl.ev_data,

--- a/sql/pgque-tle.sql
+++ b/sql/pgque-tle.sql
@@ -5067,6 +5067,12 @@ end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
 -- pgque.dlq_replay() -- replay a single dead letter event back into the queue
+--
+-- The initial select locks the dead_letter row (`for update of dl`) so that
+-- two concurrent dlq_replay() calls for the same dl_id cannot both pass the
+-- existence check and re-enqueue the event twice. The second caller blocks on
+-- the row lock; after the first commits its delete, the second's select
+-- re-evaluates, finds no row, and raises 'dead letter entry not found'.
 create or replace function pgque.dlq_replay(i_dead_letter_id bigint)
 returns bigint as $$
 declare
@@ -5077,7 +5083,8 @@ begin
     select dl.*, q.queue_name into v_dl
     from pgque.dead_letter dl
     join pgque.queue q on q.queue_id = dl.dl_queue_id
-    where dl.dl_id = i_dead_letter_id;
+    where dl.dl_id = i_dead_letter_id
+    for update of dl;
 
     if not found then
         raise exception 'dead letter entry not found: %', i_dead_letter_id;
@@ -5101,6 +5108,13 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 -- warning (visible at the default log_min_messages = warning, unlike notice
 -- which is hidden under many production configs). Callers can check
 -- failed > 0 to detect partial success programmatically.
+--
+-- The loop's select locks each dead_letter row (`for update of dl skip
+-- locked`) before replaying it. `skip locked` (rather than blocking) fits the
+-- replay-everything semantics: a row locked by a concurrent dlq_replay() or
+-- dlq_replay_all() is already being handled by that session, so this call
+-- skips it instead of waiting only to replay it twice (the pre-lock race) or
+-- to count a guaranteed failure.
 --
 -- Return-type change from v0.1's bare integer count to a record is a breaking
 -- API change accepted at the v0.2 cut. Callers previously doing
@@ -5128,6 +5142,7 @@ begin
         from pgque.dead_letter dl
         join pgque.queue q on q.queue_id = dl.dl_queue_id
         where q.queue_name = i_queue_name
+        for update of dl skip locked
     loop
         begin
             perform pgque.insert_event(v_dl.queue_name, v_dl.ev_type, v_dl.ev_data,

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -4979,6 +4979,12 @@ end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
 -- pgque.dlq_replay() -- replay a single dead letter event back into the queue
+--
+-- The initial select locks the dead_letter row (`for update of dl`) so that
+-- two concurrent dlq_replay() calls for the same dl_id cannot both pass the
+-- existence check and re-enqueue the event twice. The second caller blocks on
+-- the row lock; after the first commits its delete, the second's select
+-- re-evaluates, finds no row, and raises 'dead letter entry not found'.
 create or replace function pgque.dlq_replay(i_dead_letter_id bigint)
 returns bigint as $$
 declare
@@ -4989,7 +4995,8 @@ begin
     select dl.*, q.queue_name into v_dl
     from pgque.dead_letter dl
     join pgque.queue q on q.queue_id = dl.dl_queue_id
-    where dl.dl_id = i_dead_letter_id;
+    where dl.dl_id = i_dead_letter_id
+    for update of dl;
 
     if not found then
         raise exception 'dead letter entry not found: %', i_dead_letter_id;
@@ -5013,6 +5020,13 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 -- warning (visible at the default log_min_messages = warning, unlike notice
 -- which is hidden under many production configs). Callers can check
 -- failed > 0 to detect partial success programmatically.
+--
+-- The loop's select locks each dead_letter row (`for update of dl skip
+-- locked`) before replaying it. `skip locked` (rather than blocking) fits the
+-- replay-everything semantics: a row locked by a concurrent dlq_replay() or
+-- dlq_replay_all() is already being handled by that session, so this call
+-- skips it instead of waiting only to replay it twice (the pre-lock race) or
+-- to count a guaranteed failure.
 --
 -- Return-type change from v0.1's bare integer count to a record is a breaking
 -- API change accepted at the v0.2 cut. Callers previously doing
@@ -5040,6 +5054,7 @@ begin
         from pgque.dead_letter dl
         join pgque.queue q on q.queue_id = dl.dl_queue_id
         where q.queue_name = i_queue_name
+        for update of dl skip locked
     loop
         begin
             perform pgque.insert_event(v_dl.queue_name, v_dl.ev_type, v_dl.ev_data,

--- a/tests/two_session_dlq_replay_race.sh
+++ b/tests/two_session_dlq_replay_race.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Validate dlq_replay() serialization with two real sessions.
+# Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+# Includes code derived from PgQ (ISC license, Marko Kreen / Skype Technologies OU).
+set -Eeuo pipefail
+
+# Usage:
+#   PGQUE_TEST_DSN=postgresql://postgres:***@localhost/pgque_test \
+#     tests/two_session_dlq_replay_race.sh
+#
+# The target database must already have sql/pgque.sql installed. The harness
+# dead-letters one event, then has session 1 call pgque.dlq_replay(dl_id)
+# inside an open transaction (commit delayed by pg_sleep) while session 2
+# calls pgque.dlq_replay(dl_id) for the same id concurrently. With the
+# row lock in dlq_replay, session 2 must block behind session 1's locked
+# dead_letter row, re-evaluate after commit, find the row gone, and raise
+# 'dead letter entry not found'. Pre-fix code fails this harness: session 2's
+# unlocked select still sees the row, so both sessions call insert_event and
+# the event is re-enqueued twice.
+
+if [[ -z "${PGQUE_TEST_DSN:-}" ]]; then
+  echo "PGQUE_TEST_DSN is required" >&2
+  exit 2
+fi
+
+psql_base=(psql --no-psqlrc -v ON_ERROR_STOP=1 "${PGQUE_TEST_DSN}")
+queue_name="two_session_dlq_replay_${$}_$(date +%s)"
+session1_app="pgque_dlq_replay_s1_${$}_$(date +%s)"
+hold_seconds=4
+workdir="$(mktemp -d)"
+cleanup() {
+  "${psql_base[@]}" -qAtc "
+    select pgque.unregister_consumer('${queue_name}', 'c1');
+    select pgque.drop_queue('${queue_name}', true);
+  " >/dev/null 2>&1 || true
+  rm -rf "${workdir}"
+}
+trap cleanup EXIT
+
+cat >"${workdir}/setup.sql" <<SQL
+select pgque.create_queue('${queue_name}');
+select pgque.set_queue_config('${queue_name}', 'max_retries', '0');
+select pgque.register_consumer('${queue_name}', 'c1');
+select pgque.insert_event('${queue_name}', 'dlq.race', '{"n":1}');
+select pgque.force_tick('${queue_name}');
+select pgque.ticker();
+SQL
+
+cat >"${workdir}/dead_letter.sql" <<SQL
+do \$\$
+declare
+  v_msg pgque.message;
+begin
+  select * into v_msg from pgque.receive('${queue_name}', 'c1', 1) limit 1;
+  assert v_msg.msg_id is not null, 'expected one message to dead-letter';
+  perform pgque.nack(v_msg.batch_id, v_msg, '0 seconds'::interval, 'force dlq');
+  perform pgque.ack(v_msg.batch_id);
+end \$\$;
+SQL
+
+"${psql_base[@]}" -f "${workdir}/setup.sql" >/dev/null
+"${psql_base[@]}" -f "${workdir}/dead_letter.sql" >/dev/null
+
+dl_id=$("${psql_base[@]}" -qAtc "
+  select dl.dl_id
+  from pgque.dead_letter dl
+  join pgque.queue q on q.queue_id = dl.dl_queue_id
+  where q.queue_name = '${queue_name}'
+")
+if [[ -z "${dl_id}" ]]; then
+  echo "FAIL: no dead_letter row created during setup" >&2
+  exit 1
+fi
+
+cat >"${workdir}/session1.sql" <<SQL
+begin;
+select 's1_new_eid=' || pgque.dlq_replay(${dl_id});
+select pg_sleep(${hold_seconds});
+commit;
+SQL
+
+cat >"${workdir}/session2.sql" <<SQL
+select 's2_new_eid=' || pgque.dlq_replay(${dl_id});
+SQL
+
+PGAPPNAME="${session1_app}" "${psql_base[@]}" -f "${workdir}/session1.sql" >"${workdir}/session1.out" 2>"${workdir}/session1.err" &
+session1_pid=$!
+
+print_debug() {
+  echo "--- session1.out ---" >&2
+  cat "${workdir}/session1.out" >&2 || true
+  echo "--- session1.err ---" >&2
+  cat "${workdir}/session1.err" >&2 || true
+  echo "--- session2.out ---" >&2
+  cat "${workdir}/session2.out" >&2 || true
+  echo "--- session2.err ---" >&2
+  cat "${workdir}/session2.err" >&2 || true
+}
+
+# Wait until session 1 is visibly inside pg_sleep() with its replay
+# transaction still open (delete of the dead_letter row uncommitted).
+session1_ready=0
+for _ in $(seq 1 50); do
+  if "${psql_base[@]}" -tAc "
+    select 1
+    from pg_stat_activity
+    where application_name = '${session1_app}'
+      and state = 'active'
+      and wait_event_type = 'Timeout'
+      and wait_event = 'PgSleep'
+      and query like 'select pg_sleep(%'
+    limit 1
+  " | grep -q 1; then
+    session1_ready=1
+    break
+  fi
+  sleep 0.2
+done
+if (( session1_ready != 1 )); then
+  echo "FAIL: session1 did not reach pg_sleep() while holding the replay transaction" >&2
+  print_debug
+  exit 1
+fi
+
+set +e
+"${psql_base[@]}" -f "${workdir}/session2.sql" >"${workdir}/session2.out" 2>"${workdir}/session2.err"
+session2_status=$?
+wait "${session1_pid}"
+session1_status=$?
+set -e
+
+if (( session1_status != 0 )); then
+  echo "FAIL: session1 replay failed unexpectedly" >&2
+  print_debug
+  exit 1
+fi
+
+if (( session2_status == 0 )); then
+  echo "FAIL: session2 replay succeeded; expected 'dead letter entry not found' after waiting on session1" >&2
+  print_debug
+  exit 1
+fi
+if ! grep -q "dead letter entry not found: ${dl_id}" "${workdir}/session2.err"; then
+  echo "FAIL: session2 failed with an unexpected error" >&2
+  print_debug
+  exit 1
+fi
+
+# The event must be re-enqueued exactly once (pre-fix code enqueues it twice).
+"${psql_base[@]}" -qAtc "
+  select pgque.force_tick('${queue_name}');
+  select pgque.ticker();
+" >/dev/null
+replayed_count=$("${psql_base[@]}" -qAtc "
+  select count(*)
+  from pgque.receive('${queue_name}', 'c1', 100)
+  where type = 'dlq.race'
+")
+if [[ "${replayed_count}" != "1" ]]; then
+  echo "FAIL: expected exactly 1 replayed event, got ${replayed_count}" >&2
+  print_debug
+  exit 1
+fi
+
+dlq_count=$("${psql_base[@]}" -qAtc "
+  select count(*)
+  from pgque.dead_letter dl
+  join pgque.queue q on q.queue_id = dl.dl_queue_id
+  where q.queue_name = '${queue_name}'
+")
+if [[ "${dlq_count}" != "0" ]]; then
+  echo "FAIL: expected empty DLQ after replay, got ${dlq_count} rows" >&2
+  print_debug
+  exit 1
+fi
+
+echo "PASS: concurrent dlq_replay serialized; second caller got 'dead letter entry not found' and the event was re-enqueued exactly once"


### PR DESCRIPTION
## Bug

`pgque.dlq_replay(i_dead_letter_id)` selected the `pgque.dead_letter` row (joined to `pgque.queue`) without `for update`, then called `pgque.insert_event()`, then deleted the row. Two concurrent `dlq_replay()` calls for the same `dl_id` (the function is granted to `pgque_writer`, so any two writers) could both pass the unlocked select and both call `insert_event()` — the dead-lettered event was re-enqueued **twice**. Both deletes then "succeeded" (the loser's delete removed 0 rows, silently). `pgque.dlq_replay_all()` had the same unlocked-select shape in its loop query.

## Fix

- `dlq_replay()`: the initial select now ends with `for update of dl`, locking only the `dead_letter` row (not the joined `pgque.queue` row). The second concurrent caller blocks on the row lock; after the first transaction commits its delete, the second's select re-evaluates under read committed, finds no row, and the existing `if not found` branch raises the existing error: `dead letter entry not found: <id>`. No behavior change for non-concurrent callers.
- `dlq_replay_all()`: the loop query now uses `for update of dl skip locked`.

**Locking-choice rationale for `dlq_replay_all`:** `skip locked` fits the "replay everything" semantics better than a blocking `for update`. A row locked by a concurrent `dlq_replay()`/`dlq_replay_all()` is already being handled by that session; blocking would only make this call wait so it could either replay the row a second time (the exact race being fixed) or count a guaranteed `not found`-style failure. Skipping leaves the row to its owner; if that owner rolls back, the row is still in the DLQ for the next replay pass.

Error messages, grants, `security definer` + `set search_path = pgque, pg_catalog`, and SQL style are unchanged. Generated files `sql/pgque.sql` and `sql/pgque-tle.sql` are regenerated via `bash build/transform.sh` and committed together with the source change (only the dlq chunk differs).

## TDD / verification

New deterministic two-session harness, following the pattern of `tests/two_session_receive_lock.sh`: `tests/two_session_dlq_replay_race.sh`. Session 1 runs `begin; select pgque.dlq_replay(<dl_id>); pg_sleep(4); commit;`; once session 1 is observed inside `pg_sleep` via `pg_stat_activity`, session 2 calls `pgque.dlq_replay(<dl_id>)` for the same id. The harness then asserts session 2 fails with `dead letter entry not found`, exactly 1 event of the replayed type is received, and the DLQ is empty.

**Red (unfixed code, origin/main install):**

```
$ PGQUE_TEST_DSN=postgresql:///pgque_dlq_oqxpbr tests/two_session_dlq_replay_race.sh
FAIL: session2 replay succeeded; expected 'dead letter entry not found' after waiting on session1
--- session1.out ---
 s1_new_eid=2003
--- session2.out ---
 s2_new_eid=2004
```

Both sessions re-enqueued the same dead letter (two new event ids).

**Green (fixed build, fresh install):**

```
$ psql -d pgque_dlq_oqxpbr -v ON_ERROR_STOP=1 -f sql/pgque.sql   # exit 0
$ PGQUE_TEST_DSN=postgresql:///pgque_dlq_oqxpbr tests/two_session_dlq_replay_race.sh
PASS: concurrent dlq_replay serialized; second caller got 'dead letter entry not found' and the event was re-enqueued exactly once
```

**Full regression suite (fresh DB, fixed build):**

```
$ psql -d pgque_dlq_oqxpbr -v ON_ERROR_STOP=1 -f tests/run_all.sql   # exit 0
153 PASS notices, including test_api_dlq and test_dlq_edge_cases
```

**Generated-file sync:** `bash build/transform.sh` after the source edit; `git status` showed only `sql/pgque-additions/dlq.sql`, `sql/pgque.sql`, `sql/pgque-tle.sql`, and the new test changed; the embedded chunks match the source edit.

Manual verification command for reviewers:

```
createdb pgque_dlq_check
psql -d pgque_dlq_check -v ON_ERROR_STOP=1 -f sql/pgque.sql
PGQUE_TEST_DSN=postgresql:///pgque_dlq_check tests/two_session_dlq_replay_race.sh
psql -d pgque_dlq_check -v ON_ERROR_STOP=1 -f tests/run_all.sql
```

Addresses finding A3 of #283

https://claude.ai/code/session_01KAaEGkQZmey1D1xCsVGmqv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAaEGkQZmey1D1xCsVGmqv)_