### PR TITLE
fix(python): consumer loop drain, error survival, dead Event.extra

### DIFF
--- a/clients/python/pgque/consumer.py
+++ b/clients/python/pgque/consumer.py
@@ -158,10 +158,19 @@ class Consumer:
                 )
 
                 while self._running:
-                    self._poll_once(conn)
+                    processed = self._poll_once(conn)
 
                     if not self._running:
                         break
+
+                    if processed:
+                        # Non-empty batch: more batches may already be
+                        # ticked (backlog). Their notifies fired while
+                        # we were not listening, so waiting for a new
+                        # NOTIFY would drain the backlog at one batch
+                        # per poll_interval. Re-poll immediately until
+                        # the queue comes back empty.
+                        continue
 
                     # Wait for NOTIFY or poll_interval timeout in short
                     # bounded slices. psycopg's conn.notifies() can
@@ -228,8 +237,13 @@ class Consumer:
                     pass
                 return
 
-    def _poll_once(self, conn: psycopg.Connection) -> None:
+    def _poll_once(self, conn: psycopg.Connection) -> bool:
         """Receive one batch and dispatch messages.
+
+        Returns True when a non-empty batch was processed and acked
+        (the caller should re-poll immediately to drain any backlog),
+        False when the queue was empty or the batch was left unacked
+        for redelivery (the caller should wait for NOTIFY/timeout).
 
         If any per-message ``nack()`` raises, all remaining messages in
         the batch are still dispatched (their handlers run), but the
@@ -256,7 +270,7 @@ class Consumer:
                 )
 
             if not msgs:
-                return
+                return False
 
             batch_id = msgs[0].batch_id
             logger.debug(
@@ -318,8 +332,10 @@ class Consumer:
                         continue
 
             if nack_failed:
-                # Do NOT ack -- redeliver on next poll.
-                return
+                # Do NOT ack -- redeliver on next poll. Report False so
+                # the caller waits before re-polling instead of
+                # redelivering the same batch in a hot loop.
+                return False
 
             # pgque.ack returns 1 on success, 0 if the batch was already
             # finished or not found (stale/double ack, cross-consumer
@@ -331,3 +347,5 @@ class Consumer:
                     "(batch already finished or not found)",
                     batch_id,
                 )
+
+            return True

--- a/clients/python/pgque/consumer.py
+++ b/clients/python/pgque/consumer.py
@@ -15,6 +15,7 @@ import psycopg
 from psycopg import sql
 
 from .client import PgqueClient
+from .errors import PgqueError
 from .types import Message
 
 logger = logging.getLogger("pgque")
@@ -124,6 +125,11 @@ class Consumer:
         Opens its own connection, subscribes to LISTEN, and polls for
         batches. Each batch is processed and acked in a single
         transaction.
+
+        Database errors (failover, restart, network blip) do not kill
+        the loop: the consumer logs the error, waits ``poll_interval``,
+        reconnects, and resumes. Only ``stop()`` / SIGTERM / SIGINT end
+        the loop.
         """
         self._running = True
 
@@ -146,47 +152,83 @@ class Consumer:
             signal.signal(signal.SIGINT, _stop)
 
         try:
-            with psycopg.connect(self.dsn, autocommit=True) as conn:
-                # Subscribe for wakeup notifications
-                channel = f"pgque_{self.queue}"
-                conn.execute(sql.SQL("LISTEN {}").format(sql.Identifier(channel)))
-                logger.info(
-                    "consumer %s listening on %s (poll=%ds)",
-                    self.name,
-                    self.queue,
-                    self.poll_interval,
-                )
-
-                while self._running:
-                    processed = self._poll_once(conn)
-
+            while self._running:
+                # Each session owns one connection. Any database error
+                # (connect failure, receive/ack failure, dead socket in
+                # the LISTEN wait) lands here: log it, wait, reconnect.
+                # Handler exceptions and nack failures never reach this
+                # point -- they are contained inside _poll_once.
+                # KeyboardInterrupt is a BaseException and propagates.
+                try:
+                    self._run_session()
+                except (psycopg.Error, PgqueError):
                     if not self._running:
                         break
