### PR TITLE
fix(upgrade): preserve legacy hash consumers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,15 +165,27 @@ jobs:
         if: always()
         run: docker rm -f pgque-stable-smoke
 
-  upgrade-v0-1-to-head:
-    name: upgrade v0.1.0 to HEAD (PG ${{ matrix.pg_version }})
+  upgrade-to-head:
+    name: upgrade ${{ matrix.from_version }} to HEAD (PG ${{ matrix.pg_version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        # Upgrade coverage uses oldest/newest supported PG endpoints; the main
-        # regression matrix above covers every supported version (14–19).
-        pg_version: ['19beta1', '14']
+        include:
+          # Keep the oldest upgrade on both supported-version endpoints.
+          - pg_version: '19beta1'
+            from_version: 'v0.1.0'
+            fixture: 'tests/test_upgrade_v0_1_fixture.sql'
+            assertions: 'tests/test_upgrade_v0_1_assertions.sql'
+          - pg_version: '14'
+            from_version: 'v0.1.0'
+            fixture: 'tests/test_upgrade_v0_1_fixture.sql'
+            assertions: 'tests/test_upgrade_v0_1_assertions.sql'
+          # Exercise the immediately preceding release with its compatibility fixture.
+          - pg_version: '17'
+            from_version: 'v0.2.0'
+            fixture: 'tests/test_upgrade_v0_2_fixture.sql'
+            assertions: 'tests/test_upgrade_v0_2_assertions.sql'
 
     steps:
       - uses: actions/checkout@v4
@@ -207,18 +219,18 @@ jobs:
       - name: Build HEAD pgque
         run: bash build/transform.sh
 
-      - name: Install v0.1.0
+      - name: Install ${{ matrix.from_version }}
         run: |
           set -Eeuo pipefail
-          git show v0.1.0:sql/pgque.sql > /tmp/pgque-v0.1.0.sql
+          git show ${{ matrix.from_version }}:sql/pgque.sql > /tmp/pgque-previous.sql
           PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
-            -v ON_ERROR_STOP=1 -f /tmp/pgque-v0.1.0.sql
+            -v ON_ERROR_STOP=1 -f /tmp/pgque-previous.sql
 
-      - name: Prepare v0.1.0 fixture
+      - name: Prepare ${{ matrix.from_version }} fixture
         run: |
           set -Eeuo pipefail
           PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
-            -v ON_ERROR_STOP=1 -f tests/test_upgrade_v0_1_fixture.sql
+            -v ON_ERROR_STOP=1 -f ${{ matrix.fixture }}
 
       - name: Upgrade to HEAD
         run: |
@@ -230,7 +242,7 @@ jobs:
         run: |
           set -Eeuo pipefail
           PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
-            -v ON_ERROR_STOP=1 -f tests/test_upgrade_v0_1_assertions.sql
+            -v ON_ERROR_STOP=1 -f ${{ matrix.assertions }}
           PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
             -v ON_ERROR_STOP=1 -f tests/test_security_public_execute.sql
           PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,15 +222,17 @@ jobs:
       - name: Install ${{ matrix.from_version }}
         run: |
           set -Eeuo pipefail
-          git show ${{ matrix.from_version }}:sql/pgque.sql > /tmp/pgque-previous.sql
-          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
-            -v ON_ERROR_STOP=1 -f /tmp/pgque-previous.sql
+          git show ${{ matrix.from_version }}:sql/pgque.sql \
+            | PAGER=cat PGPASSWORD=pgque_test psql --no-psqlrc \
+                --host=localhost --username=postgres --dbname=pgque_test \
+                --set=ON_ERROR_STOP=1
 
       - name: Prepare ${{ matrix.from_version }} fixture
         run: |
           set -Eeuo pipefail
-          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
-            -v ON_ERROR_STOP=1 -f ${{ matrix.fixture }}
+          PAGER=cat PGPASSWORD=pgque_test psql --no-psqlrc \
+            --host=localhost --username=postgres --dbname=pgque_test \
+            --set=ON_ERROR_STOP=1 --file=${{ matrix.fixture }}
 
       - name: Upgrade to HEAD
         run: |
@@ -241,8 +243,9 @@ jobs:
       - name: Verify upgraded state
         run: |
           set -Eeuo pipefail
-          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
-            -v ON_ERROR_STOP=1 -f ${{ matrix.assertions }}
+          PAGER=cat PGPASSWORD=pgque_test psql --no-psqlrc \
+            --host=localhost --username=postgres --dbname=pgque_test \
+            --set=ON_ERROR_STOP=1 --file=${{ matrix.assertions }}
           PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
             -v ON_ERROR_STOP=1 -f tests/test_security_public_execute.sql
           PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \

--- a/devel/sql/pgque-api/partition_keys.sql
+++ b/devel/sql/pgque-api/partition_keys.sql
@@ -246,6 +246,9 @@ returns void as $$
 declare
     v_queue_id int4;
     v_n int4;
+    v_slot_name text;
+    v_slot_materialized boolean;
+    v_registered int;
 begin
     if i_queue is null or i_queue = '' then
         raise exception 'queue name must not be empty';
@@ -284,8 +287,26 @@ begin
             i_consumer, i_queue, v_n, i_n;
     end if;
 
-    -- register_consumer is idempotent for an existing subscription.
-    perform pgque.register_consumer(i_queue, pgque._slot_name(i_consumer, i_slot, i_n));
+    v_slot_name := pgque._slot_name(i_consumer, i_slot, i_n);
+    select exists (
+        select 1
+        from pgque.partition_slot as ps
+        where ps.queue_id = v_queue_id
+          and ps.co_name = i_consumer
+          and ps.slot = i_slot
+    ) into v_slot_materialized;
+
+    /*
+     * register_consumer returns zero for an existing subscription. That is
+     * idempotent only when this slot was already materialized; otherwise the
+     * generated name belongs to an ordinary consumer. Raising also rolls back
+     * a partition_consumer row inserted above.
+     */
+    v_registered := pgque.register_consumer(i_queue, v_slot_name);
+    if v_registered = 0 and not v_slot_materialized then
+        raise exception 'consumer name % is already registered as an ordinary consumer on queue %; cannot reuse it for partition slot %/%',
+            v_slot_name, i_queue, i_slot, i_n;
+    end if;
 
     -- Materialize the slot's lease row (unleased). Idempotent re-subscribe.
     insert into pgque.partition_slot (queue_id, co_name, slot)

--- a/devel/sql/pgque-api/receive.sql
+++ b/devel/sql/pgque-api/receive.sql
@@ -25,11 +25,42 @@ begin
     end if;
 end $$;
 
+/* A `#` name is a slot only when subscribe_slot materialized matching
+   partition metadata. Ordinary consumers created before `#` was reserved
+   remain ordinary consumers after upgrade. */
+create or replace function pgque._is_partition_slot_consumer(
+    i_queue_id int4,
+    i_consumer text)
+returns boolean as $$
+begin
+    if i_queue_id is null
+        or i_consumer is null
+        or to_regclass('pgque.partition_consumer') is null
+        or to_regclass('pgque.partition_slot') is null
+    then
+        return false;
+    end if;
+
+    return exists (
+        select 1
+        from pgque.partition_consumer as pc
+        join pgque.partition_slot as ps
+            on ps.queue_id = pc.queue_id
+            and ps.co_name = pc.co_name
+        where pc.queue_id = i_queue_id
+          and pc.co_name || '#' || ps.slot::text || '/' || pc.n::text = i_consumer
+    );
+end;
+$$ language plpgsql stable security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque._is_partition_slot_consumer(int4, text)
+    from public, pgque_reader, pgque_writer;
+
 -- pgque.receive() -- wraps next_batch + get_batch_events
 create or replace function pgque.receive(
     i_queue text, i_consumer text, i_max_return int default 100)
 returns setof pgque.message as $$
 declare
+    v_queue_id int4;
     v_batch_id bigint;
     ev record;
     cnt int := 0;
@@ -39,14 +70,19 @@ begin
     end if;
 
     /*
-     * Guard the raw slot consumer. subscribe_slot reserves '#' (it rejects '#'
-     * in base consumer names), so a '#' name can only be a partition slot
-     * consumer "<consumer>#<slot>/<n>". The plain receive path applies neither
-     * the lease fence nor the hash filter, so it would hand back the whole
-     * unfiltered stream -- force callers onto the partitioned API.
+     * The plain receive path applies neither the lease fence nor the hash
+     * filter. Refuse cataloged slots while preserving ordinary `#` consumers
+     * that predate the reserved namespace.
      */
     if position('#' in i_consumer) > 0 then
-        raise exception 'consumer % is a partition slot consumer; use pgque.receive_partitioned()', i_consumer;
+        select q.queue_id
+        into v_queue_id
+        from pgque.queue as q
+        where q.queue_name = i_queue;
+
+        if pgque._is_partition_slot_consumer(v_queue_id, i_consumer) then
+            raise exception 'consumer % is a partition slot consumer; use pgque.receive_partitioned()', i_consumer;
+        end if;
     end if;
 
     -- Get next batch (may return NULL if no tick window is ready)
@@ -83,20 +119,29 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 create or replace function pgque.ack(i_batch_id bigint)
 returns integer as $$
 declare
+    v_queue_id int4;
     v_cname text;
 begin
     /*
      * Guard the raw slot consumer (see pgque.receive). A partition slot batch
      * must be finished through the lease-fenced ack_partitioned(); plain ack()
      * lets a fenced zombie double-ack it. Resolve the batch's consumer and
-     * reject when its name carries the reserved '#'. An unknown batch id falls
-     * through to finish_batch(), preserving the pre-guard not-found behavior.
+     * reject when the partition catalogs identify it as a slot. An unknown
+     * batch id falls through to finish_batch(), preserving not-found behavior.
      */
-    select c.co_name into v_cname
+    select
+        s.sub_queue,
+        c.co_name
+    into
+        v_queue_id,
+        v_cname
     from pgque.subscription as s
     join pgque.consumer as c on c.co_id = s.sub_consumer
     where s.sub_batch = i_batch_id;
-    if found and position('#' in v_cname) > 0 then
+    if found
+        and position('#' in v_cname) > 0
+        and pgque._is_partition_slot_consumer(v_queue_id, v_cname)
+    then
         raise exception 'batch % belongs to partition slot consumer %; use pgque.ack_partitioned()', i_batch_id, v_cname;
     end if;
 
@@ -175,6 +220,7 @@ create or replace function pgque.nack(
     i_reason text default null)
 returns integer as $$
 declare
+    v_queue_id int4;
     v_cname text;
 begin
     /*
@@ -183,11 +229,19 @@ begin
      * nack_partitioned), not plain nack(). An unknown batch id falls through to
      * the shared core, which raises the same 'batch not found' as before.
      */
-    select c.co_name into v_cname
+    select
+        s.sub_queue,
+        c.co_name
+    into
+        v_queue_id,
+        v_cname
     from pgque.subscription as s
     join pgque.consumer as c on c.co_id = s.sub_consumer
     where s.sub_batch = i_batch_id;
-    if found and position('#' in v_cname) > 0 then
+    if found
+        and position('#' in v_cname) > 0
+        and pgque._is_partition_slot_consumer(v_queue_id, v_cname)
+    then
         raise exception 'batch % belongs to partition slot consumer %; retry slot batches via pgque.nack_partitioned()', i_batch_id, v_cname;
     end if;
 

--- a/devel/sql/pgque-tle.sql
+++ b/devel/sql/pgque-tle.sql
@@ -5435,11 +5435,42 @@ begin
     end if;
 end $$;
 
+/* A `#` name is a slot only when subscribe_slot materialized matching
+   partition metadata. Ordinary consumers created before `#` was reserved
+   remain ordinary consumers after upgrade. */
+create or replace function pgque._is_partition_slot_consumer(
+    i_queue_id int4,
+    i_consumer text)
+returns boolean as $$
+begin
+    if i_queue_id is null
+        or i_consumer is null
+        or to_regclass('pgque.partition_consumer') is null
+        or to_regclass('pgque.partition_slot') is null
+    then
+        return false;
+    end if;
+
+    return exists (
+        select 1
+        from pgque.partition_consumer as pc
+        join pgque.partition_slot as ps
+            on ps.queue_id = pc.queue_id
+            and ps.co_name = pc.co_name
+        where pc.queue_id = i_queue_id
+          and pc.co_name || '#' || ps.slot::text || '/' || pc.n::text = i_consumer
+    );
+end;
+$$ language plpgsql stable security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque._is_partition_slot_consumer(int4, text)
+    from public, pgque_reader, pgque_writer;
+
 -- pgque.receive() -- wraps next_batch + get_batch_events
 create or replace function pgque.receive(
     i_queue text, i_consumer text, i_max_return int default 100)
 returns setof pgque.message as $$
 declare
+    v_queue_id int4;
     v_batch_id bigint;
     ev record;
     cnt int := 0;
@@ -5449,14 +5480,19 @@ begin
     end if;
 
     /*
-     * Guard the raw slot consumer. subscribe_slot reserves '#' (it rejects '#'
-     * in base consumer names), so a '#' name can only be a partition slot
-     * consumer "<consumer>#<slot>/<n>". The plain receive path applies neither
-     * the lease fence nor the hash filter, so it would hand back the whole
-     * unfiltered stream -- force callers onto the partitioned API.
+     * The plain receive path applies neither the lease fence nor the hash
+     * filter. Refuse cataloged slots while preserving ordinary `#` consumers
+     * that predate the reserved namespace.
      */
     if position('#' in i_consumer) > 0 then
-        raise exception 'consumer % is a partition slot consumer; use pgque.receive_partitioned()', i_consumer;
+        select q.queue_id
+        into v_queue_id
+        from pgque.queue as q
+        where q.queue_name = i_queue;
+
+        if pgque._is_partition_slot_consumer(v_queue_id, i_consumer) then
+            raise exception 'consumer % is a partition slot consumer; use pgque.receive_partitioned()', i_consumer;
+        end if;
     end if;
 
     -- Get next batch (may return NULL if no tick window is ready)
@@ -5493,20 +5529,29 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 create or replace function pgque.ack(i_batch_id bigint)
 returns integer as $$
 declare
+    v_queue_id int4;
     v_cname text;
 begin
     /*
      * Guard the raw slot consumer (see pgque.receive). A partition slot batch
      * must be finished through the lease-fenced ack_partitioned(); plain ack()
      * lets a fenced zombie double-ack it. Resolve the batch's consumer and
-     * reject when its name carries the reserved '#'. An unknown batch id falls
-     * through to finish_batch(), preserving the pre-guard not-found behavior.
+     * reject when the partition catalogs identify it as a slot. An unknown
+     * batch id falls through to finish_batch(), preserving not-found behavior.
      */
-    select c.co_name into v_cname
+    select
+        s.sub_queue,
+        c.co_name
+    into
+        v_queue_id,
+        v_cname
     from pgque.subscription as s
     join pgque.consumer as c on c.co_id = s.sub_consumer
     where s.sub_batch = i_batch_id;
-    if found and position('#' in v_cname) > 0 then
+    if found
+        and position('#' in v_cname) > 0
+        and pgque._is_partition_slot_consumer(v_queue_id, v_cname)
+    then
         raise exception 'batch % belongs to partition slot consumer %; use pgque.ack_partitioned()', i_batch_id, v_cname;
     end if;
 
@@ -5585,6 +5630,7 @@ create or replace function pgque.nack(
     i_reason text default null)
 returns integer as $$
 declare
+    v_queue_id int4;
     v_cname text;
 begin
     /*
@@ -5593,11 +5639,19 @@ begin
      * nack_partitioned), not plain nack(). An unknown batch id falls through to
      * the shared core, which raises the same 'batch not found' as before.
      */
-    select c.co_name into v_cname
+    select
+        s.sub_queue,
+        c.co_name
+    into
+        v_queue_id,
+        v_cname
     from pgque.subscription as s
     join pgque.consumer as c on c.co_id = s.sub_consumer
     where s.sub_batch = i_batch_id;
-    if found and position('#' in v_cname) > 0 then
+    if found
+        and position('#' in v_cname) > 0
+        and pgque._is_partition_slot_consumer(v_queue_id, v_cname)
+    then
         raise exception 'batch % belongs to partition slot consumer %; retry slot batches via pgque.nack_partitioned()', i_batch_id, v_cname;
     end if;
 
@@ -7433,6 +7487,9 @@ returns void as $$
 declare
     v_queue_id int4;
     v_n int4;
+    v_slot_name text;
+    v_slot_materialized boolean;
+    v_registered int;
 begin
     if i_queue is null or i_queue = '' then
         raise exception 'queue name must not be empty';
@@ -7471,8 +7528,26 @@ begin
             i_consumer, i_queue, v_n, i_n;
     end if;
 
-    -- register_consumer is idempotent for an existing subscription.
-    perform pgque.register_consumer(i_queue, pgque._slot_name(i_consumer, i_slot, i_n));
+    v_slot_name := pgque._slot_name(i_consumer, i_slot, i_n);
+    select exists (
+        select 1
+        from pgque.partition_slot as ps
+        where ps.queue_id = v_queue_id
+          and ps.co_name = i_consumer
+          and ps.slot = i_slot
+    ) into v_slot_materialized;
+
+    /*
+     * register_consumer returns zero for an existing subscription. That is
+     * idempotent only when this slot was already materialized; otherwise the
+     * generated name belongs to an ordinary consumer. Raising also rolls back
+     * a partition_consumer row inserted above.
+     */
+    v_registered := pgque.register_consumer(i_queue, v_slot_name);
+    if v_registered = 0 and not v_slot_materialized then
+        raise exception 'consumer name % is already registered as an ordinary consumer on queue %; cannot reuse it for partition slot %/%',
+            v_slot_name, i_queue, i_slot, i_n;
+    end if;
 
     -- Materialize the slot's lease row (unleased). Idempotent re-subscribe.
     insert into pgque.partition_slot (queue_id, co_name, slot)

--- a/devel/sql/pgque.sql
+++ b/devel/sql/pgque.sql
@@ -5345,11 +5345,42 @@ begin
     end if;
 end $$;
 
+/* A `#` name is a slot only when subscribe_slot materialized matching
+   partition metadata. Ordinary consumers created before `#` was reserved
+   remain ordinary consumers after upgrade. */
+create or replace function pgque._is_partition_slot_consumer(
+    i_queue_id int4,
+    i_consumer text)
+returns boolean as $$
+begin
+    if i_queue_id is null
+        or i_consumer is null
+        or to_regclass('pgque.partition_consumer') is null
+        or to_regclass('pgque.partition_slot') is null
+    then
+        return false;
+    end if;
+
+    return exists (
+        select 1
+        from pgque.partition_consumer as pc
+        join pgque.partition_slot as ps
+            on ps.queue_id = pc.queue_id
+            and ps.co_name = pc.co_name
+        where pc.queue_id = i_queue_id
+          and pc.co_name || '#' || ps.slot::text || '/' || pc.n::text = i_consumer
+    );
+end;
+$$ language plpgsql stable security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque._is_partition_slot_consumer(int4, text)
+    from public, pgque_reader, pgque_writer;
+
 -- pgque.receive() -- wraps next_batch + get_batch_events
 create or replace function pgque.receive(
     i_queue text, i_consumer text, i_max_return int default 100)
 returns setof pgque.message as $$
 declare
+    v_queue_id int4;
     v_batch_id bigint;
     ev record;
     cnt int := 0;
@@ -5359,14 +5390,19 @@ begin
     end if;
 
     /*
-     * Guard the raw slot consumer. subscribe_slot reserves '#' (it rejects '#'
-     * in base consumer names), so a '#' name can only be a partition slot
-     * consumer "<consumer>#<slot>/<n>". The plain receive path applies neither
-     * the lease fence nor the hash filter, so it would hand back the whole
-     * unfiltered stream -- force callers onto the partitioned API.
+     * The plain receive path applies neither the lease fence nor the hash
+     * filter. Refuse cataloged slots while preserving ordinary `#` consumers
+     * that predate the reserved namespace.
      */
     if position('#' in i_consumer) > 0 then
-        raise exception 'consumer % is a partition slot consumer; use pgque.receive_partitioned()', i_consumer;
+        select q.queue_id
+        into v_queue_id
+        from pgque.queue as q
+        where q.queue_name = i_queue;
+
+        if pgque._is_partition_slot_consumer(v_queue_id, i_consumer) then
+            raise exception 'consumer % is a partition slot consumer; use pgque.receive_partitioned()', i_consumer;
+        end if;
     end if;
 
     -- Get next batch (may return NULL if no tick window is ready)
@@ -5403,20 +5439,29 @@ $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 create or replace function pgque.ack(i_batch_id bigint)
 returns integer as $$
 declare
+    v_queue_id int4;
     v_cname text;
 begin
     /*
      * Guard the raw slot consumer (see pgque.receive). A partition slot batch
      * must be finished through the lease-fenced ack_partitioned(); plain ack()
      * lets a fenced zombie double-ack it. Resolve the batch's consumer and
-     * reject when its name carries the reserved '#'. An unknown batch id falls
-     * through to finish_batch(), preserving the pre-guard not-found behavior.
+     * reject when the partition catalogs identify it as a slot. An unknown
+     * batch id falls through to finish_batch(), preserving not-found behavior.
      */
-    select c.co_name into v_cname
+    select
+        s.sub_queue,
+        c.co_name
+    into
+        v_queue_id,
+        v_cname
     from pgque.subscription as s
     join pgque.consumer as c on c.co_id = s.sub_consumer
     where s.sub_batch = i_batch_id;
-    if found and position('#' in v_cname) > 0 then
+    if found
+        and position('#' in v_cname) > 0
+        and pgque._is_partition_slot_consumer(v_queue_id, v_cname)
+    then
         raise exception 'batch % belongs to partition slot consumer %; use pgque.ack_partitioned()', i_batch_id, v_cname;
     end if;
 
@@ -5495,6 +5540,7 @@ create or replace function pgque.nack(
     i_reason text default null)
 returns integer as $$
 declare
+    v_queue_id int4;
     v_cname text;
 begin
     /*
@@ -5503,11 +5549,19 @@ begin
      * nack_partitioned), not plain nack(). An unknown batch id falls through to
      * the shared core, which raises the same 'batch not found' as before.
      */
-    select c.co_name into v_cname
+    select
+        s.sub_queue,
+        c.co_name
+    into
+        v_queue_id,
+        v_cname
     from pgque.subscription as s
     join pgque.consumer as c on c.co_id = s.sub_consumer
     where s.sub_batch = i_batch_id;
-    if found and position('#' in v_cname) > 0 then
+    if found
+        and position('#' in v_cname) > 0
+        and pgque._is_partition_slot_consumer(v_queue_id, v_cname)
+    then
         raise exception 'batch % belongs to partition slot consumer %; retry slot batches via pgque.nack_partitioned()', i_batch_id, v_cname;
     end if;
 
@@ -7343,6 +7397,9 @@ returns void as $$
 declare
     v_queue_id int4;
     v_n int4;
+    v_slot_name text;
+    v_slot_materialized boolean;
+    v_registered int;
 begin
     if i_queue is null or i_queue = '' then
         raise exception 'queue name must not be empty';
@@ -7381,8 +7438,26 @@ begin
             i_consumer, i_queue, v_n, i_n;
     end if;
 
-    -- register_consumer is idempotent for an existing subscription.
-    perform pgque.register_consumer(i_queue, pgque._slot_name(i_consumer, i_slot, i_n));
+    v_slot_name := pgque._slot_name(i_consumer, i_slot, i_n);
+    select exists (
+        select 1
+        from pgque.partition_slot as ps
+        where ps.queue_id = v_queue_id
+          and ps.co_name = i_consumer
+          and ps.slot = i_slot
+    ) into v_slot_materialized;
+
+    /*
+     * register_consumer returns zero for an existing subscription. That is
+     * idempotent only when this slot was already materialized; otherwise the
+     * generated name belongs to an ordinary consumer. Raising also rolls back
+     * a partition_consumer row inserted above.
+     */
+    v_registered := pgque.register_consumer(i_queue, v_slot_name);
+    if v_registered = 0 and not v_slot_materialized then
+        raise exception 'consumer name % is already registered as an ordinary consumer on queue %; cannot reuse it for partition slot %/%',
+            v_slot_name, i_queue, i_slot, i_n;
+    end if;
 
     -- Materialize the slot's lease row (unleased). Idempotent re-subscribe.
     insert into pgque.partition_slot (queue_id, co_name, slot)

--- a/tests/test_partition_keys.sql
+++ b/tests/test_partition_keys.sql
@@ -574,15 +574,14 @@ begin
 end $$;
 
 -- (a2) pgque.subscribe() must reject the reserved '#' at registration time.
--- The plain receive/ack/nack guards treat any '#' name as a partition slot
--- consumer, so a plain consumer registered with a '#' in its name would be
--- permanently locked out of receive/ack/nack. Reject '#' up front instead.
+-- Existing ordinary '#' consumers remain valid for upgrade compatibility,
+-- but new registrations must not collide with the slot namespace.
 do $$
 declare
   v_raised boolean := false;
 begin
   begin
-    perform pgque.subscribe('pk_q', 'team#1');
+    perform pgque.subscribe('pk_q', 'new#plain');
   exception
     when others then
       v_raised := true;
@@ -592,7 +591,7 @@ begin
   assert v_raised, 'guard: subscribe() must reject a consumer name containing #';
 
   -- No half-created state: the rejected name must not leave a consumer row.
-  perform 1 from pgque.consumer where co_name = 'team#1';
+  perform 1 from pgque.consumer where co_name = 'new#plain';
   assert not found, 'guard: rejected subscribe() must not create the consumer';
   raise notice 'PASS guard: subscribe() refuses # in the consumer name';
 end $$;

--- a/tests/test_upgrade_v0_2_assertions.sql
+++ b/tests/test_upgrade_v0_2_assertions.sql
@@ -1,0 +1,165 @@
+\set ON_ERROR_STOP on
+
+-- Verify a v0.2.0 ordinary consumer containing # remains usable after upgrade.
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+set role pgque_reader;
+
+do $$
+declare
+  v_msg pgque.message;
+  v_batch_id bigint;
+  v_count int := 0;
+begin
+  for v_msg in
+    select *
+    from pgque.receive('upgrade_v02_hash_q', 'team#1', 10)
+  loop
+    v_count := v_count + 1;
+    v_batch_id := v_msg.batch_id;
+    assert v_msg.type = 'upgrade.pending',
+      'legacy # consumer should receive the pending pre-upgrade event';
+    assert v_msg.payload::jsonb = '{"phase":"before-upgrade"}'::jsonb,
+      'pending pre-upgrade payload should survive';
+  end loop;
+
+  assert v_count = 1,
+    format('legacy # consumer should receive one pending event, got %s', v_count);
+  assert pgque.ack(v_batch_id) = 1,
+    'plain ack should remain usable for a legacy # consumer';
+end $$;
+
+reset role;
+
+do $$
+declare
+  v_raised boolean := false;
+begin
+  begin
+    perform pgque.subscribe_slot('upgrade_v02_hash_q', 'workers', 0, 2);
+  exception when others then
+    v_raised := true;
+    assert sqlerrm like '%already registered as an ordinary consumer%',
+      format('slot-name collision should identify the ordinary consumer, got: %s', sqlerrm);
+  end;
+
+  assert v_raised,
+    'an ordinary consumer matching a generated slot name must not be reclassified';
+  assert exists (
+    select 1
+    from pgque.subscription as s
+    join pgque.queue as q on q.queue_id = s.sub_queue
+    join pgque.consumer as c on c.co_id = s.sub_consumer
+    where q.queue_name = 'upgrade_v02_hash_q'
+      and c.co_name = 'workers#0/2'
+  ), 'slot-name collision must preserve the ordinary subscription';
+  assert not exists (
+    select 1
+    from pgque.partition_consumer as pc
+    join pgque.queue as q on q.queue_id = pc.queue_id
+    where q.queue_name = 'upgrade_v02_hash_q'
+      and pc.co_name = 'workers'
+  ), 'slot-name collision must roll back the partial partition consumer';
+  assert not exists (
+    select 1
+    from pgque.partition_slot as ps
+    join pgque.queue as q on q.queue_id = ps.queue_id
+    where q.queue_name = 'upgrade_v02_hash_q'
+      and ps.co_name = 'workers'
+      and ps.slot = 0
+  ), 'slot-name collision must not materialize a partition slot';
+
+  perform pgque.subscribe_slot('upgrade_v02_hash_q', 'materialized', 0, 2);
+  perform pgque.subscribe_slot('upgrade_v02_hash_q', 'materialized', 0, 2);
+  assert (
+    select count(*) = 1
+    from pgque.partition_slot as ps
+    join pgque.queue as q on q.queue_id = ps.queue_id
+    where q.queue_name = 'upgrade_v02_hash_q'
+      and ps.co_name = 'materialized'
+      and ps.slot = 0
+  ), 're-subscribing a materialized slot must remain idempotent';
+  assert (
+    select count(*) = 1
+    from pgque.subscription as s
+    join pgque.queue as q on q.queue_id = s.sub_queue
+    join pgque.consumer as c on c.co_id = s.sub_consumer
+    where q.queue_name = 'upgrade_v02_hash_q'
+      and c.co_name = 'materialized#0/2'
+  ), 'idempotent slot re-subscribe must keep one engine subscription';
+  perform pgque.unsubscribe_slot('upgrade_v02_hash_q', 'materialized', 0);
+
+  raise notice 'PASS: exact generated slot-name collision remains ordinary';
+end $$;
+
+do $$
+begin
+  perform pgque.send(
+    'upgrade_v02_hash_q',
+    'upgrade.nack',
+    '{"phase":"after-upgrade"}'::jsonb
+  );
+end $$;
+
+do $$
+begin
+  perform pgque.force_next_tick('upgrade_v02_hash_q');
+  perform pgque.ticker();
+end $$;
+
+set role pgque_reader;
+
+do $$
+declare
+  v_msg pgque.message;
+  v_batch_id bigint;
+  v_count int := 0;
+begin
+  for v_msg in
+    select *
+    from pgque.receive('upgrade_v02_hash_q', 'team#1', 10)
+  loop
+    v_count := v_count + 1;
+    v_batch_id := v_msg.batch_id;
+    assert pgque.nack(v_msg.batch_id, v_msg, interval '0 seconds', 'upgrade check') = 1,
+      'plain nack should remain usable for a legacy # consumer';
+  end loop;
+
+  assert v_count = 1,
+    format('legacy # consumer should receive one post-upgrade event, got %s', v_count);
+  assert pgque.ack(v_batch_id) = 1,
+    'batch containing the nacked event should be finishable';
+  assert exists (
+    select 1
+    from pgque.dead_letter as dl
+    join pgque.queue as q on q.queue_id = dl.dl_queue_id
+    join pgque.consumer as c on c.co_id = dl.dl_consumer_id
+    where q.queue_name = 'upgrade_v02_hash_q'
+      and c.co_name = 'team#1'
+      and dl.ev_type = 'upgrade.nack'
+  ), 'legacy # consumer nack should create a dead-letter row';
+end $$;
+
+do $$
+declare
+  v_raised boolean := false;
+begin
+  begin
+    perform pgque.subscribe('upgrade_v02_hash_q', 'new#plain');
+  exception when others then
+    v_raised := true;
+    assert sqlerrm like '%reserved character #%',
+      format('new # consumer rejection should name the reserved character, got: %s', sqlerrm);
+  end;
+
+  assert v_raised, 'new plain consumers containing # should remain rejected';
+  assert not exists (
+    select 1
+    from pgque.consumer
+    where co_name = 'new#plain'
+  ), 'rejected new # consumer should leave no catalog row';
+
+  raise notice 'PASS: legacy # consumer receive/ack/nack survived v0.2.0 upgrade';
+end $$;
+
+reset role;

--- a/tests/test_upgrade_v0_2_fixture.sql
+++ b/tests/test_upgrade_v0_2_fixture.sql
@@ -1,0 +1,54 @@
+\set ON_ERROR_STOP on
+
+-- Build v0.2.0 state that exercises the legacy consumer-name namespace.
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+do $$
+begin
+  if exists (
+    select 1
+    from pgque.queue
+    where queue_name = 'upgrade_v02_hash_q'
+  ) then
+    perform pgque.drop_queue('upgrade_v02_hash_q', true);
+  end if;
+
+  perform pgque.create_queue('upgrade_v02_hash_q');
+  perform pgque.set_queue_config('upgrade_v02_hash_q', 'max_retries', '0');
+  perform pgque.subscribe('upgrade_v02_hash_q', 'team#1');
+  perform pgque.subscribe('upgrade_v02_hash_q', 'workers#0/2');
+  perform pgque.send(
+    'upgrade_v02_hash_q',
+    'upgrade.pending',
+    '{"phase":"before-upgrade"}'::jsonb
+  );
+end $$;
+
+do $$
+begin
+  perform pgque.force_next_tick('upgrade_v02_hash_q');
+  perform pgque.ticker();
+end $$;
+
+do $$
+begin
+  assert exists (
+    select 1
+    from pgque.subscription as s
+    join pgque.queue as q on q.queue_id = s.sub_queue
+    join pgque.consumer as c on c.co_id = s.sub_consumer
+    where q.queue_name = 'upgrade_v02_hash_q'
+      and c.co_name = 'team#1'
+  ), 'legacy # consumer subscription should exist before upgrade';
+
+  assert exists (
+    select 1
+    from pgque.subscription as s
+    join pgque.queue as q on q.queue_id = s.sub_queue
+    join pgque.consumer as c on c.co_id = s.sub_consumer
+    where q.queue_name = 'upgrade_v02_hash_q'
+      and c.co_name = 'workers#0/2'
+  ), 'legacy consumer colliding with a generated slot name should exist before upgrade';
+
+  raise notice 'PASS: v0.2.0 legacy # consumer fixture prepared';
+end $$;


### PR DESCRIPTION
## What changed

- classify a consumer as a partition slot only when matching partition metadata exists, rather than from `#` in its name;
- preserve plain receive/ack/nack for ordinary consumers created before `#` became reserved;
- prevent `subscribe_slot` from silently reusing an exact generated name that belongs to a legacy ordinary consumer;
- retain rejection of new plain `#` registrations and idempotent re-subscribe for genuine slots;
- add a real v0.2.0→HEAD upgrade fixture/assertion set and CI lane;
- regenerate development install artifacts.

## Why

PgQue 0.2.0 allowed ordinary consumer names containing `#`. After upgrade, 0.3's string-only guard stranded those subscriptions even though their queue position and pending events survived. Exact slot-shaped names could also be silently reclassified.

Fixes #306.

## Validation

Red evidence:

```text
ERROR: consumer team#1 is a partition slot consumer;
       use pgque.receive_partitioned()
```

The collision regression also reproduced `subscribe_slot` silently reusing `workers#0/2` before the fix.

Green checks:

- real v0.2.0 install → pending legacy event → transactional HEAD upgrade;
- legacy `team#1` receive, ack, nack, and DLQ behavior as bare `pgque_reader`;
- exact generated-name collision is rejected with ordinary subscription and rollback-clean partition metadata preserved;
- genuine slot re-subscribe remains idempotent;
- exact new CI sequence including grants, roles, security, reinstall, and idempotency checks;
- existing v0.1.0→HEAD upgrade fixture;
- complete `tests/run_all.sql`;
- `bash build/transform.sh`, YAML parse, shell syntax, and `git diff --check`.

This is intentionally a draft and has not been merged.