### PR TITLE
fix: experimental SQL bugs + CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,22 @@ jobs:
           PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
             -v ON_ERROR_STOP=1 -f tests/run_all.sql
 
+      - name: Run experimental tests
+        run: |
+          # devel/sql/experimental/*.sql is not part of devel/sql/pgque.sql;
+          # install it into a separate database so the steps below keep
+          # testing the default install.
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d postgres \
+            -v ON_ERROR_STOP=1 -c 'create database pgque_experimental'
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_experimental \
+            -v ON_ERROR_STOP=1 \
+            -f devel/sql/pgque.sql \
+            -f devel/sql/experimental/delayed.sql \
+            -f devel/sql/experimental/observability.sql \
+            -f devel/sql/experimental/config_api.sql
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_experimental \
+            -v ON_ERROR_STOP=1 -f tests/run_experimental.sql
+
       - name: Run acceptance tests
         run: |
           PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \

--- a/devel/sql/experimental/config_api.sql
+++ b/devel/sql/experimental/config_api.sql
@@ -11,26 +11,13 @@ declare
 begin
     v_ret := pgque.create_queue(i_queue);
 
+    /*
+     * Route every option through pgque.set_queue_config() so its
+     * per-parameter validation (e.g. max_retries >= 0) always applies.
+     */
     for v_key, v_val in select key, value #>> '{}' from jsonb_each(i_options)
     loop
-        if v_key = 'max_retries' then
-            update pgque.queue
-            set queue_max_retries = v_val::int4
-            where queue_name = i_queue;
-        else
-            perform pgque.set_queue_config(
-                i_queue,
-                case v_key
-                    when 'rotation_period' then 'rotation_period'
-                    when 'ticker_max_count' then 'ticker_max_count'
-                    when 'ticker_max_lag' then 'ticker_max_lag'
-                    when 'ticker_idle_period' then 'ticker_idle_period'
-                    when 'ticker_paused' then 'ticker_paused'
-                    else v_key
-                end,
-                v_val
-            );
-        end if;
+        perform pgque.set_queue_config(i_queue, v_key, v_val);
     end loop;
 
     return v_ret;

--- a/devel/sql/experimental/observability.sql
+++ b/devel/sql/experimental/observability.sql
@@ -322,13 +322,20 @@ returns table (
 ) as $$
 declare
     v_queue_id int4;
+    v_bucket_sec numeric;
 begin
+    if i_bucket_size is null or i_bucket_size <= interval '0' then
+        raise exception 'throughput: bucket size must be > 0, got %', i_bucket_size;
+    end if;
+
     select q.queue_id into v_queue_id
     from pgque.queue q where q.queue_name = i_queue_name;
 
     if not found then
         raise exception 'queue not found: %', i_queue_name;
     end if;
