### PR TITLE
fix(python): derive runtime version from metadata

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   build:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || inputs.dry_run
     runs-on: ubuntu-latest
     env:
       VERSION: ${{ inputs.version }}

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -42,10 +42,19 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install release tooling
+        run: |
+          set -Eeuo pipefail
+          python -m pip install -U \
+            build \
+            packaging \
+            'psycopg[binary]>=3.1,<4' \
+            pytest \
+            twine
+
       - name: Verify version input
         run: |
           set -Eeuo pipefail
-          python -m pip install -U packaging
           # Validate PEP 440 (accepts 0.2.0, 0.2.0rc1, 0.2.0.dev1, 0.2.0a1, 0.2.0.post1, ...).
           # Reject hyphenated forms like 0.2.0-dev that PyPI normalises into something
           # the operator did not type, since "version input == pyproject.toml" then
@@ -71,25 +80,127 @@ jobs:
             exit 1
           }
 
+      - name: Verify source and editable runtime versions
+        run: |
+          set -Eeuo pipefail
+          python - <<'PY'
+          import importlib.metadata as md
+          import os
+          import sys
+
+          try:
+              installed = md.version("pgque-py")
+          except md.PackageNotFoundError:
+              pass
+          else:
+              sys.exit(f"expected clean source checkout, found pgque-py {installed}")
+
+          import pgque
+
+          expected = os.environ["VERSION"]
+          if pgque.__version__ != expected:
+              sys.exit(
+                  f"source runtime version {pgque.__version__!r} != input {expected!r}"
+              )
+          print(f"source runtime version: {pgque.__version__}")
+          PY
+
+          pytest -q
+
+          python -m pip install --no-deps -e .
+          tmp=$(mktemp -d)
+          trap 'rm -rf "$tmp"' EXIT
+          (
+            cd "$tmp"
+            python - <<'PY'
+          import importlib.metadata as md
+          import os
+          import pgque
+
+          expected = os.environ["VERSION"]
+          distribution = md.version("pgque-py")
+          if distribution != expected or pgque.__version__ != expected:
+              raise SystemExit(
+                  "editable version mismatch: "
+                  f"input={expected!r}, metadata={distribution!r}, "
+                  f"runtime={pgque.__version__!r}"
+              )
+          print(f"editable runtime version: {pgque.__version__}")
+          PY
+          )
+
       - name: Build distribution
         run: |
           set -Eeuo pipefail
