### PR TITLE
fix(idempotency): use wall-clock TTL

### DIFF
--- a/devel/sql/pgque-api/send_idem.sql
+++ b/devel/sql/pgque-api/send_idem.sql
@@ -63,8 +63,8 @@ begin
     if i_idem_key is null then
         raise exception 'idem_key must not be null';
     end if;
-    if i_ttl is null or i_ttl <= interval '0' then
-        raise exception 'ttl must be a positive interval';
+    if i_ttl is null or not isfinite(i_ttl) or i_ttl <= interval '0' then
+        raise exception 'ttl must be a positive finite interval';
     end if;
 
     select q.queue_id, q.queue_extra_maint
@@ -95,11 +95,13 @@ begin
      * conditional do-update lets only an EXPIRED key be reclaimed.
      */
     insert into pgque.idem as k (queue_id, idem_key, event_id, expires_at)
-    values (v_queue_id, i_idem_key, null, now() + i_ttl)
+    values (v_queue_id, i_idem_key, null, clock_timestamp() + i_ttl)
     on conflict (queue_id, idem_key) do update
         set event_id = excluded.event_id,
-            expires_at = excluded.expires_at
-        where k.expires_at <= now()
+            /* Evaluated after any conflicting row-lock wait, so a takeover
+               always receives a fresh TTL window. */
+            expires_at = clock_timestamp() + i_ttl
+        where k.expires_at <= clock_timestamp()
     returning true into v_claimed;
 
     if v_claimed then
@@ -182,7 +184,7 @@ begin
         select d.queue_id, d.idem_key
         from pgque.idem d
         where d.queue_id = v_queue_id
-          and d.expires_at < now()
+          and d.expires_at < clock_timestamp()
         limit 10000);
     get diagnostics v_deleted = row_count;
 
@@ -205,7 +207,7 @@ begin
     where (k.queue_id, k.idem_key) in (
         select d.queue_id, d.idem_key
         from pgque.idem d
-        where d.expires_at < now()
+        where d.expires_at < clock_timestamp()
         limit 10000);
     get diagnostics v_deleted = row_count;
 

--- a/devel/sql/pgque-tle.sql
+++ b/devel/sql/pgque-tle.sql
@@ -7958,8 +7958,8 @@ begin
     if i_idem_key is null then
         raise exception 'idem_key must not be null';
     end if;
-    if i_ttl is null or i_ttl <= interval '0' then
-        raise exception 'ttl must be a positive interval';
+    if i_ttl is null or not isfinite(i_ttl) or i_ttl <= interval '0' then
+        raise exception 'ttl must be a positive finite interval';
     end if;
 
     select q.queue_id, q.queue_extra_maint
@@ -7990,11 +7990,13 @@ begin
      * conditional do-update lets only an EXPIRED key be reclaimed.
      */
     insert into pgque.idem as k (queue_id, idem_key, event_id, expires_at)
-    values (v_queue_id, i_idem_key, null, now() + i_ttl)
+    values (v_queue_id, i_idem_key, null, clock_timestamp() + i_ttl)
     on conflict (queue_id, idem_key) do update
         set event_id = excluded.event_id,
-            expires_at = excluded.expires_at
-        where k.expires_at <= now()
+            /* Evaluated after any conflicting row-lock wait, so a takeover
+               always receives a fresh TTL window. */
+            expires_at = clock_timestamp() + i_ttl
+        where k.expires_at <= clock_timestamp()
     returning true into v_claimed;
 
     if v_claimed then
@@ -8077,7 +8079,7 @@ begin
         select d.queue_id, d.idem_key
         from pgque.idem d
         where d.queue_id = v_queue_id
-          and d.expires_at < now()
+          and d.expires_at < clock_timestamp()
         limit 10000);
     get diagnostics v_deleted = row_count;
 
@@ -8100,7 +8102,7 @@ begin
     where (k.queue_id, k.idem_key) in (
         select d.queue_id, d.idem_key
         from pgque.idem d
-        where d.expires_at < now()
+        where d.expires_at < clock_timestamp()
         limit 10000);
     get diagnostics v_deleted = row_count;
 

--- a/devel/sql/pgque.sql
+++ b/devel/sql/pgque.sql
@@ -7868,8 +7868,8 @@ begin
     if i_idem_key is null then
         raise exception 'idem_key must not be null';
     end if;
-    if i_ttl is null or i_ttl <= interval '0' then
-        raise exception 'ttl must be a positive interval';
+    if i_ttl is null or not isfinite(i_ttl) or i_ttl <= interval '0' then
+        raise exception 'ttl must be a positive finite interval';
     end if;
 
     select q.queue_id, q.queue_extra_maint
@@ -7900,11 +7900,13 @@ begin
      * conditional do-update lets only an EXPIRED key be reclaimed.
      */
     insert into pgque.idem as k (queue_id, idem_key, event_id, expires_at)
-    values (v_queue_id, i_idem_key, null, now() + i_ttl)
+    values (v_queue_id, i_idem_key, null, clock_timestamp() + i_ttl)
     on conflict (queue_id, idem_key) do update
         set event_id = excluded.event_id,
-            expires_at = excluded.expires_at
-        where k.expires_at <= now()
+            /* Evaluated after any conflicting row-lock wait, so a takeover
+               always receives a fresh TTL window. */
+            expires_at = clock_timestamp() + i_ttl
+        where k.expires_at <= clock_timestamp()
     returning true into v_claimed;
 
     if v_claimed then
