### PR TITLE
fix: harden uninstall paths (stop jobs, narrow guards)

### DIFF
--- a/build/transform.sh
+++ b/build/transform.sh
@@ -1226,8 +1226,10 @@ cat > "${PGTLE_FILE}" << HEADER
 -- After loading this script, the extension is registered with pg_tle and can
 -- be created or dropped via the standard create / drop extension commands.
 --
--- This file is self-contained: it works in psql, GUI tools (DBeaver, etc.),
--- JDBC, libpq-direct callers — anywhere that accepts SQL.
+-- This file is a psql script: it uses backslash meta-commands (\set
+-- ON_ERROR_STOP, \echo), so run it with psql. From other clients (GUI
+-- tools, JDBC, direct libpq), call pgtle.install_extension() directly,
+-- passing the contents of sql/pgque.sql as the extension body.
 --
 -- Prerequisites:
 --   1. pg_tle is installed in this database:

--- a/sql/pgque-additions/lifecycle.sql
+++ b/sql/pgque-additions/lifecycle.sql
@@ -421,6 +421,14 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 create or replace function pgque.uninstall()
 returns void as $$
 begin
+    -- Extension installs (pg_tle) must go through the extension machinery:
+    -- dropping the schema out from under the extension would fail with a
+    -- confusing dependency error ("extension pgque requires it").
+    if exists (select 1 from pg_catalog.pg_extension where extname = 'pgque') then
+        raise exception 'pgque is installed as an extension; run: '
+            'drop extension pgque cascade; (for pg_tle installs, use '
+            'sql/pgque-tle-uninstall.sql to also unregister from pg_tle)';
+    end if;
     -- Stop pg_cron jobs before dropping the schema.
     if exists (select 1 from pg_extension where extname = 'pg_cron') then
         perform pgque.stop();

--- a/sql/pgque-tle-uninstall.sql
+++ b/sql/pgque-tle-uninstall.sql
@@ -1,9 +1,10 @@
 -- pgque-tle-uninstall.sql -- Remove PgQue from pg_tle.
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 --
--- Drops the pgque extension from this database (if installed) and unregisters
--- pgque from pg_tle's catalog. Roles are NOT dropped because they may still
--- be referenced by other databases on the cluster.
+-- Stops scheduler jobs, drops the pgque extension from this database (if
+-- installed), and unregisters pgque from pg_tle's catalog. Roles are NOT
+-- dropped because they may still be referenced by other databases on the
+-- cluster.
 --
 -- Idempotent: safe to re-run.
 --
@@ -12,7 +13,22 @@
 
 \set ON_ERROR_STOP on
 
-drop extension if exists pgque cascade;
+-- Stop scheduler jobs (pg_cron / pg_timetable) before dropping the
+-- extension: scheduler jobs are catalog rows, not dependent objects, so
+-- drop extension alone would leave them behind, failing forever afterwards.
+-- A real stop() failure therefore aborts the uninstall; only "pgque is not
+-- installed" errors are tolerated, keeping the script idempotent.
+do $$
+begin
+    begin
+        perform pgque.stop();
+    exception
+        when undefined_function or invalid_schema_name then
+            -- pgque is not installed (or has no stop()); nothing to stop.
+            null;
+    end;
+    drop extension if exists pgque cascade;
+end $$;
 
 do $$
 begin

--- a/sql/pgque-tle.sql
+++ b/sql/pgque-tle.sql
@@ -8,8 +8,10 @@
 -- After loading this script, the extension is registered with pg_tle and can
 -- be created or dropped via the standard create / drop extension commands.
 --
--- This file is self-contained: it works in psql, GUI tools (DBeaver, etc.),
--- JDBC, libpq-direct callers — anywhere that accepts SQL.
+-- This file is a psql script: it uses backslash meta-commands (\set
+-- ON_ERROR_STOP, \echo), so run it with psql. From other clients (GUI
+-- tools, JDBC, direct libpq), call pgtle.install_extension() directly,
+-- passing the contents of sql/pgque.sql as the extension body.
 --
 -- Prerequisites:
 --   1. pg_tle is installed in this database:

