### PR TITLE
fix(partition-keys): make claims nonblocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,11 @@ jobs:
           PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
             -v ON_ERROR_STOP=1 -f tests/run_all.sql
 
+      - name: Run partition lease concurrency tests
+        env:
+          PGQUE_TEST_DSN: postgresql://postgres:pgque_test@localhost/pgque_test
+        run: tests/two_session_slot_claim.sh
+
       - name: Run experimental tests
         run: |
           # devel/sql/experimental/*.sql is not part of devel/sql/pgque.sql;

--- a/devel/sql/pgque-api/partition_keys.sql
+++ b/devel/sql/pgque-api/partition_keys.sql
@@ -377,8 +377,8 @@ begin
     if i_worker is null or i_worker = '' then
         raise exception 'worker id must not be empty';
     end if;
-    if i_ttl is null or i_ttl < interval '1 second' then
-        raise exception 'lease ttl must be >= 1 second, got %', i_ttl;
+    if i_ttl is null or not isfinite(i_ttl) or i_ttl < interval '1 second' then
+        raise exception 'lease ttl must be a finite interval >= 1 second, got %', i_ttl;
     end if;
 
     select pc.queue_id, pc.n into v_queue_id, v_n
@@ -400,8 +400,19 @@ begin
     where queue_id = v_queue_id
       and co_name = i_consumer
       and slot = i_slot
-    for update;
+    for update skip locked;
     if not found then
+        /* A matching row that could not be locked is busy in another
+           transaction. Steer the caller to its next candidate slot. */
+        perform 1
+        from pgque.partition_slot
+        where queue_id = v_queue_id
+          and co_name = i_consumer
+          and slot = i_slot;
+        if found then
+            return null;
+        end if;
+
         raise exception 'slot % of consumer % on queue % is not subscribed; call pgque.subscribe_slot()',
             i_slot, i_consumer, i_queue;
     end if;

--- a/devel/sql/pgque-tle.sql
+++ b/devel/sql/pgque-tle.sql
@@ -7564,8 +7564,8 @@ begin
     if i_worker is null or i_worker = '' then
         raise exception 'worker id must not be empty';
     end if;
-    if i_ttl is null or i_ttl < interval '1 second' then
-        raise exception 'lease ttl must be >= 1 second, got %', i_ttl;
+    if i_ttl is null or not isfinite(i_ttl) or i_ttl < interval '1 second' then
+        raise exception 'lease ttl must be a finite interval >= 1 second, got %', i_ttl;
     end if;
 
     select pc.queue_id, pc.n into v_queue_id, v_n
@@ -7587,8 +7587,19 @@ begin
     where queue_id = v_queue_id
       and co_name = i_consumer
       and slot = i_slot
-    for update;
+    for update skip locked;
     if not found then
+        /* A matching row that could not be locked is busy in another
+           transaction. Steer the caller to its next candidate slot. */
+        perform 1
+        from pgque.partition_slot
+        where queue_id = v_queue_id
+          and co_name = i_consumer
+          and slot = i_slot;
+        if found then
+            return null;
+        end if;
+
         raise exception 'slot % of consumer % on queue % is not subscribed; call pgque.subscribe_slot()',
             i_slot, i_consumer, i_queue;
     end if;

--- a/devel/sql/pgque.sql
+++ b/devel/sql/pgque.sql
@@ -7474,8 +7474,8 @@ begin
     if i_worker is null or i_worker = '' then
         raise exception 'worker id must not be empty';
     end if;
-    if i_ttl is null or i_ttl < interval '1 second' then
-        raise exception 'lease ttl must be >= 1 second, got %', i_ttl;
+    if i_ttl is null or not isfinite(i_ttl) or i_ttl < interval '1 second' then
+        raise exception 'lease ttl must be a finite interval >= 1 second, got %', i_ttl;
     end if;
 
     select pc.queue_id, pc.n into v_queue_id, v_n
@@ -7497,8 +7497,19 @@ begin
     where queue_id = v_queue_id
       and co_name = i_consumer
       and slot = i_slot
-    for update;
+    for update skip locked;
     if not found then
+        /* A matching row that could not be locked is busy in another
+           transaction. Steer the caller to its next candidate slot. */
+        perform 1
+        from pgque.partition_slot
+        where queue_id = v_queue_id
+          and co_name = i_consumer
+          and slot = i_slot;
+        if found then
+            return null;
+        end if;
+
         raise exception 'slot % of consumer % on queue % is not subscribed; call pgque.subscribe_slot()',
             i_slot, i_consumer, i_queue;
     end if;

