### PR TITLE
[codex] ci: add PostgreSQL 19 beta coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg_version: ['18', '17', '16', '15', '14']
+        pg_version: ['19beta1', '18', '17', '16', '15', '14']
 
     steps:
       - uses: actions/checkout@v4
@@ -101,14 +101,14 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Start PostgreSQL 18
+      - name: Start PostgreSQL 19 beta 1
         run: |
           set -Eeuo pipefail
           docker run -d --name pgque-stable-smoke \
             -e POSTGRES_PASSWORD=pgque_test \
             -e POSTGRES_DB=pgque_test \
             -p 5432:5432 \
-            postgres:18
+            postgres:19beta1
 
           for _ in $(seq 1 30); do
             docker exec pgque-stable-smoke pg_isready -U postgres && break
@@ -172,8 +172,8 @@ jobs:
       fail-fast: false
       matrix:
         # Upgrade coverage uses oldest/newest supported PG endpoints; the main
-        # regression matrix above covers every supported version (14–18).
-        pg_version: ['18', '14']
+        # regression matrix above covers every supported version (14–19).
+        pg_version: ['19beta1', '14']
 
     steps:
       - uses: actions/checkout@v4
@@ -254,6 +254,8 @@ jobs:
     name: pg_tle install path
     runs-on: ubuntu-latest
     env:
+      # pg_tle v1.5.2 does not compile against PostgreSQL 19 beta 1 yet;
+      # keep this optional extension path on the newest compatible major.
       PG_VERSION: '18'
       PGTLE_TAG: v1.5.2
     steps:
@@ -326,7 +328,8 @@ jobs:
     name: pg_cron install path
     runs-on: ubuntu-latest
     env:
-      PG_VERSION: '18'
+      PG_VERSION: '19beta1'
+      PG_MAJOR: '19'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -340,6 +343,7 @@ jobs:
           set -Eeuo pipefail
           docker build \
             --build-arg "PG_VERSION=${PG_VERSION}" \
+            --build-arg "PG_MAJOR=${PG_MAJOR}" \
             -t pgque-pgcron:test \
             -f ci/Dockerfile.pgcron .
 
@@ -434,7 +438,7 @@ jobs:
     name: pg_timetable real worker
     runs-on: ubuntu-latest
     env:
-      PG_VERSION: '18'
+      PG_VERSION: '19beta1'
       PGTT_IMAGE: cybertecpostgresql/pg_timetable@sha256:6bed16f944ab91392fac9cd04aba82cd6690769e179d411748fd0bb538f55acd
       PGTT_NET: pgque-pgtimetable-test
       PG_CONTAINER: pgque-pgtimetable-pg
@@ -448,7 +452,7 @@ jobs:
       - name: Build pgque
         run: bash build/transform.sh
 
-      - name: Start PostgreSQL 18
+      - name: Start PostgreSQL ${{ env.PG_VERSION }}
         run: |
           set -Eeuo pipefail
           docker network create "${PGTT_NET}"
@@ -516,19 +520,20 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PGQUE_TEST_DSN: postgresql://postgres:pgque_test@localhost/pgque_test
+      PG_VERSION: '19beta1'
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Start PostgreSQL 18
+      - name: Start PostgreSQL ${{ env.PG_VERSION }}
         run: |
           set -Eeuo pipefail
           docker run -d --name pgque-python-test \
             -e POSTGRES_PASSWORD=pgque_test \
             -e POSTGRES_DB=pgque_test \
             -p 5432:5432 \
-            postgres:18
+            postgres:${PG_VERSION}
 
           for i in $(seq 1 30); do
             docker exec pgque-python-test pg_isready -U postgres && break
