### PR TITLE
fix(ruby): make Consumer resilient

### DIFF
--- a/clients/ruby/README.md
+++ b/clients/ruby/README.md
@@ -100,6 +100,19 @@ instance; the default targets `$stderr` at `FATAL`, so the consumer is
 effectively silent unless you set `PGQUE_LOG_LEVEL=warn` or pass your
 own).
 
+After finishing a non-empty batch, the consumer polls again immediately
+until the existing backlog is empty. `LISTEN`/`NOTIFY` is only a wakeup
+optimization: notifications sent before a consumer connected cannot be
+replayed, so waiting after every batch would otherwise drain an existing
+backlog at only one batch per `poll_interval`.
+
+Connection, `LISTEN`, receive, and ack errors do not terminate `start`.
+The consumer closes the failed connection, waits `poll_interval` in
+stop-aware slices, reconnects, re-subscribes to notifications, and resumes.
+Set `PGQUE_LOG_LEVEL=error` (or pass `logger:`) to make these retry events
+visible. Permanent configuration errors such as a missing queue or consumer
+also retry until `stop`, SIGTERM, or SIGINT.
+
 ### Handling unknown event types
 
 By default the consumer **nacks** any message whose type has no

--- a/clients/ruby/lib/pgque/consumer.rb
+++ b/clients/ruby/lib/pgque/consumer.rb
@@ -87,25 +87,22 @@ module Pgque
       end
 
       begin
-        conn = PG.connect(@dsn)
-        begin
-          channel = "pgque_#{@queue}"
-          conn.exec("LISTEN #{conn.escape_identifier(channel)}")
-          @logger.info(
-            "consumer #{@name} listening on #{@queue} (poll=#{@poll_interval}s)"
-          )
-
-          while running?
-            poll_once(conn)
+        while running?
+          begin
+            run_session
+          rescue PG::Error, Pgque::Error => e
             break unless running?
-            wait_for_notify_or_stop(conn)
-          end
 
-          if @stop_signum
-            @logger.info("received signal #{@stop_signum}, shutting down")
+            @logger.error(
+              "consumer #{@name}: database error; retrying in " \
+              "#{@poll_interval}s: #{e.class}: #{e.message}",
+            )
+            wait_before_reconnect
           end
-        ensure
-          conn.close unless conn.finished?
+        end
+
+        if @stop_signum
+          @logger.info("received signal #{@stop_signum}, shutting down")
         end
       ensure
         # Clear running? before logging so callers observing the flag
@@ -132,6 +129,7 @@ module Pgque
 
     # Public for testability; not part of the stable API.
     def poll_once(conn)
+      processed = false
       conn.transaction do
         client = Client.new(conn)
         msgs =
@@ -161,10 +159,39 @@ module Pgque
             "double ack (batch already finished or not found)",
           )
         end
+        processed = true
       end
+      processed
     end
 
     private
+
+    def run_session
+      conn = PG.connect(@dsn)
+      begin
+        channel = "pgque_#{@queue}"
+        conn.exec("LISTEN #{conn.escape_identifier(channel)}")
+        @logger.info(
+          "consumer #{@name} listening on #{@queue} (poll=#{@poll_interval}s)"
+        )
+
+        while running?
+          processed = poll_once(conn)
+          break unless running?
+
+          # NOTIFY is only a wakeup optimization. Notifications for a
+          # pre-existing backlog may have fired before this session began,
+          # so keep polling immediately after a finished batch until the
+          # queue comes back empty. An unfinished batch (for example after
+          # a failed nack) returns false and retains the normal backoff.
+          next if processed
+
+          wait_for_notify_or_stop(conn)
+        end
+      ensure
+        conn.close unless conn.finished?
+      end
+    end
 
     def dispatch_batch(client, batch_id, msgs)
       nack_failed = false
@@ -239,6 +266,16 @@ module Pgque
           end
           return
         end
+      end
+    end
+
+    def wait_before_reconnect
+      deadline = monotonic + @poll_interval
+      while running?
+        remaining = deadline - monotonic
+        return if remaining <= 0
+
+        sleep [WAIT_SLICE_SECONDS, remaining].min
       end
     end
 

