### PR TITLE
docs(clients): repair snapshot links

### DIFF
--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -251,7 +251,7 @@ and a final disjoint-delivery summary.
 
 `Send` → ticker → `Receive` must each run in its own committed transaction (PgQue is snapshot-based). `pgxpool` satisfies this transparently — every `Send`/`Receive`/`Ack` is its own implicit tx, and the `Consumer` is pool-level.
 
-The footgun is `Client.Pool()`: calling `pgque.send` inside your own `pgx.Tx` is fine for transactional enqueue, but the consumer must run after `tx.Commit()`. Don't wrap `pgque.send` and `pgque.receive` in one shared `pgx.Tx`; same for `pgque.maint_retry_events` + `pgque.ticker`. See [snapshot rule](https://github.com/NikolayS/pgque/blob/main/docs/pgq-concepts.md#snapshot-rule).
+The footgun is `Client.Pool()`: calling `pgque.send` inside your own `pgx.Tx` is fine for transactional enqueue, but the consumer must run after `tx.Commit()`. Don't wrap `pgque.send` and `pgque.receive` in one shared `pgx.Tx`; same for `pgque.maint_retry_events` + `pgque.ticker`. See [snapshot rule](https://github.com/NikolayS/pgque/blob/main/docs/concepts.md#the-snapshot-rule).
 
 ## Tests
 

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -177,7 +177,7 @@ client.conn.commit()
 
 `send` → ticker → `receive` must each run in its own committed transaction (PgQue is snapshot-based). `pgque.connect(dsn)` is non-autocommit by default — commit between produce and consumer. The `Consumer` is autocommit + explicit `conn.transaction()` around `receive + dispatch + ack`.
 
-Don't wrap `send` and `receive` in one explicit tx; same for `maint_retry_events` + `ticker`. See [snapshot rule](https://github.com/NikolayS/pgque/blob/main/docs/pgq-concepts.md#snapshot-rule).
+Don't wrap `send` and `receive` in one explicit tx; same for `maint_retry_events` + `ticker`. See [snapshot rule](https://github.com/NikolayS/pgque/blob/main/docs/concepts.md#the-snapshot-rule).
 
 
 ## Tests

--- a/clients/ruby/README.md
+++ b/clients/ruby/README.md
@@ -210,7 +210,7 @@ end  # commits here; raises rollback the whole block
 
 Don't wrap `send` and `receive` in one explicit transaction; same for
 `maint_retry_events` + `ticker`. See the
-[snapshot rule](https://github.com/NikolayS/pgque/blob/main/docs/pgq-concepts.md#snapshot-rule).
+[snapshot rule](https://github.com/NikolayS/pgque/blob/main/docs/concepts.md#the-snapshot-rule).
 The built-in `Pgque::Consumer` already wraps `receive` + dispatch +
 `ack` in a single `conn.transaction` per poll, so handler code does
 not need to manage that.

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -175,7 +175,7 @@ or `pg.Client` instances in the same process are unaffected.
 
 `send` → ticker → `receive` must each run in its own committed transaction (PgQue is snapshot-based). `pg.Pool#query` satisfies this transparently — every `send`/`receive`/`ack` is its own implicit tx, and the `Consumer` is pool-level.
 
-The footgun is `client.rawPool`: for transactional enqueue, call `BEGIN` / `pgque.send` / `COMMIT` on a checked-out client. Don't mix `pgque.send` and `pgque.receive` in one shared tx; same for `pgque.maint_retry_events` + `pgque.ticker`. See [snapshot rule](https://github.com/NikolayS/pgque/blob/main/docs/pgq-concepts.md#snapshot-rule).
+The footgun is `client.rawPool`: for transactional enqueue, call `BEGIN` / `pgque.send` / `COMMIT` on a checked-out client. Don't mix `pgque.send` and `pgque.receive` in one shared tx; same for `pgque.maint_retry_events` + `pgque.ticker`. See [snapshot rule](https://github.com/NikolayS/pgque/blob/main/docs/concepts.md#the-snapshot-rule).
 
 ## Tests
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -117,7 +117,7 @@ The consume API wraps `pgque.next_batch`, `pgque.get_batch_events`, `pgque.finis
 
 All consume-side functions (`receive`, `ack`, `nack`, `subscribe`, `unsubscribe`) are granted to `pgque_reader`, mirroring upstream PgQ's producer/consumer role split. Apps that both produce and consume must hold both `pgque_reader` and `pgque_writer` — `pgque_writer` does not inherit `pgque_reader`.
 
-<a id="snapshot-rule"></a>**Snapshot rule.** `pgque.send` → `pgque.ticker` → `pgque.receive` must each run in its own committed transaction (the ticker's snapshot must be taken after `send` commits; `receive` only sees what committed before it). Same for `pgque.maint_retry_events` → `pgque.ticker` → `pgque.receive`. Each call must be its own committed transaction; never wrap producer and consumer calls together in one transaction. See [concepts.md#snapshot-rule](concepts.md#snapshot-rule).
+<a id="snapshot-rule"></a>**Snapshot rule.** `pgque.send` → `pgque.ticker` → `pgque.receive` must each run in its own committed transaction (the ticker's snapshot must be taken after `send` commits; `receive` only sees what committed before it). Same for `pgque.maint_retry_events` → `pgque.ticker` → `pgque.receive`. Each call must be its own committed transaction; never wrap producer and consumer calls together in one transaction. See [concepts.md#the-snapshot-rule](concepts.md#the-snapshot-rule).
 
 #### `pgque.receive(queue text, consumer text, max_return int default 100) → setof pgque.message`
 


### PR DESCRIPTION
## What changed

- update the Python, Go, TypeScript, and Ruby client READMEs from the deleted `docs/pgq-concepts.md` page to `docs/concepts.md#the-snapshot-rule`;
- correct the stale local anchor in `docs/reference.md`.

Fixes #317.

## Validation

- confirmed `docs/concepts.md` contains the `## The snapshot rule` heading;
- confirmed no affected file retains `pgq-concepts.md#snapshot-rule` or `concepts.md#snapshot-rule`;
- `git diff --check`;
- `bun install --frozen-lockfile`;
- `bun run build` — Astro/Starlight site and Pagefind index built successfully.

This is intentionally a draft and has not been merged.