@@ -572,19 +577,20 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PGQUE_TEST_DSN: postgresql://postgres:pgque_test@localhost/pgque_test
+      PG_VERSION: '19beta1'
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Start PostgreSQL 18
+      - name: Start PostgreSQL ${{ env.PG_VERSION }}
         run: |
           set -Eeuo pipefail
           docker run -d --name pgque-go-test \
             -e POSTGRES_PASSWORD=pgque_test \
             -e POSTGRES_DB=pgque_test \
             -p 5432:5432 \
-            postgres:18
+            postgres:${PG_VERSION}
 
           for i in $(seq 1 30); do
             docker exec pgque-go-test pg_isready -U postgres && break
@@ -615,19 +621,20 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PGQUE_TEST_DSN: postgresql://postgres:pgque_test@localhost/pgque_test
+      PG_VERSION: '19beta1'
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Start PostgreSQL 18
+      - name: Start PostgreSQL ${{ env.PG_VERSION }}
         run: |
           set -Eeuo pipefail
           docker run -d --name pgque-ts-test \
             -e POSTGRES_PASSWORD=pgque_test \
             -e POSTGRES_DB=pgque_test \
             -p 5432:5432 \
-            postgres:18
+            postgres:${PG_VERSION}
 
           for i in $(seq 1 30); do
             docker exec pgque-ts-test pg_isready -U postgres && break
@@ -672,19 +679,20 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PGQUE_TEST_DSN: postgresql://postgres:pgque_test@localhost/pgque_test
+      PG_VERSION: '19beta1'
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Start PostgreSQL 18
+      - name: Start PostgreSQL ${{ env.PG_VERSION }}
         run: |
           set -Eeuo pipefail
           docker run -d --name pgque-ruby-test \
             -e POSTGRES_PASSWORD=pgque_test \
             -e POSTGRES_DB=pgque_test \
             -p 5432:5432 \
-            postgres:18
+            postgres:${PG_VERSION}
 
           for i in $(seq 1 30); do
             docker exec pgque-ruby-test pg_isready -U postgres && break

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://github.com/NikolayS/pgque/actions/workflows/ci.yml"><img src="https://github.com/NikolayS/pgque/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://www.postgresql.org/"><img src="https://img.shields.io/badge/PostgreSQL-14--18-336791?logo=postgresql&logoColor=white" alt="PostgreSQL 14-18"></a>
+  <a href="https://www.postgresql.org/"><img src="https://img.shields.io/badge/PostgreSQL-14--19-336791?logo=postgresql&logoColor=white" alt="PostgreSQL 14-19"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License"></a>
   <a href="https://github.com/citusdata/pg_cron"><img src="https://img.shields.io/badge/pg__cron-optional-336791" alt="pg_cron"></a>
   <a href="https://github.com/NikolayS/pgque"><img src="https://img.shields.io/badge/anti--extension-%5Ci_and_go-orange" alt="Anti-Extension"></a>
@@ -509,7 +509,7 @@ PgQue keeps PgQ's proven core architecture — snapshot-based batch isolation, t
 | Feature | Done |
 |---|---|
 | PgQ core engine | ✅ |
-| Modern Postgres support (14-18, 19devel) | ✅ |
+| Modern Postgres support (14-19) | ✅ |
 | Pure SQL / PL/pgSQL install | ✅ |
 | Managed Postgres support | ✅ |
 | No daemon / no C extension | ✅ |

--- a/ci/Dockerfile.pgcron
+++ b/ci/Dockerfile.pgcron
@@ -4,18 +4,20 @@
 # run, never pushed). Same packaging style as Dockerfile.tle.
 #
 # Build arg:
-#   PG_VERSION  -- Postgres major (e.g. 18). Must match an available
-#                  postgresql-NN-cron package on apt.postgresql.org.
+#   PG_VERSION  -- Postgres Docker tag (e.g. 18 or 19beta1).
+#   PG_MAJOR    -- Postgres package major (e.g. 18 or 19). Must match an
+#                  available postgresql-NN-cron package on apt.postgresql.org.
 
 ARG PG_VERSION=18
 FROM postgres:${PG_VERSION}
 
 ARG PG_VERSION