-          python -m pip install -U build twine
           python -m build
           python -m twine check dist/*
+
+      - name: Verify built wheel metadata
+        run: |
+          set -Eeuo pipefail
+          python - <<'PY'
+          from email.parser import BytesParser
+          import os
+          from pathlib import Path
+          import sys
+          from zipfile import ZipFile
+
+          wheels = list(Path("dist").glob("*.whl"))
+          if len(wheels) != 1:
+              sys.exit(f"expected exactly one wheel, found: {wheels}")
+
+          with ZipFile(wheels[0]) as wheel:
+              metadata_files = [
+                  name
+                  for name in wheel.namelist()
+                  if name.endswith(".dist-info/METADATA")
+              ]
+              if len(metadata_files) != 1:
+                  sys.exit(
+                      f"expected exactly one wheel METADATA file, found: {metadata_files}"
+                  )
+              package_metadata = BytesParser().parsebytes(
+                  wheel.read(metadata_files[0])
+              )
+
+          expected = os.environ["VERSION"]
+          name = package_metadata["Name"]
+          version = package_metadata["Version"]
+          if name != "pgque-py" or version != expected:
+              sys.exit(
+                  "wheel metadata mismatch: "
+                  f"expected pgque-py {expected}, found {name} {version}"
+              )
+          print(f"wheel metadata version: {version}")
+          PY
 
       - name: Verify built wheel installs
         run: |
           set -Eeuo pipefail
-          python -m venv /tmp/pgque-python-wheel-check
-          . /tmp/pgque-python-wheel-check/bin/activate
-          python -m pip install dist/*.whl
-          python - <<'PY'
+          tmp=$(mktemp -d)
+          trap 'rm -rf "$tmp"' EXIT
+          wheel=$(realpath dist/*.whl)
+          python -m venv "$tmp/venv"
+          "$tmp/venv/bin/python" -m pip install "$wheel"
+          (
+            cd "$tmp"
+            "$tmp/venv/bin/python" - <<'PY'
           import importlib.metadata as md
+          import os
           import pgque
-          assert md.version('pgque-py')
-          assert hasattr(pgque, 'PgqueClient')
+
+          expected = os.environ["VERSION"]
+          distribution = md.version("pgque-py")
+          if distribution != expected or pgque.__version__ != expected:
+              raise SystemExit(
+                  "installed wheel version mismatch: "
+                  f"input={expected!r}, metadata={distribution!r}, "
+                  f"runtime={pgque.__version__!r}"
+              )
+          assert hasattr(pgque, "PgqueClient")
+          print(f"installed wheel runtime version: {pgque.__version__}")
           PY
+          )
 
       - name: Upload distributions
         if: ${{ !inputs.dry_run }}

--- a/clients/python/RELEASE.md
+++ b/clients/python/RELEASE.md
@@ -23,6 +23,11 @@ Use Python/PEP 440 version strings in `pyproject.toml`. For a development or
 pre-release build, use forms like `0.2.0.dev0` or `0.2.0rc1`; do **not** use
 Git-style `0.2.0-dev`, which PyPI rejects.
 
+`pyproject.toml` is the authoritative version source. An installed or editable
+client exposes the corresponding distribution metadata as `pgque.__version__`;
+a direct import from an uninstalled source checkout falls back to reading the
+same `pyproject.toml` value.
+
 ## GitHub environment prerequisite
 
 Before the first real publish, create GitHub environments in `NikolayS/pgque`:
@@ -47,9 +52,11 @@ The release workflow is `.github/workflows/release-python.yml`.
    - environment: `pypi`
    - package: `pgque-py`
 5. In TestPyPI, configure the same workflow with environment `testpypi`.
-6. Run **Release Python client** with `dry_run=true` first. Dry runs only build
-   and validate artifacts; they do not require `testpypi` / `pypi` environment
-   approval or OIDC permissions.
+6. Run **Release Python client** with `dry_run=true` first. Dry runs compare the
+   input version with `pyproject.toml`, the built wheel metadata, and
+   `pgque.__version__` in source, editable, and installed-wheel contexts. They
+   also run the test suite and `twine check`, but do not require `testpypi` /
+   `pypi` environment approval or OIDC permissions.
 7. Run it with `dry_run=false` and `repository=testpypi`.
 8. Verify the TestPyPI artifact installs in a clean environment, using PyPI
    as the extra index for dependencies:
@@ -62,5 +69,6 @@ The release workflow is `.github/workflows/release-python.yml`.
    ```
 9. Run the workflow again with `dry_run=false` and `repository=pypi`.
 
-The workflow builds with `python -m build`, validates with `twine check`, and
-publishes via PyPI Trusted Publisher / OIDC. No long-lived PyPI token is needed.
+The workflow builds with `python -m build`, validates the exact wheel in an
+isolated virtual environment, and publishes via PyPI Trusted Publisher / OIDC.
+No long-lived PyPI token is needed.

--- a/clients/python/pgque/__init__.py
+++ b/clients/python/pgque/__init__.py
@@ -16,6 +16,7 @@ See https://github.com/NikolayS/pgque for the SQL schema install and
 full documentation.
 """
 
+from ._version import resolve_version as _resolve_version
 from .client import PgqueClient, connect
 from .consumer import Consumer
 from .errors import (
@@ -27,7 +28,8 @@ from .errors import (
 )
 from .types import Event, Message
 
-__version__ = "0.2.0"
+__version__ = _resolve_version()
+del _resolve_version
 
 __all__ = [
     "PgqueClient",

--- a/clients/python/pgque/_version.py
+++ b/clients/python/pgque/_version.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+"""Resolve the client version from installed or source metadata."""
+
+from importlib import metadata
+from pathlib import Path
+import re
+
+
+_DISTRIBUTION_NAME = "pgque-py"
+_PYPROJECT_PATH = Path(__file__).resolve().parent.parent / "pyproject.toml"
+_UNKNOWN_VERSION = "0+unknown"
+_VERSION_ASSIGNMENT = re.compile(
+    r"^version\s*=\s*(['\"])([^'\"]+)\1\s*(?:#.*)?$"
+)
+
+
+def source_version(pyproject_path: Path) -> str:
+    """Read ``project.version`` when running from an unpackaged source tree."""
+    try:
+        lines = pyproject_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return _UNKNOWN_VERSION
+
+    in_project_table = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("["):
+            in_project_table = stripped == "[project]"
+            continue
+        if not in_project_table:
+            continue
+
+        match = _VERSION_ASSIGNMENT.fullmatch(stripped)
+        if match:
+            return match.group(2)
+
+    return _UNKNOWN_VERSION
+
+
+def resolve_version() -> str:
+    """Return installed metadata, falling back for direct source imports."""
+    try:
+        return metadata.version(_DISTRIBUTION_NAME)
+    except metadata.PackageNotFoundError:
+        return source_version(_PYPROJECT_PATH)

--- a/clients/python/tests/test_version.py
+++ b/clients/python/tests/test_version.py
@@ -9,6 +9,9 @@ import pgque
 import pgque._version as version_module
 
 
+RELEASE_WORKFLOW = Path(__file__).parents[3] / ".github/workflows/release-python.yml"
+
+
 def test_distribution_metadata_is_authoritative(monkeypatch):
     monkeypatch.setattr(
         version_module.metadata,
@@ -65,3 +68,11 @@ def test_runtime_version_matches_available_package_metadata():
         )
 
     assert pgque.__version__ == expected
+
+
+def test_branch_release_dry_run_executes_validation_without_publish():
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "if: github.ref == 'refs/heads/main' || inputs.dry_run" in workflow
+    assert "if: ${{ !inputs.dry_run && inputs.repository == 'testpypi' }}" in workflow
+    assert "if: ${{ !inputs.dry_run && inputs.repository == 'pypi' }}" in workflow

--- a/clients/python/tests/test_version.py
+++ b/clients/python/tests/test_version.py
@@ -1,0 +1,67 @@
+# Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+"""Version metadata stays consistent in installed and source contexts."""
+
+from importlib import metadata
+from pathlib import Path
+
+import pgque
+import pgque._version as version_module
+
+
+def test_distribution_metadata_is_authoritative(monkeypatch):
+    monkeypatch.setattr(
+        version_module.metadata,
+        "version",
+        lambda distribution: "1.2.3" if distribution == "pgque-py" else None,
+    )
+
+    assert version_module.resolve_version() == "1.2.3"
+
+
+def test_source_tree_fallback_reads_project_version(monkeypatch, tmp_path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[tool.example]
+version = "9.9.9"
+
+[project]
+name = "pgque-py"
+version = "1.2.3rc1"
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    def package_not_found(_distribution):
+        raise metadata.PackageNotFoundError
+
+    monkeypatch.setattr(version_module.metadata, "version", package_not_found)
+    monkeypatch.setattr(version_module, "_PYPROJECT_PATH", pyproject)
+
+    assert version_module.resolve_version() == "1.2.3rc1"
+
+
+def test_source_tree_fallback_is_explicit_when_project_is_missing(
+    monkeypatch, tmp_path
+):
+    def package_not_found(_distribution):
+        raise metadata.PackageNotFoundError
+
+    monkeypatch.setattr(version_module.metadata, "version", package_not_found)
+    monkeypatch.setattr(
+        version_module, "_PYPROJECT_PATH", tmp_path / "missing.toml"
+    )
+
+    assert version_module.resolve_version() == "0+unknown"
+
+
+def test_runtime_version_matches_available_package_metadata():
+    try:
+        expected = metadata.version("pgque-py")
+    except metadata.PackageNotFoundError:
+        expected = version_module.source_version(
+            Path(__file__).parents[1] / "pyproject.toml"
+        )
+
+    assert pgque.__version__ == expected


### PR DESCRIPTION
## Summary

- make installed `pgque-py` metadata authoritative for `pgque.__version__`
- fall back to the source `pyproject.toml` for direct checkout imports
- verify source, editable, wheel metadata, and isolated installed-wheel versions in the release workflow
- document the single-source version contract

Fixes #326.

## Validation

- red-first version regression
- Python 3.9 tests: `10 passed, 70 skipped` (DB-gated)
- clean Python 3.12 source/editable/build/wheel validation
- `twine check` passed for wheel and sdist
- isolated installed-wheel runtime matched wheel metadata
- `actionlint`, YAML parsing, and `git diff --check` passed