-
-                    if processed:
-                        # Non-empty batch: more batches may already be
-                        # ticked (backlog). Their notifies fired while
-                        # we were not listening, so waiting for a new
-                        # NOTIFY would drain the backlog at one batch
-                        # per poll_interval. Re-poll immediately until
-                        # the queue comes back empty.
-                        continue
-
-                    # Wait for NOTIFY or poll_interval timeout in short
-                    # bounded slices. psycopg's conn.notifies() can
-                    # block uninterruptibly for the full timeout, which
-                    # makes stop() slow and can miss prompt wakeups.
-                    # Polling the underlying socket with
-                    # select() lets us re-check _running every SLICE
-                    # seconds and drain any pending NOTIFY immediately.
-                    self._wait_for_notify_or_stop(conn)
-
+                    logger.exception(
+                        "consumer %s: database error; retrying in %ds",
+                        self.name,
+                        self.poll_interval,
+                    )
+                    self._sleep_before_reconnect()
         finally:
             if in_main_thread:
                 signal.signal(signal.SIGTERM, original_sigterm)
                 signal.signal(signal.SIGINT, original_sigint)
 
         logger.info("consumer %s stopped", self.name)
+
+    def _run_session(self) -> None:
+        """Connect, LISTEN, and poll until ``stop()`` or a database error.
+
+        Database errors propagate to ``start()``, which closes the
+        connection (via the ``with`` block here) and reconnects after a
+        ``poll_interval`` wait.
+        """
+        with psycopg.connect(self.dsn, autocommit=True) as conn:
+            # Subscribe for wakeup notifications
+            channel = f"pgque_{self.queue}"
+            conn.execute(sql.SQL("LISTEN {}").format(sql.Identifier(channel)))
+            logger.info(
+                "consumer %s listening on %s (poll=%ds)",
+                self.name,
+                self.queue,
+                self.poll_interval,
+            )
+
+            while self._running:
+                processed = self._poll_once(conn)
+
+                if not self._running:
+                    break
+
+                if processed:
+                    # Non-empty batch: more batches may already be
+                    # ticked (backlog). Their notifies fired while
+                    # we were not listening, so waiting for a new
+                    # NOTIFY would drain the backlog at one batch
+                    # per poll_interval. Re-poll immediately until
+                    # the queue comes back empty.
+                    continue
+
+                # Wait for NOTIFY or poll_interval timeout in short
+                # bounded slices. psycopg's conn.notifies() can
+                # block uninterruptibly for the full timeout, which
+                # makes stop() slow and can miss prompt wakeups.
+                # Polling the underlying socket with
+                # select() lets us re-check _running every SLICE
+                # seconds and drain any pending NOTIFY immediately.
+                self._wait_for_notify_or_stop(conn)
+
+    def _sleep_before_reconnect(self) -> None:
+        """Wait ``poll_interval`` before reconnecting, in short slices
+        so ``stop()`` is observed within ~SLICE seconds.
+        """
+        deadline = time.monotonic() + self.poll_interval
+        while self._running:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            time.sleep(min(_WAIT_SLICE_SECONDS, remaining))
 
     def stop(self) -> None:
         """Request graceful shutdown (safe to call from another thread)."""

--- a/clients/python/pgque/types.py
+++ b/clients/python/pgque/types.py
@@ -4,7 +4,7 @@
 
 """Message and Event types for pgque."""
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Optional
 
@@ -46,4 +46,3 @@ class Event:
 
     payload: Any
     type: str = "default"
-    extra: dict[str, str] = field(default_factory=dict)

--- a/clients/python/tests/test_consumer_resilience.py
+++ b/clients/python/tests/test_consumer_resilience.py
@@ -1,0 +1,79 @@
+# Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+"""Consumer poll-loop resilience.
+
+Backlog draining: after a non-empty batch, the consumer must re-poll
+immediately instead of waiting up to ``poll_interval`` for a NOTIFY.
+Notifies fire only on new ticks, and notifies for already-accumulated
+batches were emitted while the consumer was not listening -- waiting
+on them drains a backlog at one batch per ``poll_interval``.
+"""
+
+import threading
+import time
+
+import pgque
+
+
+def _start_in_thread(consumer: pgque.Consumer) -> threading.Thread:
+    t = threading.Thread(target=consumer.start, daemon=True)
+    t.start()
+    return t
+
+
+def _send_and_tick(conn, client, queue: str, payload, type: str) -> int:
+    """Send one event and make it visible in its own batch."""
+    msg_id = client.send(queue, payload, type=type)
+    conn.commit()
+    conn.execute("select pgque.force_next_tick(%s)", (queue,))
+    conn.execute("select pgque.ticker(%s)", (queue,))
+    conn.commit()
+    return msg_id
+
+
+def test_consumer_drains_backlog_within_one_poll_interval(
+    dsn, conn, setup_queue
+):
+    """With several batches pre-accumulated, all of them must be
+    consumed well within one ``poll_interval``.
+
+    Each send+tick cycle below produces a separate PgQ batch, so the
+    consumer needs one receive per message. A consumer that waits for
+    a NOTIFY after every batch would drain this backlog at one batch
+    per ``poll_interval`` (30s here) and only deliver the first
+    message before the assertion deadline.
+    """
+    queue, consumer_name = setup_queue
+    client = pgque.PgqueClient(conn)
+
+    n_batches = 3
+    for i in range(n_batches):
+        _send_and_tick(conn, client, queue, {"i": i}, "evt.backlog")
+
+    seen: list = []
+    all_seen = threading.Event()
+
+    cons = pgque.Consumer(
+        dsn=dsn, queue=queue, name=consumer_name, poll_interval=30
+    )
+
+    @cons.on("evt.backlog")
+    def _h(m: pgque.Message):
+        seen.append(m.payload)
+        if len(seen) >= n_batches:
+            all_seen.set()
+
+    t0 = time.monotonic()
+    t = _start_in_thread(cons)
+    try:
+        drained = all_seen.wait(timeout=10.0)
+        elapsed = time.monotonic() - t0
+    finally:
+        cons.stop()
+        t.join(timeout=5.0)
+
+    assert drained, (
+        f"backlog not drained: {len(seen)}/{n_batches} messages in "
+        f"{elapsed:.1f}s -- consumer waited for NOTIFY between batches"
+    )
+    assert elapsed < 10.0

--- a/clients/python/tests/test_consumer_resilience.py
+++ b/clients/python/tests/test_consumer_resilience.py
@@ -2,17 +2,32 @@
 
 """Consumer poll-loop resilience.
 
