### PR TITLE
release: stamp v0.3.0-alpha.1

### DIFF
--- a/devel/sql/README.md
+++ b/devel/sql/README.md
@@ -7,6 +7,10 @@ churn and validate against a throwaway database, not production.
 The released, stable install lives in [`../../sql/`](../../sql/) — use that for
 anything real.
 
+Testing partition keys (ordered per-key processing via slot consumers)? Until
+`docs/` coverage lands, follow
+[`blueprints/partition-keys/SPEC.md`](../../blueprints/partition-keys/SPEC.md).
+
 Layout:
 
 - `pgque.sql`, `pgque-tle.sql` — generated single-file installs (built from the
@@ -40,6 +44,10 @@ To uninstall: `\i devel/sql/pgque_uninstall.sql`.
 
 PgQue does not deliver messages without a ticker: enqueueing works, but
 consumers see nothing until ticks are created.
+
+On a quiet queue, the ticker falls back to `queue_ticker_idle_period`
+(default 60s), so a newly enqueued event can take up to that long to become
+receivable. Run the ticker at your desired cadence to bound this latency.
 
 With `pg_cron` in the same database, one call sets up the ticker and
 maintenance jobs (10 ticks/sec by default):

--- a/devel/sql/pgque-additions/lifecycle.sql
+++ b/devel/sql/pgque-additions/lifecycle.sql
@@ -448,7 +448,7 @@ returns text as $$
 begin
     /* In-development build: the '-devel' suffix marks this as not a stable
        release. Bump to the release version (drop '-devel') at release time. */
-    return '0.3.0-devel';
+    return '0.3.0-alpha.1';
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 

--- a/devel/sql/pgque-tle.sql
+++ b/devel/sql/pgque-tle.sql
@@ -70,8 +70,8 @@ begin
     from pgtle.available_extensions()
     where name = 'pgque';
 
-    if existing_version = '0.3.0-devel' then
-        raise notice 'pgque 0.3.0-devel already registered with pg_tle; skipping install_extension().';
+    if existing_version = '0.3.0-alpha.1' then
+        raise notice 'pgque 0.3.0-alpha.1 already registered with pg_tle; skipping install_extension().';
         return;
     end if;
 
@@ -80,16 +80,16 @@ begin
             'but this script registers version %. Run '
             'devel/sql/pgque-tle-uninstall.sql first to remove the existing '
             'registration, then re-run this script.',
-            existing_version, '0.3.0-devel';
+            existing_version, '0.3.0-alpha.1';
     end if;
 
     perform pgtle.install_extension(
         'pgque',
-        '0.3.0-devel',
+        '0.3.0-alpha.1',
         'PgQue — PgQ Universal Edition (zero-bloat Postgres queue)',
 $pgque_extension_body$
 -- pgque.sql -- PgQ Universal Edition
--- Version: 0.3.0-devel
+-- Version: 0.3.0-alpha.1
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 -- Includes code derived from PgQ (ISC license, Marko Kreen / Skype Technologies OU).
 --
@@ -4670,7 +4670,7 @@ returns text as $$
 begin
     /* In-development build: the '-devel' suffix marks this as not a stable
        release. Bump to the release version (drop '-devel') at release time. */
-    return '0.3.0-devel';
+    return '0.3.0-alpha.1';
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
@@ -8121,5 +8121,5 @@ $pgque_extension_body$
 end $wrapper$;
 
 \echo ''
-\echo 'PgQue 0.3.0-devel registered with pg_tle.'
+\echo 'PgQue 0.3.0-alpha.1 registered with pg_tle.'
 \echo 'Run create extension pgque; to materialise the schema in this database.'

--- a/devel/sql/pgque.sql
+++ b/devel/sql/pgque.sql
@@ -1,5 +1,5 @@
 -- pgque.sql -- PgQ Universal Edition
--- Version: 0.3.0-devel
+-- Version: 0.3.0-alpha.1
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 -- Includes code derived from PgQ (ISC license, Marko Kreen / Skype Technologies OU).
 --
@@ -4580,7 +4580,7 @@ returns text as $$
 begin
     /* In-development build: the '-devel' suffix marks this as not a stable
        release. Bump to the release version (drop '-devel') at release time. */
-    return '0.3.0-devel';
+    return '0.3.0-alpha.1';
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 

--- a/tests/test_pgque_config.sql
+++ b/tests/test_pgque_config.sql
@@ -15,8 +15,8 @@ begin
   end;
 
   -- Version function works
-  assert pgque.version() = '0.3.0-devel',
-    'version should be 0.3.0-devel, got ' || pgque.version();
+  assert pgque.version() = '0.3.0-alpha.1',
+    'version should be 0.3.0-alpha.1, got ' || pgque.version();
 
   raise notice 'PASS: pgque_config';
 end $$;


### PR DESCRIPTION
## Summary

Stamps the **v0.3.0-alpha.1** prerelease. Bumps the devel `pgque.version()`
literal from `0.3.0-devel` to `0.3.0-alpha.1`, regenerates the single-file
installs from source via `build/transform.sh`, and updates the version
assertion in `test_pgque_config.sql`.

Also adds two terse alpha-tester notes to `devel/sql/README.md`:
- ticker idle-period latency (default `queue_ticker_idle_period` 60s — on a
  quiet queue an event can take up to that long to become receivable);
- a pointer to `blueprints/partition-keys/SPEC.md` for partition-keys testers
  until `docs/` coverage lands.

Scope note: this stamps the **devel** install only. Stable `sql/` stays at
0.2.0. A follow-up PR will restore the devel literal to `0.3.0-devel` after
this merges and the tag/release are cut.

## Changes

- `devel/sql/pgque-additions/lifecycle.sql` — `pgque.version()` → `0.3.0-alpha.1`
- `devel/sql/pgque.sql`, `devel/sql/pgque-tle.sql` — regenerated (version-only diff)
- `tests/test_pgque_config.sql` — version assertion → `0.3.0-alpha.1`
- `devel/sql/README.md` — two alpha-tester notes

## Verification

Built and tested against Postgres 17 in Docker, mirroring CI:

```bash
bash build/transform.sh          # clean regen, version 0.3.0-alpha.1, all checks pass
# install
psql ... -v ON_ERROR_STOP=1 -f devel/sql/pgque.sql
# regression suite
psql ... -v ON_ERROR_STOP=1 -f tests/run_all.sql             # 190 PASS, exit 0
# experimental (separate db)
psql ... -f devel/sql/experimental/{delayed,observability,config_api}.sql
psql ... -v ON_ERROR_STOP=1 -f tests/run_experimental.sql    # 18 PASS, exit 0
# acceptance
psql ... -v ON_ERROR_STOP=1 -f tests/acceptance/run_acceptance.sql  # 54 PASS, exit 0
# idempotency re-install
psql ... -f devel/sql/pgque.sql && psql ... -f tests/test_install_idempotency.sql  # PASS
# runtime version
psql ... -tAc "select pgque.version()"   # 0.3.0-alpha.1
```

Generated-file diff is version-only churn (header `Version:` line, `version()`
return, and the pg_tle registration strings); no incidental regeneration noise.

## Release notes draft

Posted as a PR comment for review. After merge: annotated tag `v0.3.0-alpha.1`
on the merge commit, GitHub **prerelease** with those notes, then the
devel-restore follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
