### PR TITLE
release(pg_tle): preserve data across 0.3 upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,6 +330,40 @@ jobs:
             --host=localhost --username=postgres --dbname=pgque_tle_upgrade \
             --set=ON_ERROR_STOP=1 --file=tests/test_tle_upgrade.sql
 
+      - name: Reject an untested pg_tle update without data loss
+        run: |
+          set -Eeuo pipefail
+          PAGER=cat PGPASSWORD=pgque_test psql --no-psqlrc \
+            --host=localhost --username=postgres --dbname=postgres \
+            --set=ON_ERROR_STOP=1 \
+            --command='create database pgque_tle_unsupported'
+          PAGER=cat PGPASSWORD=pgque_test psql --no-psqlrc \
+            --host=localhost --username=postgres \
+            --dbname=pgque_tle_unsupported \
+            --set=ON_ERROR_STOP=1 --command='create extension pg_tle'
+          PAGER=cat PGPASSWORD=pgque_test psql --no-psqlrc \
+            --host=localhost --username=postgres \
+            --dbname=pgque_tle_unsupported \
+            --set=ON_ERROR_STOP=1 \
+            --file=tests/test_tle_unsupported_upgrade_fixture.sql
+          if upgrade_output=$(PAGER=cat PGPASSWORD=pgque_test \
+            psql --no-psqlrc \
+              --host=localhost \
+              --username=postgres \
+              --dbname=pgque_tle_unsupported \
+              --set=ON_ERROR_STOP=1 \
+              --file=devel/sql/pgque-tle.sql 2>&1); then
+            echo 'FAIL: untested pg_tle update path was accepted'
+            exit 1
+          fi
+          grep --fixed-strings 'has no tested pg_tle update path' \
+            <<<"${upgrade_output}"
+          PAGER=cat PGPASSWORD=pgque_test psql --no-psqlrc \
+            --host=localhost --username=postgres \
+            --dbname=pgque_tle_unsupported \
+            --set=ON_ERROR_STOP=1 \
+            --file=tests/test_tle_unsupported_upgrade_assertions.sql
+
       - name: Run full regression suite via pg_tle install
         run: |
           set -Eeuo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,6 +306,14 @@ jobs:
           PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
             -v ON_ERROR_STOP=1 -f tests/test_tle_install.sql
 
+      - name: Run data-preserving pg_tle upgrade test
+        run: |
+          set -Eeuo pipefail
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d postgres \
+            -v ON_ERROR_STOP=1 -c 'create database pgque_tle_upgrade'
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_tle_upgrade \
+            -v ON_ERROR_STOP=1 -f tests/test_tle_upgrade.sql
+
       - name: Run full regression suite via pg_tle install
         run: |
           set -Eeuo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,17 +313,22 @@ jobs:
       - name: Run data-preserving pg_tle upgrade test
         run: |
           set -Eeuo pipefail
-          PGPASSWORD=pgque_test psql -h localhost -U postgres -d postgres \
-            -v ON_ERROR_STOP=1 -c 'create database pgque_tle_upgrade'
-          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_tle_upgrade \
-            -v ON_ERROR_STOP=1 -c 'create extension pg_tle'
+          PAGER=cat PGPASSWORD=pgque_test psql --no-psqlrc \
+            --host=localhost --username=postgres --dbname=postgres \
+            --set=ON_ERROR_STOP=1 --command='create database pgque_tle_upgrade'
+          PAGER=cat PGPASSWORD=pgque_test psql --no-psqlrc \
+            --host=localhost --username=postgres --dbname=pgque_tle_upgrade \
+            --set=ON_ERROR_STOP=1 --command='create extension pg_tle'
           git show v0.2.0:sql/pgque-tle.sql \