--- a/clients/ruby/test/test_consumer.rb
+++ b/clients/ruby/test/test_consumer.rb
@@ -76,16 +76,19 @@ class TestConsumerUnit < Minitest::Test
     end
   end
 
-  def test_running_clears_after_start_failure
+  def test_running_clears_after_unexpected_start_failure
     skip_dsn_for_this_class!
-    # Point at an unreachable port so PG.connect raises immediately
-    # inside start, exiting before the poll loop ever runs.
     cons = Pgque::Consumer.new(
-      "postgresql://nobody:wrong@localhost:1/nodb",
+      "dummy",
       queue: "q", name: "c", logger: silent_logger
     )
+    cons.define_singleton_method(:run_session) do
+      raise "simulated non-database failure"
+    end
+
     refute cons.running?
-    assert_raises(PG::Error) { cons.start }
+    error = assert_raises(RuntimeError) { cons.start }
+    assert_includes error.message, "non-database failure"
     refute cons.running?,
            "consumer.running? must be false after start raised"
   end

--- a/clients/ruby/test/test_consumer.rb
+++ b/clients/ruby/test/test_consumer.rb
@@ -124,6 +124,31 @@ end
 class TestConsumerIntegration < Minitest::Test
   include PgqueTest::Helpers
 
+  def test_poll_once_reports_empty_queue
+    with_queue do |queue, consumer_name, conn|
+      consumer = Pgque::Consumer.new(
+        dsn, queue: queue, name: consumer_name, logger: silent_logger
+      )
+
+      assert_equal false, consumer.poll_once(conn)
+    end
+  end
+
+  def test_poll_once_reports_processed_batch
+    with_queue do |queue, consumer_name, conn|
+      client = Pgque::Client.new(conn)
+      client.send(queue, { "i" => 1 }, type: "evt.processed")
+      force_tick(conn, queue)
+
+      consumer = Pgque::Consumer.new(
+        dsn, queue: queue, name: consumer_name, logger: silent_logger
+      )
+      consumer.on("evt.processed") { |_message| }
+
+      assert_equal true, consumer.poll_once(conn)
+    end
+  end
+
   def run_consumer_for(consumer, seconds)
     t = Thread.new { consumer.start }
     Thread.new do