--- a/sql/pgque-tle.sql
+++ b/sql/pgque-tle.sql
@@ -4641,6 +4641,14 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 create or replace function pgque.uninstall()
 returns void as $$
 begin
+    -- Extension installs (pg_tle) must go through the extension machinery:
+    -- dropping the schema out from under the extension would fail with a
+    -- confusing dependency error ("extension pgque requires it").
+    if exists (select 1 from pg_catalog.pg_extension where extname = 'pgque') then
+        raise exception 'pgque is installed as an extension; run: '
+            'drop extension pgque cascade; (for pg_tle installs, use '
+            'sql/pgque-tle-uninstall.sql to also unregister from pg_tle)';
+    end if;
     -- Stop pg_cron jobs before dropping the schema.
     if exists (select 1 from pg_extension where extname = 'pg_cron') then
         perform pgque.stop();

--- a/sql/pgque.sql
+++ b/sql/pgque.sql
@@ -4553,6 +4553,14 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 create or replace function pgque.uninstall()
 returns void as $$
 begin
+    -- Extension installs (pg_tle) must go through the extension machinery:
+    -- dropping the schema out from under the extension would fail with a
+    -- confusing dependency error ("extension pgque requires it").
+    if exists (select 1 from pg_catalog.pg_extension where extname = 'pgque') then
+        raise exception 'pgque is installed as an extension; run: '
+            'drop extension pgque cascade; (for pg_tle installs, use '
+            'sql/pgque-tle-uninstall.sql to also unregister from pg_tle)';
+    end if;
     -- Stop pg_cron jobs before dropping the schema.
     if exists (select 1 from pg_extension where extname = 'pg_cron') then
         perform pgque.stop();

--- a/sql/pgque_uninstall.sql
+++ b/sql/pgque_uninstall.sql
@@ -1,13 +1,23 @@
 -- pgque_uninstall.sql -- Remove pgque from database
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- Stops scheduler jobs (pg_cron / pg_timetable) before dropping the schema:
+-- scheduler jobs are catalog rows, not dependent objects, so dropping the
+-- schema alone would leave them behind, failing forever afterwards. A real
+-- stop() failure therefore aborts the uninstall; only "pgque is not
+-- installed" errors are tolerated, keeping the script idempotent.
 
-do $$ begin
-    perform pgque.stop();
-exception when others then
-    null;
+do $$
+begin
+    begin
+        perform pgque.stop();
+    exception
+        when undefined_function or invalid_schema_name then
+            -- pgque is not installed (or has no stop()); nothing to stop.
+            null;
+    end;
+    drop schema if exists pgque cascade;
 end $$;
-
-drop schema if exists pgque cascade;
 
 -- Roles are database-global and may be shared across databases.
 -- Do not drop them automatically here.

--- a/tests/run_all.sql
+++ b/tests/run_all.sql
@@ -136,5 +136,8 @@
 \echo 'Running: test_legacy_next_batch_role_guard'
 \i tests/test_legacy_next_batch_role_guard.sql
 
+\echo 'Running: test_uninstall_guard'
+\i tests/test_uninstall_guard.sql
+
 \echo ''
 \echo '=== ALL TESTS PASSED ==='

--- a/tests/test_tle_install.sql
+++ b/tests/test_tle_install.sql
@@ -102,6 +102,29 @@ end $$;
 -- regression and acceptance suites running against the pg_tle install path
 -- in CI; nothing extra to assert here.
 
+-- pgque.uninstall() must refuse extension installs with a clear pointer to
+-- drop extension, instead of failing on the schema drop with a confusing
+-- dependency error ("extension pgque requires it").
+do $$
+begin
+    begin
+        perform pgque.uninstall();
+        raise exception 'sentinel: pgque.uninstall() did not raise';
+    exception
+        when raise_exception then
+            if sqlerrm like 'sentinel:%' then
+                raise;
+            end if;
+            assert sqlerrm like '%drop extension pgque cascade%',
+                format('uninstall() error must point to drop extension, got: %s', sqlerrm);
+    end;
+    assert exists (select 1 from pg_catalog.pg_namespace where nspname = 'pgque'),
+        'pgque schema must survive the refused uninstall()';
+    assert exists (select 1 from pg_catalog.pg_extension where extname = 'pgque'),
+        'pgque extension must survive the refused uninstall()';
+    raise notice 'PASS: uninstall() refuses extension install, points to drop extension';
+end $$;
+
 -- drop extension cascade removes the schema and the extension membership.
 drop extension pgque cascade;
 