@@ -7987,7 +7989,7 @@ begin
         select d.queue_id, d.idem_key
         from pgque.idem d
         where d.queue_id = v_queue_id
-          and d.expires_at < now()
+          and d.expires_at < clock_timestamp()
         limit 10000);
     get diagnostics v_deleted = row_count;
 
@@ -8010,7 +8012,7 @@ begin
     where (k.queue_id, k.idem_key) in (
         select d.queue_id, d.idem_key
         from pgque.idem d
-        where d.expires_at < now()
+        where d.expires_at < clock_timestamp()
         limit 10000);
     get diagnostics v_deleted = row_count;
 

--- a/tests/test_send_idem.sql
+++ b/tests/test_send_idem.sql
@@ -7,9 +7,8 @@
 
 create extension if not exists dblink;
 
-/* Expiry tests need real transaction boundaries: now() is frozen for the
-   whole transaction, so pg_sleep() inside one do-block never expires a key.
-   This temp table carries event ids across the separate transactions. */
+/* This temp table carries event ids across the transaction boundaries used
+   by the expiry tests. */
 create temporary table idem_state (k text primary key, v bigint);
 
 -- Setup
@@ -51,6 +50,74 @@ begin
     'fresh send_idem should insert exactly 1 event, got ' || v_count;
 
   raise notice 'PASS: US-13.1 fresh send inserts, deduped=false';
+end $$;
+
+/* A claim's TTL starts when send_idem runs, not when its surrounding
+   transaction began. The committed claim must therefore still be live even
+   when the transaction was already older than the requested TTL. */
+do $$
+declare
+  v_eid bigint;
+  v_dedup boolean;
+  v_expires_at timestamptz;
+begin
+  perform pg_sleep(1.25);
+
+  select s.event_id, s.deduped
+  into v_eid, v_dedup
+  from pgque.send_idem(
+    'test_idem', 'migrate', '{"late":1}', 'late-txn:k1',
+    '1 second') s;
+  select expires_at into v_expires_at
+  from pgque.idem k
+  join pgque.queue q using (queue_id)
+  where q.queue_name = 'test_idem'
+    and k.idem_key = 'late-txn:k1';
+
+  assert not v_dedup, 'first late-transaction send must insert';
+  assert v_expires_at > clock_timestamp(),
+    format('new claim must expire after send time, got expires_at=%s now=%s',
+      v_expires_at, clock_timestamp());
+  insert into idem_state values ('late_txn_eid', v_eid);
+end $$;
+
+do $$
+declare
+  v_eid bigint;
+  v_dedup boolean;
+  v_first bigint;
+begin
+  select v into v_first from idem_state where k = 'late_txn_eid';
+  select s.event_id, s.deduped
+  into v_eid, v_dedup
+  from pgque.send_idem(
+    'test_idem', 'migrate', '{"late":1}', 'late-txn:k1',
+    '100 milliseconds') s;
+
+  assert v_dedup and v_eid = v_first,
+    'immediate post-commit retry must deduplicate a late-transaction send';
+  raise notice 'PASS: idempotency TTL starts at send time, not transaction start';
+end $$;
+
+-- Infinite TTLs create claims that maintenance can never reclaim (PG19+).
+do $$
+declare
+  v_raised boolean := false;
+begin
+  if current_setting('server_version_num')::int >= 190000 then
+    begin
+      execute $q$
+        select * from pgque.send_idem(
+          'test_idem', 'migrate', '{}', 'infinite:k1', 'infinity'::interval)
+      $q$;
+    exception
+      when others then
+        v_raised := true;
+        assert sqlerrm = 'ttl must be a positive finite interval',
+          format('unexpected infinite-TTL error: %s', sqlerrm);
+    end;
+    assert v_raised, 'send_idem must reject an infinite TTL';
+  end if;
 end $$;
 
 -- US-13.1: duplicate within window returns the ORIGINAL event_id,

--- a/tests/test_send_idem.sql
+++ b/tests/test_send_idem.sql
@@ -69,8 +69,8 @@ begin
     'test_idem', 'migrate', '{"late":1}', 'late-txn:k1',
     '1 second') s;
   select expires_at into v_expires_at
-  from pgque.idem k
-  join pgque.queue q using (queue_id)
+  from pgque.idem as k
+  join pgque.queue as q using (queue_id)
   where q.queue_name = 'test_idem'
     and k.idem_key = 'late-txn:k1';
 


### PR DESCRIPTION
## What changed

- calculate dedup claim expiry and expiry qualification with `clock_timestamp()` instead of transaction-stable `now()`;
- calculate takeover expiry after any conflicting row-lock wait, so a winning contender receives a fresh window;
- use wall-clock expiry in idempotency maintenance sweeps;
- reject non-finite TTLs;
- add long-transaction and PostgreSQL 19 infinite-TTL regressions;
- regenerate the development install artifacts.

## Why

A `send_idem` call made late in an older transaction could commit a claim whose TTL had already expired. An immediate producer retry then appended a second event instead of returning the original event id.

Fixes #305.

## Validation

Red evidence on current `main`:

```text
ERROR: new claim must expire after send time,
got expires_at=...13.021104 now=...13.174104
```

Green checks:

- `bash build/transform.sh`
- `git diff --check`
- PostgreSQL 14: install + complete `tests/test_send_idem.sql`
- PostgreSQL 18: install + complete `tests/test_send_idem.sql` + full acceptance suite
- PostgreSQL 19 beta 1: install + complete `tests/test_send_idem.sql`, including infinite-TTL rejection
- existing concurrent dedup race remains green.

This is intentionally a draft and has not been merged.