--- a/clients/ruby/test/test_consumer_resilience.rb
+++ b/clients/ruby/test/test_consumer_resilience.rb
@@ -1,0 +1,257 @@
+# Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+require_relative "test_helper"
+require "logger"
+require "stringio"
+require "uri"
+
+class TestConsumerResilience < Minitest::Test
+  include PgqueTest::Helpers
+
+  def force_tick(conn, queue)
+    conn.exec_params("select pgque.force_next_tick($1)", [queue])
+    conn.exec_params("select pgque.ticker($1)", [queue])
+  end
+
+  def silent_logger
+    log = Logger.new(StringIO.new)
+    log.level = Logger::FATAL
+    log
+  end
+
+  def start_in_thread(consumer)
+    error = nil
+    thread = Thread.new do
+      consumer.start
+    rescue StandardError => e
+      error = e
+    end
+    [thread, -> { error }]
+  end
+
+  def wait_until(timeout: 10)
+    deadline = monotonic + timeout
+    until yield
+      return false if monotonic >= deadline
+
+      sleep 0.05
+    end
+    true
+  end
+
+  def monotonic
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+
+  def dsn_with_application_name(value)
+    uri = URI.parse(dsn)
+    unless uri.scheme&.start_with?("postgres")
+      return "#{dsn} application_name='#{value}'"
+    end
+
+    query = URI.decode_www_form(uri.query.to_s)
+    query.reject! { |key, _| key == "application_name" }
+    query << ["application_name", value]
+    uri.query = URI.encode_www_form(query)
+    uri.to_s
+  end
+
+  def test_consumer_drains_existing_backlog_without_poll_interval_waits
+    with_queue do |queue, consumer_name, conn|
+      client = Pgque::Client.new(conn)
+      3.times do |i|
+        client.send(queue, { "i" => i }, type: "evt.backlog")
+        force_tick(conn, queue)
+      end
+
+      seen = []
+      cons = Pgque::Consumer.new(
+        dsn, queue: queue, name: consumer_name,
+        poll_interval: 30, logger: silent_logger
+      )
+      cons.on("evt.backlog") { |msg| seen << msg.payload }
+
+      started = monotonic
+      thread, thread_error = start_in_thread(cons)
+      begin
+        drained = wait_until(timeout: 5) { seen.size == 3 }
+        elapsed = monotonic - started
+
+        assert drained,
+               "backlog stalled at #{seen.size}/3; consumer waited between batches"
+        assert_operator elapsed, :<, 5,
+                        "backlog took #{elapsed.round(2)}s to drain"
+        assert_nil thread_error.call
+      ensure
+        cons.stop
+        thread.join(3)
+      end
+    end
+  end
+
+  def test_consumer_recovers_from_initial_connect_error
+    with_queue do |queue, consumer_name, conn|
+      client = Pgque::Client.new(conn)
+      client.send(queue, { "x" => 1 }, type: "evt.connect")
+      force_tick(conn, queue)
+
+      original_connect = PG.method(:connect)
+      connect_calls = 0
+      PG.define_singleton_method(:connect) do |*args, **kwargs|
+        connect_calls += 1
+        if connect_calls == 1
+          raise PG::ConnectionBad, "simulated initial connection failure"
+        end
+
+        original_connect.call(*args, **kwargs)
+      end
+
+      seen = []
+      cons = Pgque::Consumer.new(
+        dsn, queue: queue, name: consumer_name,
+        poll_interval: 0.1, logger: silent_logger
+      )
+      cons.on("evt.connect") { |msg| seen << msg.payload }
+
+      thread, thread_error = start_in_thread(cons)
+      begin
+        assert wait_until(timeout: 5) { seen.size == 1 },
+               "consumer did not reconnect after initial failure"
+        assert_operator connect_calls, :>=, 2
+        assert thread.alive?, "consumer exited after recovering"
+        assert_nil thread_error.call
+      ensure
+        cons.stop
+        thread.join(3)
+        PG.define_singleton_method(:connect, original_connect)
+      end
+    end
+  end
+
+  def test_consumer_recovers_from_transient_receive_error
+    with_queue do |queue, consumer_name, conn|
+      client = Pgque::Client.new(conn)
+      client.send(queue, { "x" => 1 }, type: "evt.receive")
+      force_tick(conn, queue)
+
+      original_receive = Pgque::Client.instance_method(:receive)
+      receive_calls = 0
+      Pgque::Client.define_method(:receive) do |*args|
+        receive_calls += 1
+        if receive_calls == 1
+          raise Pgque::Error, "simulated transient receive failure"
+        end
+
+        original_receive.bind_call(self, *args)
+      end
+
+      seen = []
+      cons = Pgque::Consumer.new(
+        dsn, queue: queue, name: consumer_name,
+        poll_interval: 0.1, logger: silent_logger
+      )
+      cons.on("evt.receive") { |msg| seen << msg.payload }
+
+      thread, thread_error = start_in_thread(cons)
+      begin
+        assert wait_until(timeout: 5) { seen.size == 1 },
+               "consumer did not retry receive after transient failure"
+        assert_operator receive_calls, :>=, 2
+        assert thread.alive?, "consumer exited after recovering"
+        assert_nil thread_error.call
+      ensure
+        cons.stop
+        thread.join(3)
+        Pgque::Client.define_method(:receive, original_receive)
+      end
+    end
+  end
+
+  def test_consumer_reconnects_after_backend_is_terminated
+    with_queue do |queue, consumer_name, conn|
+      app_name = "pgque_ruby_#{SecureRandom.hex(6)}"
+      cons = Pgque::Consumer.new(
+        dsn_with_application_name(app_name),
+        queue: queue, name: consumer_name,
+        poll_interval: 0.2, logger: silent_logger
+      )
+      seen = []
+      cons.on("evt.restart") { |msg| seen << msg.payload }
+
+      thread, thread_error = start_in_thread(cons)
+      begin
+        old_pid = nil
+        connected = wait_until(timeout: 5) do
+          result = conn.exec_params(
+            "select pid from pg_stat_activity " \
+            "where application_name = $1 and pid <> pg_backend_pid()",
+            [app_name],
+          )
+          old_pid = result.ntuples.zero? ? nil : result.getvalue(0, 0).to_i
+        end
+        assert connected, "consumer backend did not appear"
+
+        killed = conn.exec_params(
+          "select pg_terminate_backend($1)", [old_pid]
+        ).getvalue(0, 0)
+        assert_equal "t", killed
+
+        reconnected = wait_until(timeout: 8) do
+          result = conn.exec_params(
+            "select pid from pg_stat_activity " \
+            "where application_name = $1 and pid <> pg_backend_pid()",
+            [app_name],
+          )
+          result.ntuples.positive? && result.getvalue(0, 0).to_i != old_pid
+        end
+        assert reconnected, "consumer did not reconnect after backend termination"
+
+        client = Pgque::Client.new(conn)
+        client.send(queue, { "r" => 1 }, type: "evt.restart")
+        force_tick(conn, queue)
+        assert wait_until(timeout: 5) { seen.size == 1 },
+               "reconnected consumer did not resume processing"
+        assert thread.alive?
+        assert_nil thread_error.call
+      ensure
+        cons.stop
+        thread.join(3)
+      end
+    end
+  end
+
+  def test_stop_is_prompt_during_connection_retry_wait
+    with_queue do |queue, consumer_name, _conn|
+      original_connect = PG.method(:connect)
+      connect_calls = 0
+      PG.define_singleton_method(:connect) do |*|
+        connect_calls += 1
+        raise PG::ConnectionBad, "simulated persistent connection failure"
+      end
+
+      cons = Pgque::Consumer.new(
+        dsn, queue: queue, name: consumer_name,
+        poll_interval: 30, logger: silent_logger
+      )
+      thread, thread_error = start_in_thread(cons)
+      begin
+        assert wait_until(timeout: 2) { connect_calls.positive? }
+        assert thread.alive?, "consumer exited instead of waiting to reconnect"
+
+        started = monotonic
+        cons.stop
+        thread.join(3)
+        elapsed = monotonic - started
+
+        refute thread.alive?, "consumer did not stop during retry wait"
+        assert_operator elapsed, :<, 2,
+                        "stop took #{elapsed.round(2)}s during retry wait"
+        assert_nil thread_error.call
+      ensure
+        cons.stop
+        thread.join(3)
+        PG.define_singleton_method(:connect, original_connect)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What changed