--- a/tests/test_uninstall_guard.sql
+++ b/tests/test_uninstall_guard.sql
@@ -1,0 +1,94 @@
+-- test_uninstall_guard.sql -- Uninstall scripts must stop scheduler jobs first
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- Scheduler jobs (pg_cron, pg_timetable) are catalog rows, not dependent
+-- objects: dropping the pgque schema or extension does not remove them, so
+-- both uninstall scripts must call pgque.stop() before dropping, and a real
+-- stop() failure must abort the uninstall instead of being swallowed.
+--
+-- These tests swap pgque.stop() for instrumented fakes; the real definition
+-- is saved first and restored at the end, so the rest of the suite is
+-- unaffected. Runs without pg_cron / pg_tle.
+--
+-- Run from the repo root: the \i commands below resolve relative to cwd.
+
+-- Save the real pgque.stop() so it can be restored at the end.
+create table pg_temp.saved_stop as
+select pg_catalog.pg_get_functiondef('pgque.stop()'::pg_catalog.regprocedure) as def;
+
+-- Test 1 (C6): a real pgque.stop() failure must abort sql/pgque_uninstall.sql
+-- before the schema drop (no silent "when others" swallowing).
+create or replace function pgque.stop()
+returns void as $$
+begin
+    raise exception 'simulated stop() failure (test_uninstall_guard)';
+end;
+$$ language plpgsql;
+
+\set ON_ERROR_STOP off
+\i sql/pgque_uninstall.sql
+\set ON_ERROR_STOP on
+
+do $$
+begin
+    assert exists (select 1 from pg_catalog.pg_namespace where nspname = 'pgque'),
+        'pgque schema must survive when pgque.stop() raises during uninstall';
+    raise notice 'PASS: pgque_uninstall.sql aborts before drop when stop() fails';
+end $$;
+
+-- Test 2 (C4): sql/pgque-tle-uninstall.sql must call pgque.stop() before
+-- drop extension, so pg_cron / pg_timetable jobs do not outlive the schema.
+create table pg_temp.tle_stop_called (called bool);
+
+create or replace function pgque.stop()
+returns void as $$
+begin
+    insert into pg_temp.tle_stop_called values (true);
+end;
+$$ language plpgsql;
+
+\i sql/pgque-tle-uninstall.sql
+
+do $$
+begin
+    assert exists (select 1 from pg_temp.tle_stop_called),
+        'pgque-tle-uninstall.sql must call pgque.stop() before drop extension';
+    assert exists (select 1 from pg_catalog.pg_namespace where nspname = 'pgque'),
+        'plain (non-extension) install must survive the TLE uninstall script';
+    raise notice 'PASS: pgque-tle-uninstall.sql calls stop() before drop extension';
+end $$;
+
+-- Test 3 (C4/C6): a real stop() failure must abort the TLE uninstall script
+-- before drop extension as well.
+create or replace function pgque.stop()
+returns void as $$
+begin
+    raise exception 'simulated stop() failure (test_uninstall_guard)';
+end;
+$$ language plpgsql;
+
+\set ON_ERROR_STOP off
+\i sql/pgque-tle-uninstall.sql
+\set ON_ERROR_STOP on
+
+do $$
+begin
+    assert exists (select 1 from pg_catalog.pg_namespace where nspname = 'pgque'),
+        'pgque schema must survive when stop() raises during TLE uninstall';
+    raise notice 'PASS: pgque-tle-uninstall.sql aborts before drop when stop() fails';
+end $$;
+
+-- Restore the real pgque.stop() and verify the restoration.
+do $$
+declare
+    v_def text;
+begin
+    select def into v_def from pg_temp.saved_stop;
+    execute v_def;
+    assert pg_catalog.pg_get_functiondef('pgque.stop()'::pg_catalog.regprocedure) = v_def,
+        'pgque.stop() must be restored to its original definition';
+    raise notice 'PASS: original pgque.stop() restored';
+end $$;
+
+drop table pg_temp.saved_stop;
+drop table pg_temp.tle_stop_called;