-            | PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_tle_upgrade \
-                -v ON_ERROR_STOP=1
-          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_tle_upgrade \
-            -v ON_ERROR_STOP=1 -c 'create extension pgque'
-          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_tle_upgrade \
-            -v ON_ERROR_STOP=1 -f tests/test_tle_upgrade.sql
+            | PAGER=cat PGPASSWORD=pgque_test psql --no-psqlrc \
+                --host=localhost --username=postgres --dbname=pgque_tle_upgrade \
+                --set=ON_ERROR_STOP=1
+          PAGER=cat PGPASSWORD=pgque_test psql --no-psqlrc \
+            --host=localhost --username=postgres --dbname=pgque_tle_upgrade \
+            --set=ON_ERROR_STOP=1 --command='create extension pgque'
+          PAGER=cat PGPASSWORD=pgque_test psql --no-psqlrc \
+            --host=localhost --username=postgres --dbname=pgque_tle_upgrade \
+            --set=ON_ERROR_STOP=1 --file=tests/test_tle_upgrade.sql
 
       - name: Run full regression suite via pg_tle install
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          # The upgrade test installs the immutable v0.2.0 release artifact
+          # as its source fixture. Keep tags/history available even after
+          # sql/ is promoted to a newer stable release.
+          fetch-depth: 0
 
       - name: Build pgque
         run: bash build/transform.sh