+
+    v_bucket_sec := extract(epoch from i_bucket_size);
 
     return query
     with ticks as (
@@ -342,10 +349,8 @@ begin
     ),
     bucketed as (
         select
-            date_trunc('minute', tk.tick_time)
-                - (extract(minute from date_trunc('minute', tk.tick_time))::int
-                   % (extract(epoch from i_bucket_size)::int / 60))
-                  * interval '1 minute' as bucket,
+            to_timestamp(floor(extract(epoch from tk.tick_time) / v_bucket_sec)
+                         * v_bucket_sec) as bucket,
             sum(coalesce(tk.tick_event_seq - tk.prev_event_seq, 0))::bigint as events
         from ticks tk
         where tk.prev_event_seq is not null
@@ -354,9 +359,7 @@ begin
     select
         b.bucket as bucket_start,
         b.events,
-        case when extract(epoch from i_bucket_size) > 0
-            then b.events::numeric / extract(epoch from i_bucket_size)
-            else 0 end as events_per_sec
+        b.events::numeric / v_bucket_sec as events_per_sec
     from bucketed b
     order by b.bucket;
 end;

--- a/tests/test_experimental_config_api.sql
+++ b/tests/test_experimental_config_api.sql
@@ -25,3 +25,24 @@ begin
   perform pgque.drop_queue('test_opts');
   raise notice 'PASS: experimental config API';
 end $$;
+
+-- Negative max_retries must be rejected with the same error as the
+-- canonical pgque.set_queue_config() path.
+do $$
+begin
+  begin
+    perform pgque.create_queue('test_opts_neg', '{"max_retries": -1}'::jsonb);
+    raise exception 'create_queue should reject negative max_retries';
+  exception
+    when others then
+      if sqlerrm not like '%max_retries must be >= 0%' then
+        raise;
+      end if;
+  end;
+
+  assert not exists (
+    select 1 from pgque.queue where queue_name = 'test_opts_neg'
+  ), 'queue should not exist after rejected create_queue';
+
+  raise notice 'PASS: create_queue rejects negative max_retries';
+end $$;

--- a/tests/test_observability.sql
+++ b/tests/test_observability.sql
@@ -139,6 +139,95 @@ begin
   raise notice 'PASS: error_rate() returns % rows', v_count;
 end $$;
 
+-- Test 9: throughput() with sub-minute bucket size
+do $$
+declare
+  v_row record;
+  v_count int := 0;
+begin
+  for v_row in
+    select * from pgque.throughput('obs_queue', '1 hour'::interval, '30 seconds'::interval)
+  loop
+    v_count := v_count + 1;
+    assert extract(epoch from v_row.bucket_start)::numeric % 30 = 0,
+      'bucket_start should align to 30-second boundaries, got ' || v_row.bucket_start;
+  end loop;
+  assert v_count >= 1, 'throughput(30s) should return at least one bucket';
+  raise notice 'PASS: throughput() handles 30-second buckets (% rows)', v_count;
+end $$;
+
+-- Test 10: throughput() buckets non-minute-multiple sizes correctly
+do $$
+declare
+  v_queue_id int4;
+  v_seq0 bigint;
+  v_anchor timestamptz;
+  v_row record;
+  v_count int := 0;
+begin
+  perform pgque.create_queue('obs_bucket_queue');
+
+  select q.queue_id into v_queue_id
+  from pgque.queue q
+  where q.queue_name = 'obs_bucket_queue';
+
+  select t.tick_event_seq into v_seq0
+  from pgque.tick t
+  where t.tick_queue = v_queue_id
+  order by t.tick_id desc
+  limit 1;
+
+  -- Anchor on a 90-second epoch boundary in the recent past, then insert
+  -- synthetic ticks at known offsets: +10 s and +40 s fall in bucket
+  -- [anchor, anchor+90), +100 s falls in [anchor+90, anchor+180).
+  v_anchor := to_timestamp(
+    floor(extract(epoch from now() - interval '15 minutes') / 90) * 90);
+
+  insert into pgque.tick (tick_queue, tick_id, tick_time, tick_event_seq)
+  values
+    (v_queue_id, 1001, v_anchor + interval '10 seconds', v_seq0),
+    (v_queue_id, 1002, v_anchor + interval '40 seconds', v_seq0 + 100),
+    (v_queue_id, 1003, v_anchor + interval '100 seconds', v_seq0 + 250);
+
+  for v_row in
+    select * from pgque.throughput('obs_bucket_queue', '1 hour'::interval, '90 seconds'::interval)
+  loop
+    v_count := v_count + 1;
+    if v_count = 1 then
+      assert v_row.bucket_start = v_anchor,
+        'first bucket should start at ' || v_anchor || ', got ' || v_row.bucket_start;
+      assert v_row.events = 100,
+        'first bucket should have 100 events, got ' || v_row.events;
+    elsif v_count = 2 then
+      assert v_row.bucket_start = v_anchor + interval '90 seconds',
+        'second bucket should start at ' || (v_anchor + interval '90 seconds')
+          || ', got ' || v_row.bucket_start;
+      assert v_row.events = 150,
+        'second bucket should have 150 events, got ' || v_row.events;
+    end if;
+  end loop;
+  assert v_count = 2, 'throughput(90s) should return 2 buckets, got ' || v_count;
+
+  perform pgque.drop_queue('obs_bucket_queue');
+  raise notice 'PASS: throughput() buckets 90-second intervals from epoch';
+end $$;
+
+-- Test 11: throughput() rejects non-positive bucket size
+do $$
+begin
+  begin
+    perform count(*)
+    from pgque.throughput('obs_queue', '1 hour'::interval, '0 seconds'::interval);
+    raise exception 'throughput() should reject non-positive bucket size';
+  exception
+    when others then
+      if sqlerrm not like '%bucket size must be > 0%' then
+        raise;
+      end if;
+  end;
+  raise notice 'PASS: throughput() rejects non-positive bucket size';
+end $$;
+
 -- Teardown
 do $$ begin
   perform pgque.unregister_consumer('obs_queue', 'obs_consumer');


### PR DESCRIPTION
## Bugs

**A1 (medium) — `pgque.throughput()` division by zero for sub-minute buckets.**
`sql/experimental/observability.sql` aligned buckets with `% (extract(epoch from i_bucket_size)::int / 60)`. Integer division makes the divisor 0 for any bucket size under 60 seconds, so `select * from pgque.throughput('q', '1 hour', '30 seconds')` aborted with `division by zero` whenever ticks existed in the window. Sizes between 60 s and 120 s that are not minute multiples (e.g. `'90 seconds'` → `% 1`) silently collapsed to minute boundaries.

**A2 (low) — `pgque.create_queue(text, jsonb)` accepted negative `max_retries`.**
`sql/experimental/config_api.sql` special-cased `'max_retries'` with a direct `update pgque.queue`, bypassing the `>= 0` validation in `pgque.set_queue_config()`. With `'{"max_retries": -1}'`, the `coalesce(ev_retry,0) >= v_max_retries` check in `pgque.nack()` is always true, so every event dead-letters on first nack. History check: the special case landed in the same commit (8a54a7e) that introduced the validating `set_queue_config()` override, which already accepts `max_retries` — the special case was redundant, never a workaround.

**D2 (low) — experimental SQL had zero CI coverage.**
`tests/run_experimental.sql` was referenced by no workflow, which is exactly how A1/A2 shipped.

## Fixes

- **A1:** compute buckets in epoch seconds — `to_timestamp(floor(extract(epoch from tick_time) / extract(epoch from i_bucket_size)) * ...)` — so any positive interval works; reject `i_bucket_size <= interval '0'` (or null) with a clear exception.
- **A2:** route every option through `pgque.set_queue_config()`, dropping the special case, so negative values are rejected with the canonical error (`max_retries must be >= 0`).
- **D2:** new `Run experimental tests` step in the `test` job of `.github/workflows/ci.yml` (full PG 14–18 matrix): installs `sql/pgque.sql` plus the three `sql/experimental/*.sql` files into a separate `pgque_experimental` database (so the later idempotency/uninstall steps keep testing the default install) and runs `tests/run_experimental.sql`.

Red/green TDD: tests added first and confirmed failing, then the fixes. New tests:
- `tests/test_observability.sql`: throughput with `'30 seconds'` bucket (was: division by zero), exact 90-second bucketing with synthetic ticks (2 buckets, 100/150 events), non-positive bucket size raises.
- `tests/test_experimental_config_api.sql`: `create_queue('q', '{"max_retries": -1}')` raises the canonical error and the queue is not created.

## Verification

Fresh scratch DB, PostgreSQL 16:

```
createdb pgque_exp
psql -d pgque_exp -v ON_ERROR_STOP=1 -f sql/pgque.sql
psql -d pgque_exp -v ON_ERROR_STOP=1 \
  -f sql/experimental/delayed.sql \
  -f sql/experimental/observability.sql \
  -f sql/experimental/config_api.sql
psql -d pgque_exp -v ON_ERROR_STOP=1 -f tests/run_experimental.sql
```

Result (tail):
```
NOTICE:  PASS: throughput() handles 30-second buckets (1 rows)
NOTICE:  PASS: throughput() buckets 90-second intervals from epoch
NOTICE:  PASS: throughput() rejects non-positive bucket size
NOTICE:  PASS: experimental config API
NOTICE:  PASS: create_queue rejects negative max_retries
=== ALL EXPERIMENTAL TESTS PASSED ===
```

Pre-fix run of the same suite failed with `ERROR: division by zero` (test 9) and `ERROR: create_queue should reject negative max_retries` (config test), confirming red before green.

Main suite unaffected — fresh DB:
```
createdb pgque_all
psql -d pgque_all -v ON_ERROR_STOP=1 -f sql/pgque.sql
psql -d pgque_all -v ON_ERROR_STOP=1 -f tests/run_all.sql
```
Result: `=== ALL TESTS PASSED ===` (exit 0).

`sql/experimental/*.sql` is not embedded in the generated `sql/pgque.sql` (verified: no `throughput`/jsonb `create_queue` in it), so no rebuild via `build/transform.sh` was needed.

Addresses findings A1, A2, D2 of #283

https://claude.ai/code/session_01KAaEGkQZmey1D1xCsVGmqv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAaEGkQZmey1D1xCsVGmqv)_