--- a/tests/test_uninstall_guard.sql
+++ b/tests/test_uninstall_guard.sql
@@ -8,7 +8,8 @@
 --
 -- These tests swap pgque.stop() for instrumented fakes; the real definition
 -- is saved first and restored at the end, so the rest of the suite is
--- unaffected. Runs without pg_cron / pg_tle.
+-- unaffected. Runs without pg_cron / pg_tle. The TLE uninstall sub-tests
+-- only run against a plain (non-extension) install; see the gate below.
 --
 -- Run from the repo root: the \i commands below resolve relative to cwd.
 
@@ -35,6 +36,21 @@ begin
         'pgque schema must survive when pgque.stop() raises during uninstall';
     raise notice 'PASS: pgque_uninstall.sql aborts before drop when stop() fails';
 end $$;
+
+-- Tests 2 and 3 execute sql/pgque-tle-uninstall.sql, which (correctly)
+-- drops the pgque extension -- taking the whole schema with it -- and
+-- unregisters pgque from pg_tle. Against an extension install (the pg_tle
+-- CI job) that would destroy the install mid-suite, so the script must not
+-- run at all there: skip both sub-tests. The extension path of the script
+-- is covered by tests/test_tle_install.sql.
+select exists (select 1 from pg_catalog.pg_extension where extname = 'pgque') as pgque_is_extension
+\gset
+
+\if :pgque_is_extension
+
+\echo 'SKIP: pgque is installed as an extension; TLE uninstall sub-tests need a plain install'
+
+\else
 
 -- Test 2 (C4): sql/pgque-tle-uninstall.sql must call pgque.stop() before
 -- drop extension, so pg_cron / pg_timetable jobs do not outlive the schema.
@@ -78,6 +94,10 @@ begin
     raise notice 'PASS: pgque-tle-uninstall.sql aborts before drop when stop() fails';
 end $$;
 
+drop table pg_temp.tle_stop_called;
+
+\endif
+
 -- Restore the real pgque.stop() and verify the restoration.
 do $$
 declare
@@ -91,4 +111,3 @@ begin
 end $$;
 
 drop table pg_temp.saved_stop;
-drop table pg_temp.tle_stop_called;


### PR DESCRIPTION
## Bugs

Four uninstall-path findings from #283:

- **C4 (medium):** `sql/pgque-tle-uninstall.sql` ran `drop extension if exists pgque cascade` without calling `pgque.stop()` first. pg_cron / pg_timetable jobs are catalog rows, not dependent objects, so `pgque_ticker` (every 1 s), `pgque_retry_events`, `pgque_maint`, and `pgque_rotate_step2` survived the drop and failed every 1–30 s forever ("schema pgque does not exist"), spamming logs and `cron.job_run_details`.
- **C6 (low):** `sql/pgque_uninstall.sql` wrapped `pgque.stop()` in `exception when others then null`, silently swallowing real failures (e.g. `cron.unschedule` permission errors, the "untrusted pg_timetable schema owner" exception) and dropping the schema anyway — same orphaned-jobs outcome, but silent.
- **C7 (low):** the generated `sql/pgque-tle.sql` header claimed the file "works in psql, GUI tools (DBeaver, etc.), JDBC, libpq-direct callers", but the script uses `\set ON_ERROR_STOP` and `\echo` psql meta-commands, so any non-psql client fails on the first one.
- **C9 (low):** `pgque.uninstall()` ran `drop schema pgque cascade`, which fails on extension (pg_tle) installs with a confusing dependency error ("extension pgque requires it").

## Fixes