-Backlog draining: after a non-empty batch, the consumer must re-poll
-immediately instead of waiting up to ``poll_interval`` for a NOTIFY.
-Notifies fire only on new ticks, and notifies for already-accumulated
-batches were emitted while the consumer was not listening -- waiting
-on them drains a backlog at one batch per ``poll_interval``.
+Covers two contracts of ``Consumer.start()``:
+
+  1. Backlog draining: after a non-empty batch, the consumer must
+     re-poll immediately instead of waiting up to ``poll_interval``
+     for a NOTIFY. Notifies fire only on new ticks, and notifies for
+     already-accumulated batches were emitted while the consumer was
+     not listening -- waiting on them drains a backlog at one batch
+     per ``poll_interval``.
+  2. Error survival: a transient database error (failover, restart,
+     network blip) must not kill the loop. ``start()`` documents
+     "blocks until SIGTERM/SIGINT"; it must log, wait, reconnect,
+     and resume.
 """
 
+import json
 import threading
 import time
 
+from psycopg import conninfo
+
 import pgque
+
+
+def _as_dicts(payloads: list) -> list:
+    """Normalize received payloads (jsonb decodes to dict, text stays str)."""
+    return [p if isinstance(p, dict) else json.loads(p) for p in payloads]
 
 
 def _start_in_thread(consumer: pgque.Consumer) -> threading.Thread:
@@ -77,3 +92,157 @@ def test_consumer_drains_backlog_within_one_poll_interval(
         f"{elapsed:.1f}s -- consumer waited for NOTIFY between batches"
     )
     assert elapsed < 10.0
+
+
+def test_consumer_survives_transient_receive_error(dsn, conn, setup_queue):
+    """A single failing receive must not kill ``start()``.
+
+    The first receive raises a (simulated) transient database error;
+    the consumer must log it, wait, reconnect, and process the message
+    on a later poll.
+    """
+    queue, consumer_name = setup_queue
+    client = pgque.PgqueClient(conn)
+    _send_and_tick(conn, client, queue, {"x": 1}, "evt.recover")
+
+    real_receive = pgque.PgqueClient.receive
+    calls = {"n": 0}
+
+    def flaky_receive(self, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise pgque.PgqueError("simulated transient failure")
+        return real_receive(self, *args, **kwargs)
+
+    pgque.PgqueClient.receive = flaky_receive  # type: ignore[method-assign]
+
+    seen: list = []
+    got_msg = threading.Event()
+
+    cons = pgque.Consumer(
+        dsn=dsn, queue=queue, name=consumer_name, poll_interval=1
+    )
+
+    @cons.on("evt.recover")
+    def _h(m: pgque.Message):
+        seen.append(m.payload)
+        got_msg.set()
+
+    t = _start_in_thread(cons)
+    try:
+        recovered = got_msg.wait(timeout=10.0)
+        assert t.is_alive(), (
+            "consumer thread died after a transient receive error"
+        )
+    finally:
+        pgque.PgqueClient.receive = real_receive  # type: ignore[method-assign]
+        cons.stop()
+        t.join(timeout=5.0)
+
+    assert calls["n"] >= 2, "receive was not retried after the error"
+    assert recovered, (
+        "message was not processed after the transient error; "
+        "consumer did not recover"
+    )
+    assert _as_dicts(seen) == [{"x": 1}]
+
+
+def test_consumer_survives_killed_backend(dsn, conn, setup_queue):
+    """Terminating the consumer's server backend (what the consumer
+    sees during a DB restart or failover) must not kill ``start()``.
+    The consumer must reconnect, re-LISTEN, and resume consuming.
+    """
+    queue, consumer_name = setup_queue
+    client = pgque.PgqueClient(conn)
+
+    app_name = f"pgque_kill_{consumer_name[-12:]}"
+    cons_dsn = conninfo.make_conninfo(dsn, application_name=app_name)
+
+    seen: list = []
+    got_msg = threading.Event()
+
+    cons = pgque.Consumer(
+        dsn=cons_dsn, queue=queue, name=consumer_name, poll_interval=1
+    )
+
+    @cons.on("evt.restart")
+    def _h(m: pgque.Message):
+        seen.append(m.payload)
+        got_msg.set()
+
+    t = _start_in_thread(cons)
+    try:
+        # Let the consumer connect and enter the LISTEN wait.
+        time.sleep(1.0)
+
+        killed = conn.execute(
+            "select count(pg_terminate_backend(pid)) "
+            "from pg_stat_activity "
+            "where application_name = %s and pid <> pg_backend_pid()",
+            (app_name,),
+        ).fetchone()[0]
+        conn.commit()
+        assert killed >= 1, "did not find the consumer backend to kill"
+
+        # Give the consumer time to notice the dead connection and
+        # reconnect (it waits poll_interval=1s between attempts).
+        time.sleep(2.5)
+        assert t.is_alive(), (
+            "consumer thread died after its backend was terminated"
+        )
+
+        # Produce after the kill: only a reconnected consumer sees this.
+        _send_and_tick(conn, client, queue, {"r": 1}, "evt.restart")
+        conn.execute(f"notify pgque_{queue}, 'go'")
+        conn.commit()
+
+        recovered = got_msg.wait(timeout=10.0)
+    finally:
+        cons.stop()
+        t.join(timeout=5.0)
+
+    assert recovered, (
+        "message was not processed after backend termination; "
+        "consumer did not reconnect"
+    )
+    assert _as_dicts(seen) == [{"r": 1}]
+
+
+def test_consumer_stop_is_prompt_during_error_retry_wait(dsn, setup_queue):
+    """While waiting to retry after a database error, the consumer
+    must (a) still be running and (b) honor ``stop()`` promptly.
+    """
+    queue, consumer_name = setup_queue
+
+    real_receive = pgque.PgqueClient.receive
+
+    def always_failing_receive(self, *args, **kwargs):
+        raise pgque.PgqueError("simulated persistent failure")
+
+    pgque.PgqueClient.receive = always_failing_receive  # type: ignore[method-assign]
+
+    cons = pgque.Consumer(
+        dsn=dsn, queue=queue, name=consumer_name, poll_interval=30
+    )
+    t = _start_in_thread(cons)
+    try:
+        time.sleep(1.5)
+        # The loop must survive the persistent error (it is inside the
+        # retry wait at this point, not dead).
+        assert t.is_alive(), (
+            "consumer thread died on a database error instead of retrying"
+        )
+
+        t0 = time.monotonic()
+        cons.stop()
+        t.join(timeout=5.0)
+        elapsed = time.monotonic() - t0
+    finally:
+        pgque.PgqueClient.receive = real_receive  # type: ignore[method-assign]
+        cons.stop()
+        t.join(timeout=5.0)
+
+    assert not t.is_alive(), "consumer did not stop during error retry wait"
+    assert elapsed < 2.0, (
+        f"stop() took {elapsed:.2f}s during error retry wait; expected <2s"
+    )

--- a/clients/python/tests/test_send.py
+++ b/clients/python/tests/test_send.py
@@ -31,6 +31,17 @@ def test_send_event_object(conn, setup_queue):
     assert isinstance(eid, int)
 
 
+def test_event_rejects_extra_kwarg():
+    """``Event`` must not accept an ``extra`` field.
+
+    ``send()`` never transmitted it (the SQL ``pgque.send`` overloads
+    carry only queue, type, and payload), so accepting the kwarg
+    silently dropped user data. Constructing with it must fail loudly.
+    """
+    with pytest.raises(TypeError):
+        pgque.Event(payload={"x": 1}, type="t", extra={"k": "v"})
+
+
 def test_send_str_payload_passes_through(conn, setup_queue):
     queue, _ = setup_queue
     client = pgque.PgqueClient(conn)


### PR DESCRIPTION
## Bugs

**B2 (medium) — backlog drained at one batch per `poll_interval`.**
`Consumer.start()` unconditionally ran `_poll_once(conn)` then `_wait_for_notify_or_stop(conn)`. After a non-empty batch the consumer still waited up to `poll_interval` (default 30s) for a NOTIFY — but notifies fire only on new ticks, and the notifies for accumulated batches were emitted while the consumer was not listening. A consumer that was down with N batches accumulated drained them at ~1 batch per `poll_interval` and could never catch up.

**B3 (medium) — a transient SQL error killed the consumer.**
There was no try/except around the poll iteration, so a transient error from receive or ack (failover, restart, network blip) propagated out of `start()` and the consumer died, contradicting the documented "blocks until SIGTERM/SIGINT" contract. Nack failures were already handled, making this an oversight.

**B5 (low) — `Event.extra` was silently dropped.**
`pgque/types.py` declared `Event.extra: dict[str, str]`, but `client.send()` unpacks only `type` and `payload`; `extra` was referenced nowhere. Data placed there was silently lost.

## Fixes

- **B2:** `_poll_once` now returns whether it processed a batch; the loop re-polls immediately after a non-empty batch and only waits for NOTIFY/timeout when the queue came back empty (matches the Go consumer). A batch left unacked due to a nack failure reports `False`, so redelivery waits a poll cycle instead of hot-looping.
- **B3:** `start()` now wraps each connection session: on `psycopg.Error` / `PgqueError` it logs, sleeps `poll_interval` in short slices (so `stop()` stays prompt), reconnects, re-`LISTEN`s, and resumes — paralleling the Go consumer's log-and-retry on receive errors. `KeyboardInterrupt` (BaseException) and `stop()` semantics are unchanged; handler exceptions and nack failures remain contained inside `_poll_once`.
- **B5:** I checked the SQL surface first: the `pgque.send` overloads are `(queue, payload)` and `(queue, type, payload)` only — no `ev_extra1..4` parameters (those exist only on the PgQ primitive `pgque.insert_event(7)`), and a `dict[str, str]` has no natural mapping to four positional extra columns anyway. So there is no natural wiring through `pgque.send`; the dead field is removed. A never-working field that silently loses data is worse than a removed field — construction with `extra=` now fails loudly with `TypeError`.

All three fixes were done red/green: each new test was verified failing against the unfixed code, then turned green by the fix (separate commits per finding).

## New tests (`clients/python/tests/`)

- `test_consumer_drains_backlog_within_one_poll_interval` — 3 pre-accumulated batches, `poll_interval=30`; all must be consumed within 10s. Red on old code: `1/3 messages in 10.0s`.
- `test_consumer_survives_transient_receive_error` — first receive raises, consumer must recover and process the message.
- `test_consumer_survives_killed_backend` — `pg_terminate_backend` on the consumer's session (what a DB restart/failover looks like to the client); consumer must reconnect, re-LISTEN, and consume an event produced after the kill.
- `test_consumer_stop_is_prompt_during_error_retry_wait` — persistent receive failure with `poll_interval=30`; thread must stay alive and `stop()` must return in <2s.
- `test_event_rejects_extra_kwarg` — `Event(..., extra={...})` raises `TypeError`.

## Verification

Against a fresh scratch database (PostgreSQL 16, `sql/pgque.sql` installed via `psql -f`):

```
$ createdb pgque_pyconsumer
$ psql -d pgque_pyconsumer -v ON_ERROR_STOP=1 -q -f sql/pgque.sql
$ pip install -e 'clients/python[dev]'
$ cd clients/python
$ PGQUE_TEST_DSN="postgresql:///pgque_pyconsumer" python -m pytest tests/ -q
76 passed in 49.68s
```

Red-state evidence before each fix:
- B2: `FAILED tests/test_consumer_resilience.py::test_consumer_drains_backlog_within_one_poll_interval — AssertionError: backlog not drained: 1/3 messages in 10.0s`
- B3: `3 failed, 1 passed` (`test_consumer_survives_transient_receive_error`, `test_consumer_survives_killed_backend`, `test_consumer_stop_is_prompt_during_error_retry_wait`)
- B5: `FAILED tests/test_send.py::test_event_rejects_extra_kwarg - Failed: DID NOT RAISE`

Addresses findings B2, B3, B5 of #283

https://claude.ai/code/session_01KAaEGkQZmey1D1xCsVGmqv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAaEGkQZmey1D1xCsVGmqv)_