### PR TITLE
fix(ruby): reject unsupported event extras

### DIFF
--- a/clients/ruby/README.md
+++ b/clients/ruby/README.md
@@ -95,7 +95,7 @@ client.send("orders", event)
 
 It accepts only `payload:` and `type:`. The receive-side `extra1` through
 `extra4` fields are not supported by this producer wrapper; unknown keywords
-such as `extra:` raise `ArgumentError` instead of being silently discarded.
+such as `extra:` raise `ArgumentError`.
 
 ### Consumer options
 

--- a/clients/ruby/README.md
+++ b/clients/ruby/README.md
@@ -83,6 +83,20 @@ ticking from your application or an external scheduler — see the
 project [Installation](https://github.com/NikolayS/pgque#installation)
 section for both paths.
 
+### Event inputs
+
+`Pgque::Event` is an optional value object for carrying a payload and type
+together before sending:
+
+```ruby
+event = Pgque::Event.new(payload: { "order_id" => 42 }, type: "order.created")
+client.send("orders", event)
+```
+
+It accepts only `payload:` and `type:`. The receive-side `extra1` through
+`extra4` fields are not supported by this producer wrapper; unknown keywords
+such as `extra:` raise `ArgumentError` instead of being silently discarded.
+
 ### Consumer options
 
 `Consumer.new(..., max_messages: ...)` controls the per-`receive` limit.

--- a/clients/ruby/lib/pgque/event.rb
+++ b/clients/ruby/lib/pgque/event.rb
@@ -2,12 +2,11 @@
 
 module Pgque
   class Event
-    attr_reader :payload, :type, :extra
+    attr_reader :payload, :type
 
-    def initialize(payload:, type: "default", extra: {})
+    def initialize(payload:, type: "default")
       @payload = payload
       @type = type
-      @extra = extra
     end
   end
 end

--- a/clients/ruby/test/test_send.rb
+++ b/clients/ruby/test/test_send.rb
@@ -23,12 +23,33 @@ class TestSend < Minitest::Test
   end
 
   def test_send_event_object
-    with_queue do |queue, _consumer, conn|
+    with_queue do |queue, consumer, conn|
       client = Pgque::Client.new(conn)
-      event = Pgque::Event.new(payload: { "x" => 1 }, type: "custom.t")
+      payload = { "x" => 1 }
+      event = Pgque::Event.new(payload: payload, type: "custom.t")
+      refute_respond_to event, :extra
       eid = client.send(queue, event)
       assert_kind_of Integer, eid
+
+      conn.exec_params("select pgque.force_next_tick($1)", [queue])
+      conn.exec_params("select pgque.ticker($1)", [queue])
+      msg = client.receive(queue, consumer, 1).fetch(0)
+      assert_equal eid, msg.msg_id
+      assert_equal "custom.t", msg.type
+      assert_equal payload, msg.payload
+      client.ack(msg.batch_id)
     end
+  end
+
+  def test_event_rejects_extra_keyword_instead_of_silently_dropping_it
+    error = assert_raises(ArgumentError) do
+      Pgque::Event.new(
+        payload: { "x" => 1 },
+        type: "custom.t",
+        extra: { "trace_id" => "lost" },
+      )
+    end
+    assert_match(/unknown keyword.*extra/, error.message)
   end
 
   def test_send_str_payload_passes_through


### PR DESCRIPTION
## Summary

- remove the unsupported `extra:` field from `Pgque::Event`
- reject unknown event keywords instead of silently discarding producer data
- document the exact event input contract and test the database round trip

Fixes #314.

## Validation

- baseline replay of the final focused tests: `2 runs, 2 assertions, 2 expected failures`
- focused head command: `ruby -Ilib -Itest test/test_send.rb --name '/^(test_send_event_object|test_event_rejects_extra_keyword_instead_of_silently_dropping_it)$/'` — `2 runs, 8 assertions, 0 failures`
- full database-backed command: `PGQUE_TEST_DSN=postgresql:///pgque_pr_rules_audit ruby -S rake test` — `77 runs, 199 assertions, 0 failures, 0 errors, 0 skips`
- gem build, isolated install, and installed-artifact contract smoke passed
- `git diff --check` passed