@@ -311,6 +315,13 @@ jobs:
           set -Eeuo pipefail
           PGPASSWORD=pgque_test psql -h localhost -U postgres -d postgres \
             -v ON_ERROR_STOP=1 -c 'create database pgque_tle_upgrade'
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_tle_upgrade \
+            -v ON_ERROR_STOP=1 -c 'create extension pg_tle'
+          git show v0.2.0:sql/pgque-tle.sql \
+            | PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_tle_upgrade \
+                -v ON_ERROR_STOP=1
+          PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_tle_upgrade \
+            -v ON_ERROR_STOP=1 -c 'create extension pgque'
           PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_tle_upgrade \
             -v ON_ERROR_STOP=1 -f tests/test_tle_upgrade.sql
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,20 @@ Once pg_tle is loaded, register and create PgQue:
 create extension pgque;
 ```
 
+To upgrade an existing pg_tle installation, load the new release's wrapper
+and then let Postgres apply its registered, data-preserving update path:
+
+```sql
+\i sql/pgque-tle.sql
+alter extension pgque update;
+```
+
+The 0.3 package includes a tested update path from 0.2.0. The registration
+step does not change the active extension; queue data is migrated only by the
+explicit `alter extension`. If the wrapper reports that no tested path exists,
+keep the extension installed and consult the release notes -- do not run the
+uninstall script, because `drop extension pgque cascade` removes queue data.
+
 To uninstall: `\i sql/pgque-tle-uninstall.sql`.
 
 ## Roles and grants

--- a/build/transform.sh
+++ b/build/transform.sh
@@ -1206,6 +1206,10 @@ echo "=== Packaging pg_tle install script ==="
 
 PGTLE_FILE="${SQL_DIR}/pgque-tle.sql"
 PGTLE_DOLLAR_TAG="pgque_extension_body"
+# This is the prior pg_tle registration from which the current idempotent SQL
+# body is exercised as an extension update in CI. Do not silently register an
+# update from an untested version: ALTER EXTENSION must be a data-safe promise.
+PGTLE_UPGRADE_FROM_VERSION="0.2.0"
 
 # Sanity check: neither dollar-quote tag (the body tag and the outer wrapper
 # tag) may appear in the body content, otherwise the literal terminates early
@@ -1284,47 +1288,61 @@ end \$\$;
 
 -- Step 3: register the extension body with pg_tle.
 -- Same version already registered -> no-op (so deployment scripts can rerun).
--- Different version already registered -> raise so the user goes through the
--- explicit uninstall + reinstall path; pg_tle has no managed upgrade path
--- between unrelated registrations of an extension.
+-- A tested previous version -> register the standalone target version plus a
+-- data-preserving ALTER EXTENSION update path, then make the target default.
 do \$wrapper\$
 declare
     existing_version text;
-begin
-    select default_version into existing_version
-    from pgtle.available_extensions()
-    where name = 'pgque';
-
-    if existing_version = '${PGQUE_VERSION}' then
-        raise notice 'pgque ${PGQUE_VERSION} already registered with pg_tle; skipping install_extension().';
-        return;
-    end if;
-
-    if existing_version is not null then
-        raise exception 'pgque is already registered with pg_tle at version % '
-            'but this script registers version %. Run '
-            '${SQL_REL}/pgque-tle-uninstall.sql first to remove the existing '
-            'registration, then re-run this script.',
-            existing_version, '${PGQUE_VERSION}';
-    end if;
-
-    perform pgtle.install_extension(
-        'pgque',
-        '${PGQUE_VERSION}',
-        'PgQue — PgQ Universal Edition (zero-bloat Postgres queue)',
+    extension_sql text :=
 \$${PGTLE_DOLLAR_TAG}\$
 HEADER
 
 cat "${INSTALL_FILE}" >> "${PGTLE_FILE}"
 
 cat >> "${PGTLE_FILE}" << FOOTER
-\$${PGTLE_DOLLAR_TAG}\$
+\$${PGTLE_DOLLAR_TAG}\$;
+begin
+    select default_version into existing_version
+    from pgtle.available_extensions()
+    where name = 'pgque';
+
+    if existing_version = '${PGQUE_VERSION}' then
+        raise notice 'pgque ${PGQUE_VERSION} already registered with pg_tle; no registration changes needed.';
+        return;
+    end if;
+
+    if existing_version is null then
+        perform pgtle.install_extension(
+            'pgque',
+            '${PGQUE_VERSION}',
+            'PgQue — PgQ Universal Edition (zero-bloat Postgres queue)',
+            extension_sql
+        );
+        return;
+    end if;
+
+    if existing_version <> '${PGTLE_UPGRADE_FROM_VERSION}' then
+        raise exception 'pgque has no tested pg_tle update path from version % to %. '
+            'Keep the existing extension installed and consult the PgQue release notes; '
+            'do not uninstall it because that would drop queue data.',
+            existing_version, '${PGQUE_VERSION}';
+    end if;
+
+    -- One transaction makes interrupted/repeated registration safe: either the
+    -- target version, update path, and default all appear, or none of them do.
+    perform pgtle.install_extension_version_sql(
+        'pgque', '${PGQUE_VERSION}', extension_sql
     );
+    perform pgtle.install_update_path(
+        'pgque', existing_version, '${PGQUE_VERSION}', extension_sql
+    );
+    perform pgtle.set_default_version('pgque', '${PGQUE_VERSION}');
 end \$wrapper\$;
 
 \\echo ''
 \\echo 'PgQue ${PGQUE_VERSION} registered with pg_tle.'
-\\echo 'Run create extension pgque; to materialise the schema in this database.'
+\\echo 'New install: run create extension pgque;'
+\\echo 'Existing extension: run alter extension pgque update;'
 FOOTER
 
 pgtle_lines=$(wc -l < "${PGTLE_FILE}")
@@ -1335,6 +1353,13 @@ pgtle_errors=0
 
 if ! grep -q 'pgtle.install_extension(' "${PGTLE_FILE}"; then
   echo "FAIL: pg_tle install script missing pgtle.install_extension() call"
+  pgtle_errors=$((pgtle_errors + 1))
+fi
+
+if ! grep -q 'pgtle.install_extension_version_sql(' "${PGTLE_FILE}" \
+   || ! grep -q 'pgtle.install_update_path(' "${PGTLE_FILE}" \
+   || ! grep -q 'pgtle.set_default_version(' "${PGTLE_FILE}"; then
+  echo "FAIL: pg_tle install script missing version/update/default registration calls"
   pgtle_errors=$((pgtle_errors + 1))
 fi
 

--- a/build/transform.sh
+++ b/build/transform.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2129
+# The installer is assembled incrementally from ordered source sections.
 set -Eeuo pipefail
+IFS=$'\n\t'
 
 # transform.sh -- Mechanical transformation of PgQ sources into pgque
 #
@@ -92,6 +95,8 @@ apply_schema_rename() {
   #
   # Strategy: apply targeted replacements in order of specificity.
   local content="$1"
+  local pgq_literal="'pgq'"
+  local pgque_literal="'pgque'"
 
   # 1. Role names: pgq_reader -> pgque_reader, etc.
   content=$(echo "$content" | sed \
@@ -105,7 +110,7 @@ apply_schema_rename() {
 
   # 3. String literals referencing the schema name:
   #    'pgq' -> 'pgque' (used in information_schema queries, extname, etc.)
-  content=$(echo "$content" | sed "s/'pgq'/'pgque'/g")
+  content="${content//${pgq_literal}/${pgque_literal}}"
 
   # 4. Standalone pgq as schema name in CREATE/DROP SCHEMA, GRANT ON SCHEMA, etc.
   #    "schema pgq" -> "schema pgque"
@@ -139,7 +144,7 @@ apply_txid_function_renames() {
 apply_txid_snapshot_type_rename() {
   # Replace txid_snapshot type with pg_snapshot in column defs and signatures.
   local content="$1"
-  content=$(echo "$content" | sed 's/txid_snapshot/pg_snapshot/g')
+  content="${content//txid_snapshot/pg_snapshot}"
   echo "$content"
 }
 
@@ -302,7 +307,7 @@ for src_file in "${SOURCE_FILES[@]}"; do
   fi
 
   # Determine output filename (rename pgq. prefix in filenames)
-  out_file=$(echo "${src_file}" | sed 's/pgq\./pgque./g')
+  out_file="${src_file//pgq./pgque.}"
   out_path="${OUTPUT_DIR}/${out_file}"
 
   # Read source

--- a/devel/sql/pgque-tle.sql
+++ b/devel/sql/pgque-tle.sql
@@ -59,34 +59,12 @@ end $$;
 
 -- Step 3: register the extension body with pg_tle.
 -- Same version already registered -> no-op (so deployment scripts can rerun).
--- Different version already registered -> raise so the user goes through the
--- explicit uninstall + reinstall path; pg_tle has no managed upgrade path
--- between unrelated registrations of an extension.
+-- A tested previous version -> register the standalone target version plus a
+-- data-preserving ALTER EXTENSION update path, then make the target default.
 do $wrapper$
 declare
     existing_version text;
-begin
-    select default_version into existing_version
-    from pgtle.available_extensions()
-    where name = 'pgque';
-
-    if existing_version = '0.3.0-devel' then
-        raise notice 'pgque 0.3.0-devel already registered with pg_tle; skipping install_extension().';
-        return;
-    end if;
-
-    if existing_version is not null then
-        raise exception 'pgque is already registered with pg_tle at version % '
-            'but this script registers version %. Run '
-            'devel/sql/pgque-tle-uninstall.sql first to remove the existing '
-            'registration, then re-run this script.',
-            existing_version, '0.3.0-devel';
-    end if;
-
-    perform pgtle.install_extension(
-        'pgque',
-        '0.3.0-devel',
-        'PgQue — PgQ Universal Edition (zero-bloat Postgres queue)',
+    extension_sql text :=
 $pgque_extension_body$
 -- pgque.sql -- PgQ Universal Edition
 -- Version: 0.3.0-devel
@@ -8117,10 +8095,46 @@ grant execute on function
 grant execute on function pgque.maint_idem()     to pgque_admin;
 grant execute on function pgque.maint_idem(text) to pgque_admin;
 
-$pgque_extension_body$
+$pgque_extension_body$;
+begin
+    select default_version into existing_version
+    from pgtle.available_extensions()
+    where name = 'pgque';
+
+    if existing_version = '0.3.0-devel' then
+        raise notice 'pgque 0.3.0-devel already registered with pg_tle; no registration changes needed.';
+        return;
+    end if;
+
+    if existing_version is null then
+        perform pgtle.install_extension(
+            'pgque',
+            '0.3.0-devel',
+            'PgQue — PgQ Universal Edition (zero-bloat Postgres queue)',
+            extension_sql
+        );
+        return;
+    end if;
+
+    if existing_version <> '0.2.0' then
+        raise exception 'pgque has no tested pg_tle update path from version % to %. '
+            'Keep the existing extension installed and consult the PgQue release notes; '
+            'do not uninstall it because that would drop queue data.',
+            existing_version, '0.3.0-devel';
+    end if;
+
+    -- One transaction makes interrupted/repeated registration safe: either the
+    -- target version, update path, and default all appear, or none of them do.
+    perform pgtle.install_extension_version_sql(
+        'pgque', '0.3.0-devel', extension_sql
     );
+    perform pgtle.install_update_path(
+        'pgque', existing_version, '0.3.0-devel', extension_sql
+    );
+    perform pgtle.set_default_version('pgque', '0.3.0-devel');
 end $wrapper$;
 
 \echo ''
 \echo 'PgQue 0.3.0-devel registered with pg_tle.'
-\echo 'Run create extension pgque; to materialise the schema in this database.'
+\echo 'New install: run create extension pgque;'
+\echo 'Existing extension: run alter extension pgque update;'

--- a/tests/test_tle_unsupported_upgrade_assertions.sql
+++ b/tests/test_tle_unsupported_upgrade_assertions.sql
@@ -1,0 +1,24 @@
+\set ON_ERROR_STOP on
+
+-- A refused pg_tle update must preserve the installed version and its data.
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+do $$
+begin
+  assert (
+    select extversion = '0.1.0'
+    from pg_catalog.pg_extension
+    where extname = 'pgque'
+  ), 'refused update must preserve the installed extension version';
+  assert (
+    select default_version = '0.1.0'
+    from pgtle.available_extensions()
+    where name = 'pgque'
+  ), 'refused update must preserve the registered default version';
+  assert (
+    select value = 'preserved'
+    from public.tle_unsupported_state
+  ), 'refused update must preserve extension-owned data';
+
+  raise notice 'PASS: unsupported pg_tle update failed without changing state';
+end $$;

--- a/tests/test_tle_unsupported_upgrade_fixture.sql
+++ b/tests/test_tle_unsupported_upgrade_fixture.sql
@@ -1,0 +1,19 @@
+\set ON_ERROR_STOP on
+
+-- Register a synthetic older pg_tle version with durable state. The current
+-- wrapper must reject it because only the 0.2.0 update path is tested.
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+select pgtle.install_extension(
+  'pgque',
+  '0.1.0',
+  'unsupported-upgrade fixture',
+  $extension_body$
+    create table public.tle_unsupported_state (
+      value text primary key
+    );
+    insert into public.tle_unsupported_state values ('preserved');
+  $extension_body$
+);
+
+create extension pgque;

--- a/tests/test_tle_upgrade.sql
+++ b/tests/test_tle_upgrade.sql
@@ -1,0 +1,197 @@
+-- test_tle_upgrade.sql -- Data-preserving pg_tle upgrade from 0.2.0.
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+--
+-- Preconditions: a fresh database with pg_tle preloaded. This test uses the
+-- checked-in stable 0.2.0 TLE package as the real source installation, then
+-- registers the generated development package and exercises ALTER EXTENSION.
+
+\set ON_ERROR_STOP on
+
+\echo '=== test_tle_upgrade (0.2.0 -> current via real pg_tle) ==='
+
+create extension pg_tle;
+\i sql/pgque-tle.sql
+create extension pgque;
+
+do $$
+begin
+    assert pgque.version() = '0.2.0',
+        format('upgrade fixture must start at 0.2.0, got %s', pgque.version());
+end $$;
+
+create temporary table _tle_upgrade_state (
+    kind text primary key,
+    event_id bigint not null,
+    batch_id bigint
+);
+
+-- Preserve a queue, subscription, a terminal DLQ event, a scheduled retry,
+-- and a not-yet-ticked event. These cover each durable event location plus
+-- the consumer cursor state that users would lose on uninstall/reinstall.
+select pgque.create_queue('tle_upgrade');
+select pgque.subscribe('tle_upgrade', 'worker');
+select pgque.set_queue_config('tle_upgrade', 'max_retries', '0');
+
+insert into _tle_upgrade_state(kind, event_id)
+select 'dead_letter', pgque.send('tle_upgrade', 'upgrade.dlq', '{"state":"dlq"}'::jsonb);
+select pgque.force_next_tick('tle_upgrade');
+select pgque.ticker();
+
+do $$
+declare
+    v_msg pgque.message;
+begin
+    select * into strict v_msg from pgque.receive('tle_upgrade', 'worker', 1);
+    assert v_msg.msg_id = (select event_id from _tle_upgrade_state where kind = 'dead_letter');
+    perform pgque.nack(v_msg.batch_id, v_msg, interval '1 day', 'upgrade fixture');
+    update _tle_upgrade_state set batch_id = v_msg.batch_id where kind = 'dead_letter';
+end $$;
+
+do $$
+begin
+    perform pgque.ack((select batch_id from _tle_upgrade_state where kind = 'dead_letter'));
+end $$;
+
+select pgque.set_queue_config('tle_upgrade', 'max_retries', '5');
+insert into _tle_upgrade_state(kind, event_id)
+select 'retry', pgque.send('tle_upgrade', 'upgrade.retry', '{"state":"retry"}'::jsonb);
+select pgque.force_next_tick('tle_upgrade');
+select pgque.ticker();
+
+do $$
+declare
+    v_msg pgque.message;
+begin
+    select * into strict v_msg from pgque.receive('tle_upgrade', 'worker', 1);
+    assert v_msg.msg_id = (select event_id from _tle_upgrade_state where kind = 'retry');
+    perform pgque.nack(v_msg.batch_id, v_msg, interval '1 day', 'upgrade fixture');
+    update _tle_upgrade_state set batch_id = v_msg.batch_id where kind = 'retry';
+end $$;
+
+do $$
+begin
+    perform pgque.ack((select batch_id from _tle_upgrade_state where kind = 'retry'));
+end $$;
+
+insert into _tle_upgrade_state(kind, event_id)
+select 'pending', pgque.send('tle_upgrade', 'upgrade.pending', '{"state":"pending"}'::jsonb);
+
+do $$
+declare
+    v_pending_id bigint := (select event_id from _tle_upgrade_state where kind = 'pending');
+    v_pending_exists boolean;
+begin
+    assert exists (
+        select 1 from pgque.queue where queue_name = 'tle_upgrade'
+    ), '0.2 queue fixture missing before upgrade';
+    assert exists (
+        select 1 from pgque.subscription s
+        join pgque.queue q on q.queue_id = s.sub_queue
+        join pgque.consumer c on c.co_id = s.sub_consumer
+        where q.queue_name = 'tle_upgrade' and c.co_name = 'worker'
+    ), '0.2 subscription fixture missing before upgrade';
+    assert exists (
+        select 1 from pgque.dead_letter
+        where ev_id = (select event_id from _tle_upgrade_state where kind = 'dead_letter')
+    ), '0.2 DLQ fixture missing before upgrade';
+    assert exists (
+        select 1 from pgque.retry_queue
+        where ev_id = (select event_id from _tle_upgrade_state where kind = 'retry')
+    ), '0.2 retry fixture missing before upgrade';
+
+    execute format(
+        'select exists (select 1 from %s where ev_id = $1)',
+        pgque.current_event_table('tle_upgrade')
+    ) into v_pending_exists using v_pending_id;
+    assert v_pending_exists, '0.2 pending-event fixture missing before upgrade';
+end $$;
+
+-- Registration must not mutate the active 0.2.0 extension. A second run is a
+-- no-op, proving deployment retries cannot duplicate version/update records.
+\i devel/sql/pgque-tle.sql
+\i devel/sql/pgque-tle.sql
+
+do $$
+declare
+    v_default text;
+    v_installed text;
+    v_target text := '0.3.0-devel';
+begin
+    select default_version into v_default
+    from pgtle.available_extensions() where name = 'pgque';
+    select extversion into v_installed
+    from pg_catalog.pg_extension where extname = 'pgque';
+
+    assert v_default = v_target,
+        format('registered default should be %s, got %s', v_target, v_default);
+    assert v_installed = '0.2.0',
+        format('registration must not update active extension, got %s', v_installed);
+    assert exists (
+        select 1 from pgtle.extension_update_paths('pgque')
+        where source = '0.2.0' and target = v_target
+          and path = '0.2.0--' || v_target
+    ), '0.2.0 -> current pg_tle update path missing';
+end $$;
+
+alter extension pgque update;
+
+do $$
+declare
+    v_target text := '0.3.0-devel';
+    v_pending_id bigint := (select event_id from _tle_upgrade_state where kind = 'pending');
+    v_pending_exists boolean;
+    v_first_id bigint;
+    v_second_id bigint;
+    v_deduped boolean;
+begin
+    assert pgque.version() = v_target,
+        format('runtime version should be %s, got %s', v_target, pgque.version());
+    assert (select extversion from pg_catalog.pg_extension where extname = 'pgque') = v_target,
+        'pg_extension version did not advance';
+
+    assert exists (
+        select 1 from pgque.queue where queue_name = 'tle_upgrade'
+    ), 'queue was lost during pg_tle update';
+    assert exists (
+        select 1 from pgque.subscription s
+        join pgque.queue q on q.queue_id = s.sub_queue
+        join pgque.consumer c on c.co_id = s.sub_consumer
+        where q.queue_name = 'tle_upgrade' and c.co_name = 'worker'
+    ), 'subscription was lost during pg_tle update';
+    assert exists (
+        select 1 from pgque.dead_letter
+        where ev_id = (select event_id from _tle_upgrade_state where kind = 'dead_letter')
+          and ev_data::jsonb = '{"state":"dlq"}'::jsonb
+    ), 'dead-letter state was lost during pg_tle update';
+    assert exists (
+        select 1 from pgque.retry_queue
+        where ev_id = (select event_id from _tle_upgrade_state where kind = 'retry')
+          and ev_data::jsonb = '{"state":"retry"}'::jsonb
+    ), 'retry state was lost during pg_tle update';
+
+    execute format(
+        'select exists (select 1 from %s where ev_id = $1 and ev_data::jsonb = $2)',
+        pgque.current_event_table('tle_upgrade')
+    ) into v_pending_exists using v_pending_id, '{"state":"pending"}'::jsonb;
+    assert v_pending_exists, 'pending event was lost during pg_tle update';
+
+    select event_id, deduped into v_first_id, v_deduped
+    from pgque.send_idem(
+        'tle_upgrade', 'upgrade.new-api', '{"v":3}'::jsonb,
+        'tle-upgrade:new-api', interval '1 hour'
+    );
+    assert v_first_id is not null and not v_deduped,
+        'new send_idem API did not insert after upgrade';
+
+    select event_id, deduped into v_second_id, v_deduped
+    from pgque.send_idem(
+        'tle_upgrade', 'upgrade.new-api', '{"v":3}'::jsonb,
+        'tle-upgrade:new-api', interval '1 hour'
+    );
+    assert v_second_id = v_first_id and v_deduped,
+        'new send_idem API did not deduplicate after upgrade';
+
+    raise notice 'PASS: 0.2.0 pg_tle state survived and 0.3 APIs work';
+end $$;
+
+\echo '=== test_tle_upgrade: ALL PASSED ==='

--- a/tests/test_tle_upgrade.sql
+++ b/tests/test_tle_upgrade.sql
@@ -7,10 +7,10 @@
 -- accidentally replace the source fixture with the version under test.
 --
 -- Local setup from the repository root:
---   psql "$PGQUE_TEST_DSN" -c 'create extension pg_tle'
---   git show v0.2.0:sql/pgque-tle.sql | psql "$PGQUE_TEST_DSN" -v ON_ERROR_STOP=1
---   psql "$PGQUE_TEST_DSN" -c 'create extension pgque'
---   psql "$PGQUE_TEST_DSN" -v ON_ERROR_STOP=1 -f tests/test_tle_upgrade.sql
+--   PAGER=cat psql --no-psqlrc "$PGQUE_TEST_DSN" --command='create extension pg_tle'
+--   git show v0.2.0:sql/pgque-tle.sql | PAGER=cat psql --no-psqlrc "$PGQUE_TEST_DSN" --set=ON_ERROR_STOP=1
+--   PAGER=cat psql --no-psqlrc "$PGQUE_TEST_DSN" --command='create extension pgque'
+--   PAGER=cat psql --no-psqlrc "$PGQUE_TEST_DSN" --set=ON_ERROR_STOP=1 --file=tests/test_tle_upgrade.sql
 
 \set ON_ERROR_STOP on
 
@@ -88,9 +88,9 @@ begin
         select 1 from pgque.queue where queue_name = 'tle_upgrade'
     ), '0.2 queue fixture missing before upgrade';
     assert exists (
-        select 1 from pgque.subscription s
-        join pgque.queue q on q.queue_id = s.sub_queue
-        join pgque.consumer c on c.co_id = s.sub_consumer
+        select 1 from pgque.subscription as s
+        join pgque.queue as q on q.queue_id = s.sub_queue
+        join pgque.consumer as c on c.co_id = s.sub_consumer
         where q.queue_name = 'tle_upgrade' and c.co_name = 'worker'
     ), '0.2 subscription fixture missing before upgrade';
     assert exists (
@@ -156,9 +156,9 @@ begin
         select 1 from pgque.queue where queue_name = 'tle_upgrade'
     ), 'queue was lost during pg_tle update';
     assert exists (
-        select 1 from pgque.subscription s
-        join pgque.queue q on q.queue_id = s.sub_queue
-        join pgque.consumer c on c.co_id = s.sub_consumer
+        select 1 from pgque.subscription as s
+        join pgque.queue as q on q.queue_id = s.sub_queue
+        join pgque.consumer as c on c.co_id = s.sub_consumer
         where q.queue_name = 'tle_upgrade' and c.co_name = 'worker'
     ), 'subscription was lost during pg_tle update';
     assert exists (

--- a/tests/test_tle_upgrade.sql
+++ b/tests/test_tle_upgrade.sql
@@ -1,17 +1,20 @@
 -- test_tle_upgrade.sql -- Data-preserving pg_tle upgrade from 0.2.0.
 -- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 --
--- Preconditions: a fresh database with pg_tle preloaded. This test uses the
--- checked-in stable 0.2.0 TLE package as the real source installation, then
--- registers the generated development package and exercises ALTER EXTENSION.
+-- Preconditions: pg_tle is preloaded and PgQue is installed from the
+-- v0.2.0-tagged sql/pgque-tle.sql artifact. CI deliberately reads the tag,
+-- rather than the mutable sql/ stable directory, so final promotion cannot
+-- accidentally replace the source fixture with the version under test.
+--
+-- Local setup from the repository root:
+--   psql "$PGQUE_TEST_DSN" -c 'create extension pg_tle'
+--   git show v0.2.0:sql/pgque-tle.sql | psql "$PGQUE_TEST_DSN" -v ON_ERROR_STOP=1
+--   psql "$PGQUE_TEST_DSN" -c 'create extension pgque'
+--   psql "$PGQUE_TEST_DSN" -v ON_ERROR_STOP=1 -f tests/test_tle_upgrade.sql
 
 \set ON_ERROR_STOP on
 
 \echo '=== test_tle_upgrade (0.2.0 -> current via real pg_tle) ==='
-
-create extension pg_tle;
-\i sql/pgque-tle.sql
-create extension pgque;
 
 do $$
 begin


### PR DESCRIPTION
## Summary

- register the 0.3 standalone pg_tle version, tested 0.2.0 → 0.3 update path, and new default atomically
- stop directing unknown upgrade paths toward destructive uninstall
- add a real 0.2.0 TLE fixture with queue, subscription, pending, retry, and DLQ state
- verify `ALTER EXTENSION` preserves all state and activates the new `send_idem` API
- document the explicit registration/update sequence

Fixes #308.

## Validation

- reproduced the old wrapper rejecting a live 0.2.0 extension and recommending uninstall
- real pg_tle v1.5.2 0.2.0 → 0.3.0-devel update test passed
- fresh pg_tle install, rerun, drop, and idempotent unregister test passed
- full `tests/run_all.sql` passed through a fresh pg_tle install
- generator ran twice with identical output hashes
- `bash -n build/transform.sh` and `git diff --check` passed

`actionlint` reports only the workflow's pre-existing shellcheck warnings; the added CI step introduces no new warning.