### PR TITLE
chore: restore devel version after v0.3.0-alpha.1

### DIFF
--- a/devel/sql/pgque-additions/lifecycle.sql
+++ b/devel/sql/pgque-additions/lifecycle.sql
@@ -446,9 +446,10 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 create or replace function pgque.version()
 returns text as $$
 begin
-    /* In-development build: the '-devel' suffix marks this as not a stable
-       release. Bump to the release version (drop '-devel') at release time. */
-    return '0.3.0-alpha.1';
+    /* Devel builds carry a '-devel' version; a release stamp replaces this
+       literal with the release version, then a follow-up restores '-devel'.
+       transform.sh reads this literal, so keep it a valid semver string. */
+    return '0.3.0-devel';
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 

--- a/devel/sql/pgque-tle.sql
+++ b/devel/sql/pgque-tle.sql
@@ -70,8 +70,8 @@ begin
     from pgtle.available_extensions()
     where name = 'pgque';
 
-    if existing_version = '0.3.0-alpha.1' then
-        raise notice 'pgque 0.3.0-alpha.1 already registered with pg_tle; skipping install_extension().';
+    if existing_version = '0.3.0-devel' then
+        raise notice 'pgque 0.3.0-devel already registered with pg_tle; skipping install_extension().';
         return;
     end if;
 
@@ -80,16 +80,16 @@ begin
             'but this script registers version %. Run '
             'devel/sql/pgque-tle-uninstall.sql first to remove the existing '
             'registration, then re-run this script.',
-            existing_version, '0.3.0-alpha.1';
+            existing_version, '0.3.0-devel';
     end if;
 
     perform pgtle.install_extension(
         'pgque',
-        '0.3.0-alpha.1',
+        '0.3.0-devel',
         'PgQue — PgQ Universal Edition (zero-bloat Postgres queue)',
 $pgque_extension_body$
 -- pgque.sql -- PgQ Universal Edition
--- Version: 0.3.0-alpha.1
+-- Version: 0.3.0-devel
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 -- Includes code derived from PgQ (ISC license, Marko Kreen / Skype Technologies OU).
 --
@@ -4668,9 +4668,10 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 create or replace function pgque.version()
 returns text as $$
 begin
-    /* In-development build: the '-devel' suffix marks this as not a stable
-       release. Bump to the release version (drop '-devel') at release time. */
-    return '0.3.0-alpha.1';
+    /* Devel builds carry a '-devel' version; a release stamp replaces this
+       literal with the release version, then a follow-up restores '-devel'.
+       transform.sh reads this literal, so keep it a valid semver string. */
+    return '0.3.0-devel';
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 
@@ -8121,5 +8122,5 @@ $pgque_extension_body$
 end $wrapper$;
 
 \echo ''
-\echo 'PgQue 0.3.0-alpha.1 registered with pg_tle.'
+\echo 'PgQue 0.3.0-devel registered with pg_tle.'
 \echo 'Run create extension pgque; to materialise the schema in this database.'

--- a/devel/sql/pgque.sql
+++ b/devel/sql/pgque.sql
@@ -1,5 +1,5 @@
 -- pgque.sql -- PgQ Universal Edition
--- Version: 0.3.0-alpha.1
+-- Version: 0.3.0-devel
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 -- Includes code derived from PgQ (ISC license, Marko Kreen / Skype Technologies OU).
 --
@@ -4578,9 +4578,10 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 create or replace function pgque.version()
 returns text as $$
 begin
-    /* In-development build: the '-devel' suffix marks this as not a stable
-       release. Bump to the release version (drop '-devel') at release time. */
-    return '0.3.0-alpha.1';
+    /* Devel builds carry a '-devel' version; a release stamp replaces this
+       literal with the release version, then a follow-up restores '-devel'.
+       transform.sh reads this literal, so keep it a valid semver string. */
+    return '0.3.0-devel';
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 

--- a/tests/test_pgque_config.sql
+++ b/tests/test_pgque_config.sql
@@ -15,8 +15,8 @@ begin
   end;
 
   -- Version function works
-  assert pgque.version() = '0.3.0-alpha.1',
-    'version should be 0.3.0-alpha.1, got ' || pgque.version();
+  assert pgque.version() = '0.3.0-devel',
+    'version should be 0.3.0-devel, got ' || pgque.version();
 
   raise notice 'PASS: pgque_config';
 end $$;


### PR DESCRIPTION
## Summary

Restores main to in-development state after the **v0.3.0-alpha.1** prerelease
was tagged and published. The prerelease tag captured `0.3.0-alpha.1` on its
merge commit; this returns the devel line to `0.3.0-devel` so ongoing work is
not mislabeled as the alpha.

## Changes

- `devel/sql/pgque-additions/lifecycle.sql` — `pgque.version()` → `0.3.0-devel`;
  reworded the comment above it so it no longer hardcodes "the '-devel' suffix"
  (which reads wrong during a release stamp) and instead describes the
  stamp/restore convention plus the semver constraint `transform.sh` relies on.
  (Addresses the non-blocking nit from the v0.3.0-alpha.1 release review.)
- `devel/sql/pgque.sql`, `devel/sql/pgque-tle.sql` — regenerated (version-only diff)
- `tests/test_pgque_config.sql` — version assertion → `0.3.0-devel`

The `devel/sql/README.md` alpha-tester notes added during the stamp (ticker
idle-period latency, partition-keys SPEC pointer) are genuine doc improvements
and are intentionally **kept**.

## Verification

Postgres 17 in Docker: `bash build/transform.sh` clean regen (version
`0.3.0-devel`, all assembly checks pass, clean tree); install OK;
`tests/run_all.sql` → 190 PASS, exit 0; `select pgque.version()` → `0.3.0-devel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