+ARG PG_MAJOR=${PG_VERSION}
 
 # postgresql-NN-cron lives in the PGDG apt repo, which is already configured
 # in the official postgres:NN image since PG12. apt-get update + install is
 # enough.
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
-       postgresql-${PG_VERSION}-cron \
+       postgresql-${PG_MAJOR}-cron \
   && rm -rf /var/lib/apt/lists/*

--- a/ci/Dockerfile.tle
+++ b/ci/Dockerfile.tle
@@ -5,20 +5,22 @@
 # time stripping them.
 #
 # Build args:
-#   PG_VERSION  -- Postgres major (e.g. 18). Must match an available
-#                  postgresql-server-dev-XX package in apt.
+#   PG_VERSION  -- Postgres Docker tag (e.g. 18 or 19beta1).
+#   PG_MAJOR    -- Postgres package major (e.g. 18 or 19). Must match an
+#                  available postgresql-server-dev-XX package in apt.
 #   PGTLE_TAG   -- pg_tle git tag, e.g. v1.5.2.
 
 ARG PG_VERSION=18
 FROM postgres:${PG_VERSION}
 
 ARG PG_VERSION
+ARG PG_MAJOR=${PG_VERSION}
 ARG PGTLE_TAG=v1.5.2
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
        build-essential \
-       postgresql-server-dev-${PG_VERSION} \
+       postgresql-server-dev-${PG_MAJOR} \
        ca-certificates \
        git \
        flex \


### PR DESCRIPTION
## Summary

- Adds PostgreSQL 19 beta 1 coverage for the upcoming PgQue 0.3.0 alpha1 support line.
- Adds `postgres:19beta1` to the main SQL regression matrix so CI covers PostgreSQL 14 through 19 beta 1.
- Moves the stable frozen-`sql/` smoke, v0.1.0 upgrade endpoint, pg_cron path, pg_timetable real-worker path, and Python/Go/TypeScript/Ruby client DB backends to PG19 beta 1.
- Adds `PG_MAJOR` plumbing for CI Dockerfiles whose Docker tag (`19beta1`) differs from PGDG package names (`postgresql-19-*`).
- Updates the README badge/roadmap claim from 14-18/19devel to 14-19.

Release-note wording for 0.3.0 alpha1 can be simple: PostgreSQL 19 beta 1 is now part of the supported and continuously-tested server matrix.

`pg_tle` stays on PG18 for now because upstream `pg_tle` v1.5.2 does not compile against PostgreSQL 19 beta 1 server headers yet. I left a CI comment documenting that boundary.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `git diff --check`
- `bash build/transform.sh`
- `docker manifest inspect postgres:19beta1`
- `docker build --build-arg PG_VERSION=19beta1 --build-arg PG_MAJOR=19 -t pgque-pgcron-19beta1:test -f ci/Dockerfile.pgcron .`
- `docker build -t pgque-pgcron-default:probe -f ci/Dockerfile.pgcron .`
- PG19 beta 1 default CI path locally:
  - install `devel/sql/pgque.sql`
  - `tests/run_all.sql`
  - install experimental SQL and `tests/run_experimental.sql`
  - `tests/acceptance/run_acceptance.sql`
  - reinstall + `tests/test_install_idempotency.sql`
  - `devel/sql/pgque_uninstall.sql`
- PG19 beta 1 frozen stable smoke with `sql/pgque.sql` and `sql/pgque_uninstall.sql`
- PG19 beta 1 v0.1.0 -> HEAD upgrade path, including upgrade assertions, public execute guard, upgrade grants, roles, and post-upgrade idempotency
- PG19 beta 1 pg_cron path, including full regression suite plus non-skipped `test_tick_period.sql` and pg_timetable -> pg_cron switch assertions
- PG19 beta 1 real `pg_timetable` worker path: `PASS: real pg_timetable worker delivered event via ticker_loop()`