- immediately re-poll after a successfully acked non-empty batch, so pre-existing backlog drains without one `poll_interval` delay per batch;
- reconnect and re-LISTEN after transient `PG::Error` / `Pgque::Error` failures;
- close failed sessions and use a stop-aware bounded retry wait;
- preserve backoff for empty or intentionally unfinished batches;
- document the behavior and replace the obsolete exit-on-connect-failure test;
- add database-backed resilience coverage.

## Why

The new Ruby client could not catch up efficiently after downtime because notifications for existing batches had already fired before it connected. It also exited permanently on routine connection, receive, or ack failures, contrary to the blocking Consumer contract and the behavior of the other first-party clients.

Fixes #313.

## Regression coverage

The new five-test suite was run against the old implementation first and failed 5/5:

- backlog stalled at 1/3;
- no recovery from initial connect failure;
- no retry after transient receive failure;
- no reconnect after backend termination;
- Consumer exited instead of waiting for reconnect.

After the fix:

- resilience suite: 5 runs, 22 assertions, 0 failures (repeated under three seeds);
- full Ruby/PostgreSQL suite: 81 runs, 216 assertions, 0 failures/errors;
- gem build + isolated install + load smoke: `0.3.0.rc.1 Pgque::Consumer`;
- `ruby -c` and `git diff --check`: clean.

Tested with Ruby 3.4.8 and PostgreSQL 18.3. This PR is intentionally a draft and has not been merged.