- **C4:** `sql/pgque-tle-uninstall.sql` now calls `pgque.stop()` before `drop extension`, with the drop in the same `do` block, so a real `stop()` failure aborts the uninstall before anything is dropped.
- **C6:** both uninstall scripts narrow the handler to `undefined_function` / `invalid_schema_name` — empirically the sqlstates raised when pgque is not installed (42883 / 3F000) — keeping the scripts idempotent without swallowing real `stop()` failures. `sql/pgque_uninstall.sql` also performs the drop inside the same `do` block, so abort-before-drop holds regardless of client `ON_ERROR_STOP` settings.
- **C7:** the header (generated by `build/transform.sh`) now states the file is a psql script and points non-psql callers at `pgtle.install_extension()` with the `sql/pgque.sql` body. `ON_ERROR_STOP` behavior is kept.
- **C9:** `pgque.uninstall()` detects `pg_extension` membership first and raises a clear exception pointing to `drop extension pgque cascade` / `sql/pgque-tle-uninstall.sql`.

`sql/pgque.sql` and `sql/pgque-tle.sql` regenerated via `bash build/transform.sh` in the commits that touch sources.

## Tests (red/green TDD)

- New `tests/test_uninstall_guard.sql` (added to `tests/run_all.sql`): swaps `pgque.stop()` for instrumented fakes (real definition saved and restored), asserting (1) a raising `stop()` aborts `sql/pgque_uninstall.sql` before the schema drop, (2) `sql/pgque-tle-uninstall.sql` calls `pgque.stop()`, (3) a raising `stop()` aborts the TLE script too. Test (1) failed (schema dropped) and test (2) failed (stop never called) at origin/main; all pass after the fix. Runs without pg_cron / pg_tle.
- New assertion in `tests/test_tle_install.sql` (pg_tle CI job): `pgque.uninstall()` on an extension install must raise an error pointing to `drop extension pgque cascade`, leaving schema and extension intact.

## Verification (local PG 16, fresh scratch DBs)

```
# sqlstate probe for the narrowed handler (basis for C6 fix)
perform pgque.stop()  -- no pgque schema     -> 3F000 invalid_schema_name
perform pgque.stop()  -- schema, no function -> 42883 undefined_function

# red phase at origin/main scripts
psql -d pgque_uninst_red -f tests/test_uninstall_guard.sql
-> ERROR: pgque schema must survive when pgque.stop() raises during uninstall (exit 3)

# green phase after fix
psql -d pgque_uninst_red -v ON_ERROR_STOP=1 -f tests/test_uninstall_guard.sql
-> 4x PASS, exit 0

# C4/C6 idempotency matrix
psql -d <plain-install-db> -v ON_ERROR_STOP=1 -f sql/pgque-tle-uninstall.sql  -> exit 0, schema untouched
psql -d <empty-db> -v ON_ERROR_STOP=1 -f sql/pgque-tle-uninstall.sql          -> exit 0 (run twice, idempotent)
psql -d <plain-install-db> -v ON_ERROR_STOP=1 -f sql/pgque_uninstall.sql      -> exit 0, schema gone
psql -d <same-db> -v ON_ERROR_STOP=1 -f sql/pgque_uninstall.sql               -> exit 0 (idempotent rerun)

# C9: plain uninstall() still works
psql -d <plain-install-db> -c 'select pgque.uninstall();'  -> schema dropped, notice printed

# full suite on a fresh DB at HEAD
createdb pgque_uninst_full
psql -d pgque_uninst_full -v ON_ERROR_STOP=1 -f sql/pgque.sql
psql -d pgque_uninst_full -v ON_ERROR_STOP=1 -f tests/run_all.sql
-> === ALL TESTS PASSED === (157 PASS notices, exit 0)

# generated-file drift check
bash build/transform.sh && git diff --exit-code -- sql/pgque.sql sql/pgque-tle.sql  -> clean
```

pg_tle / pg_cron are not installed locally; the TLE-specific C9 assertion runs in the dedicated pg_tle CI job, and the new guard tests degrade cleanly without either extension.

Addresses findings C4, C6, C7, C9 of #283

https://claude.ai/code/session_01KAaEGkQZmey1D1xCsVGmqv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAaEGkQZmey1D1xCsVGmqv)_