--- a/tests/test_partition_keys.sql
+++ b/tests/test_partition_keys.sql
@@ -684,6 +684,23 @@ begin
   end;
   assert v_raised, 'guard: claim_slot with ttl < 1 second must raise';
 
+  -- Infinite leases cannot recover after a crashed worker (PG19+ syntax).
+  if current_setting('server_version_num')::int >= 190000 then
+    v_raised := false;
+    begin
+      execute $sql$
+        select pgque.claim_slot(
+          'pk_q', 'w', 0, 'wk-infinite', 'infinity'::interval)
+      $sql$;
+    exception
+      when others then
+        v_raised := true;
+        assert sqlerrm like '%finite interval%',
+          'guard: unexpected infinite lease error: ' || sqlerrm;
+    end;
+    assert v_raised, 'guard: claim_slot with infinite ttl must raise';
+  end if;
+
   -- Empty worker id is rejected.
   v_raised := false;
   begin

--- a/tests/two_session_slot_claim.sh
+++ b/tests/two_session_slot_claim.sh
@@ -39,12 +39,13 @@ if [[ -z "${PGQUE_TEST_DSN:-}" ]]; then
   exit 2
 fi
 
-psql_base=(psql --no-psqlrc -v ON_ERROR_STOP=1 "${PGQUE_TEST_DSN}")
+export PAGER=cat
+psql_base=(psql --no-psqlrc --set=ON_ERROR_STOP=1 "${PGQUE_TEST_DSN}")
 queue_name="two_session_slot_claim_${$}_$(date +%s)"
 s1_ttl="3 seconds"
 workdir="$(mktemp -d)"
 cleanup() {
-  "${psql_base[@]}" -qAtc "
+  "${psql_base[@]}" --quiet --no-align --tuples-only --command="
     select pgque.unsubscribe_slot('${queue_name}', 'w', 0);
     select pgque.unsubscribe_slot('${queue_name}', 'w', 1);
     select pgque.drop_queue('${queue_name}', true);
@@ -69,7 +70,7 @@ select pgque.subscribe_slot('${queue_name}', 'w', 0, 2);
 select pgque.subscribe_slot('${queue_name}', 'w', 1, 2);
 SQL
 
-"${psql_base[@]}" -f "${workdir}/setup.sql" \
+"${psql_base[@]}" --file="${workdir}/setup.sql" \
   >"${workdir}/setup.out" 2>&1 || {
   echo "FAIL: setup failed" >&2
   print_debug
@@ -85,13 +86,13 @@ select pg_sleep(10);
 rollback;
 SQL
 
-PGAPPNAME="${lock_app}" "${psql_base[@]}" -f "${workdir}/lock_holder.sql" \
+PGAPPNAME="${lock_app}" "${psql_base[@]}" --file="${workdir}/lock_holder.sql" \
   >"${workdir}/lock_holder.out" 2>"${workdir}/lock_holder.err" &
 lock_holder_pid=$!
 
 lock_ready=0
 for _ in $(seq 1 50); do
-  if "${psql_base[@]}" -qAtc "
+  if "${psql_base[@]}" --quiet --no-align --tuples-only --command="
     select 1
     from pg_stat_activity
     where application_name = '${lock_app}'
@@ -114,12 +115,13 @@ if (( lock_ready != 1 )); then
 fi
 
 set +e
-PGOPTIONS='-c statement_timeout=750ms' "${psql_base[@]}" -qAtc \
+PGOPTIONS='-c statement_timeout=750ms' "${psql_base[@]}" \
+  --quiet --no-align --tuples-only --command \
   "select coalesce(pgque.claim_slot('${queue_name}', 'w', 0, 'contender')::text, 'NULL')" \
   >"${workdir}/contender.out" 2>"${workdir}/contender.err"
 contender_status=$?
 set -e
-"${psql_base[@]}" -qAtc "
+"${psql_base[@]}" --quiet --no-align --tuples-only --command="
   select pg_terminate_backend(pid)
   from pg_stat_activity
   where application_name = '${lock_app}'
@@ -132,7 +134,7 @@ wait "${lock_holder_pid}" >/dev/null 2>&1 || true
 # crash-recovery scenario below starts from a genuinely free slot.
 holder_gone=0
 for _ in $(seq 1 50); do
-  if [[ "$("${psql_base[@]}" -qAtc "
+  if [[ "$("${psql_base[@]}" --quiet --no-align --tuples-only --command="
     select count(*)
     from pg_stat_activity
     where application_name = '${lock_app}'
@@ -164,7 +166,7 @@ echo "non-blocking claim: contender returned NULL behind an uncommitted slot row
 # No release_slot call: the backend dies with the lease still held. The lease
 # is committed transactional state, so it survives the backend's exit.
 s1_epoch="$(
-  "${psql_base[@]}" -qAtc \
+  "${psql_base[@]}" --quiet --no-align --tuples-only --command \
     "select pgque.claim_slot('${queue_name}', 'w', 0, 'w1', interval '${s1_ttl}')"
 )"
 if [[ -z "${s1_epoch}" || ! "${s1_epoch}" =~ ^[0-9]+$ ]]; then
@@ -208,7 +210,7 @@ select 's2_checks=ok';
 SQL
 
 set +e
-"${psql_base[@]}" -f "${workdir}/session2.sql" \
+"${psql_base[@]}" --file="${workdir}/session2.sql" \
   >"${workdir}/session2.out" 2>"${workdir}/session2.err"
 session2_status=$?
 set -e
@@ -244,7 +246,7 @@ select 's3_reclaim=ok';
 SQL
 
 set +e
-"${psql_base[@]}" -f "${workdir}/session3.sql" \
+"${psql_base[@]}" --file="${workdir}/session3.sql" \
   >"${workdir}/session3.out" 2>"${workdir}/session3.err"
 session3_status=$?
 set -e

--- a/tests/two_session_slot_claim.sh
+++ b/tests/two_session_slot_claim.sh
@@ -4,6 +4,7 @@
 # Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 # Includes code derived from PgQ (ISC license, Marko Kreen / Skype Technologies OU).
 set -Eeuo pipefail
+IFS=$'\n\t'
 
 # Usage:
 #   PGQUE_TEST_DSN=postgresql://postgres:***@localhost/pgque_test \
@@ -44,17 +45,32 @@ psql_base=(psql --no-psqlrc --set=ON_ERROR_STOP=1 "${PGQUE_TEST_DSN}")
 queue_name="two_session_slot_claim_${$}_$(date +%s)"
 s1_ttl="3 seconds"
 workdir="$(mktemp -d)"
+
+# Remove database and filesystem fixtures while preserving the script status.
+# Globals: psql_base, queue_name, workdir
+# Args: none
+# Returns: the status that triggered the EXIT trap
 cleanup() {
+  local exit_code=$?
+
   "${psql_base[@]}" --quiet --no-align --tuples-only --command="
     select pgque.unsubscribe_slot('${queue_name}', 'w', 0);
     select pgque.unsubscribe_slot('${queue_name}', 'w', 1);
     select pgque.drop_queue('${queue_name}', true);
   " >/dev/null 2>&1 || true
-  rm -rf "${workdir}"
+  rm -rf -- "${workdir}" || true
+  exit "${exit_code}"
 }
 trap cleanup EXIT
 
+# Print captured session output after a harness failure.
+# Globals: workdir
+# Args: none
+# Outputs: captured files to STDERR
+# Returns: zero
 print_debug() {
+  local f
+
   for f in setup.out lock_holder.out lock_holder.err contender.out \
            contender.err session1.out session1.err session2.out session2.err \
            session3.out session3.err; do

--- a/tests/two_session_slot_claim.sh
+++ b/tests/two_session_slot_claim.sh
@@ -25,6 +25,8 @@ set -Eeuo pipefail
 # psql backends proves:
 #   - session 1 claims slot 0 as 'w1' under a short TTL, then EXITS without
 #     releasing (a simulated crash)
+#   - a contender returns NULL promptly while another transaction holds the
+#     slot row, instead of blocking its first-free scan
 #   - session 2 sees claim_slot(slot 0) IS NULL -- the lease outlives the
 #     dead backend (US-12.4 exclusivity, and the TTL trade vs advisory locks)
 #   - session 2 claims the free slot 1 as 'w2'; the status view attributes
@@ -52,7 +54,8 @@ cleanup() {
 trap cleanup EXIT
 
 print_debug() {
-  for f in setup.out session1.out session1.err session2.out session2.err \
+  for f in setup.out lock_holder.out lock_holder.err contender.out \
+           contender.err session1.out session1.err session2.out session2.err \
            session3.out session3.err; do
     echo "--- ${f} ---" >&2
     cat "${workdir}/${f}" >&2 2>/dev/null || true
@@ -72,6 +75,90 @@ SQL
   print_debug
   exit 1
 }
+
+# --- non-blocking claim: steer around an uncommitted slot row -------------
+lock_app="pgque_slot_lock_holder_${$}_$(date +%s)"
+cat >"${workdir}/lock_holder.sql" <<SQL
+begin;
+select pgque.claim_slot('${queue_name}', 'w', 0, 'lock-holder');
+select pg_sleep(10);
+rollback;
+SQL
+
+PGAPPNAME="${lock_app}" "${psql_base[@]}" -f "${workdir}/lock_holder.sql" \
+  >"${workdir}/lock_holder.out" 2>"${workdir}/lock_holder.err" &
+lock_holder_pid=$!
+
+lock_ready=0
+for _ in $(seq 1 50); do
+  if "${psql_base[@]}" -qAtc "
+    select 1
+    from pg_stat_activity
+    where application_name = '${lock_app}'
+      and state = 'active'
+      and wait_event_type = 'Timeout'
+      and wait_event = 'PgSleep'
+    limit 1
+  " | grep -q 1; then
+    lock_ready=1
+    break
+  fi
+  sleep 0.1
+done
+if (( lock_ready != 1 )); then
+  kill "${lock_holder_pid}" >/dev/null 2>&1 || true
+  wait "${lock_holder_pid}" >/dev/null 2>&1 || true
+  echo "FAIL: lock holder did not acquire the slot row" >&2
+  print_debug
+  exit 1
+fi
+
+set +e
+PGOPTIONS='-c statement_timeout=750ms' "${psql_base[@]}" -qAtc \
+  "select coalesce(pgque.claim_slot('${queue_name}', 'w', 0, 'contender')::text, 'NULL')" \
+  >"${workdir}/contender.out" 2>"${workdir}/contender.err"
+contender_status=$?
+set -e
+"${psql_base[@]}" -qAtc "
+  select pg_terminate_backend(pid)
+  from pg_stat_activity
+  where application_name = '${lock_app}'
+" >/dev/null 2>&1 || true
+kill "${lock_holder_pid}" >/dev/null 2>&1 || true
+wait "${lock_holder_pid}" >/dev/null 2>&1 || true
+
+# The client process can exit just before the server backend observes the
+# closed socket and rolls its transaction back. Wait for that rollback so the
+# crash-recovery scenario below starts from a genuinely free slot.
+holder_gone=0
+for _ in $(seq 1 50); do
+  if [[ "$("${psql_base[@]}" -qAtc "
+    select count(*)
+    from pg_stat_activity
+    where application_name = '${lock_app}'
+  ")" = "0" ]]; then
+    holder_gone=1
+    break
+  fi
+  sleep 0.1
+done
+if (( holder_gone != 1 )); then
+  echo "FAIL: lock-holder backend did not roll back after disconnect" >&2
+  print_debug
+  exit 1
+fi
+
+if (( contender_status != 0 )); then
+  echo "FAIL: claim_slot blocked behind an uncommitted lease row" >&2
+  print_debug
+  exit 1
+fi
+if [[ "$(tr -d '[:space:]' <"${workdir}/contender.out")" != "NULL" ]]; then
+  echo "FAIL: busy locked slot must return NULL" >&2
+  print_debug
+  exit 1
+fi
+echo "non-blocking claim: contender returned NULL behind an uncommitted slot row"
 
 # --- session 1: claim slot 0 as 'w1' under a short TTL, then exit ----------
 # No release_slot call: the backend dies with the lease still held. The lease


### PR DESCRIPTION
## Stack

This PR is intentionally stacked on #311 because both changes touch the partition lease implementation. Review only the commit above `agent/fix-partition-lease-boundary`.

## What changed

- use a non-blocking row lock in `claim_slot`;
- return `NULL` when another transaction currently owns the slot row, allowing a first-free scan to continue;
- keep the distinct “slot is not subscribed” error when no row exists;
- reject non-finite lease TTLs;
- extend the real two-session lease harness with an uncommitted-row-lock contender;
- run that harness in every PostgreSQL matrix lane;
- add PostgreSQL 19 infinite-lease coverage and regenerate development artifacts.

## Why

The API contract says a busy claim returns `NULL`; it previously blocked on `SELECT ... FOR UPDATE`. A slow claim/renew/receive transaction could therefore head-of-line-block a worker scanning for any free slot.

Fixes #309.

## Validation

Red evidence on the parent/current behavior:

```text
ERROR: canceling statement due to statement timeout
CONTEXT: while locking tuple ... in relation "partition_slot"
```

Green checks:

- real two-session harness: contender returns `NULL` behind an uncommitted lease row, existing lease-expiry/epoch recovery still passes;
- PostgreSQL 14: complete partition regression;
- PostgreSQL 18: complete partition regression + two-session harness;
- PostgreSQL 19 beta 1: complete partition regression including infinite-TTL rejection;
- `bash build/transform.sh`;
- workflow YAML parse, shell syntax, and `git diff --check`.

This is intentionally a draft and has not been merged.