### PR TITLE
fix(partition-keys): make slot setup atomic

### DIFF
--- a/blueprints/partition-keys/SPEC.md
+++ b/blueprints/partition-keys/SPEC.md
@@ -260,11 +260,17 @@ optimization is future (R6).
   `subscription` (`partition_block.sub_id → subscription.sub_consumer =
   dead_letter.dl_consumer_id`) — `sub_id` and `co_id` are different ID spaces
   (`dlq.sql:24,75-85`, `pgque.sql:170-183`); do not compare them directly.
-- **Teardown:** `unsubscribe_slot` removes the slot subscription (the
-  `partition_slot` and `partition_block` FKs cascade). Note `unregister_consumer`
-  cascades `dead_letter` (`dlq.sql:24`), so dropping a slot drops its DLQ audit —
+- **Teardown:** `unsubscribe_partitioned(queue, consumer)` is the whole-consumer
+  inverse of `subscribe_partitioned`: one transaction drops every slot
+  subscription and the pinned-N row (lease rows cascade via FK). It succeeds on
+  partial setups — it is the recreate path the incomplete-setup error names —
+  and an absent consumer is a notice-level no-op. `unsubscribe_slot` removes one
+  slot (the `partition_slot` and `partition_block` FKs cascade); on a complete
+  consumer it emits a WARNING, because it creates exactly the incomplete-setup
+  state `subscribe_partitioned` rejects. Note `unregister_consumer` cascades
+  `dead_letter` (`dlq.sql:24`), so dropping a slot drops its DLQ audit —
   documented.
-- **Grants:** producer → `pgque_writer`; `subscribe_partitioned`/`subscribe_slot`/`unsubscribe_slot`/
+- **Grants:** producer → `pgque_writer`; `subscribe_partitioned`/`subscribe_slot`/`unsubscribe_slot`/`unsubscribe_partitioned`/
   `receive_partitioned`/`ack_partitioned`/`nack_partitioned`/`claim_slot`/
   `release_slot` and `select` on `partition_slot_status` → `pgque_reader`;
   `partition_consumer`/`partition_slot`/`partition_block` revoked from all app

--- a/blueprints/partition-keys/SPEC.md
+++ b/blueprints/partition-keys/SPEC.md
@@ -147,7 +147,7 @@ to slot 0 — G1, so no event is dropped), assembled only from the validated int
 **SECURITY DEFINER ownership (round 3 — corrected).** `get_batch_cursor`'s
 `extra_where` is a trusted-SQL sink, revoked from `public/pgque_reader/
 pgque_writer`, admin-only (`pgque.sql:2221`, `:4852`). `receive_partitioned` and
-`subscribe_slot` reach it **because they are owned by the same role that owns
+`subscribe_partitioned`/`subscribe_slot` reach it **because they are owned by the same role that owns
 `get_batch_cursor` (the install owner) — a function owner may execute its own
 functions regardless of grants.** This is *not* the `receive`/`nack` pattern
 (those never call `get_batch_cursor`; they call reader-granted internals), and it
@@ -168,11 +168,11 @@ optimization is future (R6).
 |----|----------|---------------|-------|
 | D1 | Key location | `ev_extra1`, `send()`-sourced queues only | Triggers use `ev_extra1` for table name. |
 | D2 | Failure policy | `skip` default (Phase 1); `pause` is Phase 2 (§11) | `pause` has open mechanics. |
-| D3 | N | Fixed, persisted in `pgque.partition_consumer(queue, consumer, n)` (written inside SECURITY DEFINER `subscribe_slot`; table revoked from app roles); changed `n` rejected | Enforced invariant, not convention. |
+| D3 | N | Fixed, persisted in `pgque.partition_consumer(queue, consumer, n)` (written inside SECURITY DEFINER `subscribe_partitioned`, with `subscribe_slot` retained for repair; table revoked from app roles); changed `n` rejected | Enforced invariant, not convention. |
 | D4 | Assignment | `(hashtextextended(key,0) % N + N) % N` | Stable, sign-safe. |
 | D5 | State budget | **Phase 1 / happy / `skip`: no state, no per-event writes.** **Phase 2 `pause`:** durable `pgque.partition_block(sub_id, partition_key, head_ev_id)` marker (FK `sub_id → subscription on delete cascade`; index `(sub_id, partition_key)`). Blocked keys additionally incur defer churn (§11 O1) — so "no per-event churn" is a Phase-1/non-blocked-key claim only. | Round 3 corrected the churn framing. |
 | D6 | Producer signature | `send(queue, type, payload, partition_key => text)` | Avoids `send(queue,type,payload)` collision. |
-| D7 | Slot, single-owner, key namespace | slot = consumer `"<consumer>#k/N"`; **G2 = receive lock (batch issuance) + batch-granularity lease held logically across process→ack (§15)**; **slot identity + lease helpers `claim_slot`/`release_slot` are core**, arbitrated by the `pgque.partition_slot` table (all clients agree via shared rows, not a shared lock namespace); `partition_slot_status` view for owner+lag. **`slot_lock_key` removed** (v0.8 — no advisory-lock namespace). | Reader-callable; clients cannot diverge because arbitration is a server-side row. |
+| D7 | Slot, single-owner, key namespace | slot = consumer `"<consumer>#k/N"`; **G2 = receive lock (batch issuance) + batch-granularity lease held logically across process→ack (§15)**; **slot identity + lease helpers `claim_slot`/`release_slot` are core**, arbitrated by the `pgque.partition_slot` table (all clients agree via shared rows, not a shared lock namespace); `subscribe_partitioned` creates the whole slot set atomically; `partition_slot_status` exposes subscription completeness plus owner+lag. **`slot_lock_key` removed** (v0.8 — no advisory-lock namespace). | Reader-callable; clients cannot diverge because arbitration is a server-side row. |
 | D8 | Worker→slot assignment | Client-side **claim loop** (§15) is still client *policy* (which slot to grab, poll cadence), but the arbitration is now **server-side rows**: `claim_slot` returns an epoch or NULL by inspecting/updating `pgque.partition_slot`; **no leader, no `PartitionAssignor`, no rebalance protocol.** Boundary follows the **mechanism/policy seam**: corruption-capable transitions → core SQL, guarded policy loops → client. | Kafka needs an assignor because partitions are exclusive *by protocol*; here the DB arbitrates per batch and per lease. |
 | D9 | Online resize (grow N) | Epoch-gated **drain-then-cutover** state machine in **core SQL** (`begin_resize`/`resize_ready`/`complete_resize`/`abort_resize`); client drives the drain loop, core re-validates on cutover. Immutable N in Phase 1 (§15 → *Online resize*). | Grow-N reshuffles `hash%N` and breaks G1/G2 for in-flight keys (Fabrizio); the log-native analog of Kinesis parent-shard drain. |
 | D10 | No per-interval heartbeat `UPDATE` churn | **Upheld for that specific cost, superseded as an argument against a lease table.** The v0.7 rejection targeted a *per-interval* heartbeat `UPDATE` — that churn is real and still rejected. **Batch-boundary lease renewal (D11) is new information:** the lease is renewed on the `receive`/`ack` writes that already happen per batch, so there is no per-interval churn to add. Observability still via the read-only `pgque.partition_slot_status` view (now reading lease columns, not `pg_locks`). | A *polling* heartbeat buys nothing; a lease renewed at batch boundaries costs no extra round-trips. |
@@ -192,13 +192,22 @@ optimization is future (R6).
   functions.
 - **`partition_slot(queue_id, co_name, slot, lease_owner text, lease_until
   timestamptz, lease_ttl interval, epoch bigint)`:** one row per registered slot,
-  created by `subscribe_slot`. Primary key `(queue_id, co_name, slot)`; FK
+  created atomically by `subscribe_partitioned` or individually by the repair
+  API `subscribe_slot`. Primary key `(queue_id, co_name, slot)`; FK
   `(queue_id, co_name) → partition_consumer on delete cascade` (a dropped consumer
   drops its lease rows). `lease_owner` null when unleased; `epoch` starts at some
   base and increments on every takeover of a free/expired lease (the fencing
   token). Revoked from app roles.
-- **`subscribe_slot(queue, consumer, k int, n int)`:** validate `n>=1 and
-  0<=k<n`; upsert persisted `n`, reject a changed `n` (D3); register
+- **`subscribe_partitioned(queue, consumer, n int)`:** the default setup path.
+  Validate `n>=1`, persist N, read one starting tick, then register all generated
+  consumers `"<consumer>#0/N"` through `"<consumer>#(N-1)/N"` at that shared tick
+  and create all lease rows in one transaction. A failure rolls back the whole
+  consumer. Repeating a complete setup with the same N is idempotent and does
+  not reposition cursors. A pre-existing partial setup raises rather than
+  implying that late-created slots can recover history that they already missed.
+- **`subscribe_slot(queue, consumer, k int, n int)`:** alpha-compatible repair
+  API. Validate `n>=1 and 0<=k<n`; upsert persisted `n`, reject a changed `n`
+  (D3); register
   `"<consumer>#k/n"`; create the `partition_slot` row for `k` (unleased).
   Idempotent for the same `(k,n)`.
 - **`claim_slot(queue, consumer, k int, worker text, ttl interval default
@@ -237,8 +246,8 @@ optimization is future (R6).
   canonical-event re-query and #104 idempotent-DLQ behaviors are preserved).
   A retried keyed event keeps `ev_extra1`, so redelivery stays on the same slot.
 - **Raw-slot guards:** plain `receive`/`ack`/`nack` reject partition slot
-  consumers — `receive` rejects `#`-carrying consumer names (`subscribe_slot`
-  reserves `#`), `ack`/`nack` resolve the batch's consumer and reject `#`-names —
+  consumers — `receive` rejects `#`-carrying consumer names (the partitioned
+  setup APIs reserve `#`), `ack`/`nack` resolve the batch's consumer and reject `#`-names —
   otherwise the plain path would hand back the whole unfiltered stream with no
   lease fence, and a fenced zombie could double-ack via `ack(batch_id)` (G2, §2).
 - **`pause` (Phase 2):** on nack of `K#i`, upsert `partition_block(sub_id, K,
@@ -255,7 +264,7 @@ optimization is future (R6).
   `partition_slot` and `partition_block` FKs cascade). Note `unregister_consumer`
   cascades `dead_letter` (`dlq.sql:24`), so dropping a slot drops its DLQ audit —
   documented.
-- **Grants:** producer → `pgque_writer`; `subscribe_slot`/`unsubscribe_slot`/
+- **Grants:** producer → `pgque_writer`; `subscribe_partitioned`/`subscribe_slot`/`unsubscribe_slot`/
   `receive_partitioned`/`ack_partitioned`/`nack_partitioned`/`claim_slot`/
   `release_slot` and `select` on `partition_slot_status` → `pgque_reader`;
   `partition_consumer`/`partition_slot`/`partition_block` revoked from all app
@@ -277,10 +286,15 @@ optimization is future (R6).
   events, zero loss.
 - **T-security:** run against an install whose owner is a **non-superuser,
   non-`pgque_admin` role** — a bare `pgque_reader` can call
-  `receive_partitioned`/`subscribe_slot` end-to-end, and **cannot** call
+  `receive_partitioned`/`subscribe_partitioned` end-to-end, and **cannot** call
   `get_batch_cursor` directly (`42501`, mirror `test_security_get_batch_cursor.sql`);
   non-integer/out-of-range `n`,`k` rejected.
-- **T-N-invariant:** `subscribe_slot(…,k,n)` idempotent; `(…,k,n2≠n)` raises.
+- **T-setup-atomicity:** `subscribe_partitioned(…,n)` creates all N engine
+  subscriptions at one tick in one transaction; events produced afterward are
+  reachable across the union of all slots. Repeating setup does not reposition
+  cursors. Existing partial setup raises and remains explicitly repairable.
+- **T-N-invariant:** `subscribe_partitioned(…,n)` idempotent; a changed N raises.
+  `subscribe_slot(…,k,n)` retains the same pinned-N invariant for repair.
 - **T-lease (claim/renew/steer/release):** over `N=2`, worker `wk-a` claims slot 0
   (epoch returned); a second worker `wk-b` claiming slot 0 gets NULL (steered
   away); the owner re-claiming slot 0 renews with the **same** epoch; `wk-b` claims
@@ -526,7 +540,11 @@ server-enforced on `receive`/`ack`, with `epoch` fencing the zombie. Its
 ownership+lag benefit — *who owns what, how far behind* — is delivered by
 **`pgque.partition_slot_status`**, a read-only view over the `partition_slot`
 lease columns (`lease_owner`/`lease_until`/`epoch`) + subscription cursors
-(per-slot lag) + resize state. Reading lease columns rather than `pg_locks` means
+(per-slot lag) + resize state. It has one row for every expected slot and an
+explicit `subscribed` boolean. A missing engine subscription reports
+`subscribed=false`, `last_tick=NULL`, and `pending_events=NULL`: zero would mean
+known caught-up state, while a missing cursor makes lag unknowable. Reading lease
+columns rather than `pg_locks` means
 the view **works through poolers** (a backend pid behind PgBouncer was meaningless
 anyway). Zombie caveat: lease-expiry ≠ process-death, so a partitioned worker can
 still emit side effects until the TTL lapses while the successor is re-issued the
@@ -728,15 +746,20 @@ fencing) need two sessions and are covered by `tests/two_session_slot_claim.sh`
   - *Test:* `us12_partition_keys.sql` — US-12.5 (single-session);
     `tests/two_session_slot_claim.sh` (crash recovery).
 - **US-12.6 — Observability.** As an operator, `pgque.partition_slot_status` shows
-  each slot, its `lease_owner` (null if unleased), and cursor lag, so I can alert on
-  a stalled slot (rotation-pinning risk R7) — and it works through a pooler because
+  each expected slot, whether its engine subscription exists, its `lease_owner`
+  (null if unleased), and cursor lag, so I can alert on incomplete setup or a
+  stalled slot (rotation-pinning risk R7) — and it works through a pooler because
   it reads lease columns, not `pg_locks`.
-  - *Accept:* the view has one row per registered slot with the right `n`,
+  - *Accept:* the view has one row per expected slot with the right `n`,
+    `subscribed=true` for materialized subscriptions; missing subscriptions show
+    `subscribed=false`, `last_tick=NULL`, and `pending_events=NULL`; otherwise
     `lease_owner` null when unleased and equal to the holding worker id when leased
     (clearing on release), and a non-negative `pending_events` lag.
   - *Test:* `us12_partition_keys.sql` — US-12.6.
 - **US-12.7 — Enforced N.** As an operator, a worker calling with the wrong N is
   rejected with a clear error, never silently misrouted.
-  - *Accept:* the first `subscribe_slot` persists N for `(queue, consumer)`;
-    re-calling with the same `(slot, n)` is idempotent, a changed `n` raises (D3).
+  - *Accept:* `subscribe_partitioned` atomically persists N and all N slots for
+    `(queue, consumer)` at one start tick; re-calling with the same N is
+    idempotent without cursor movement, a changed N raises, and existing partial
+    setup is rejected as incomplete (D3).
   - *Test:* `us12_partition_keys.sql` — US-12.7.

--- a/blueprints/partition-keys/SPEC.md
+++ b/blueprints/partition-keys/SPEC.md
@@ -273,10 +273,15 @@ optimization is future (R6).
   inverse of `subscribe_partitioned`: one transaction drops every slot
   subscription and the pinned-N row (lease rows cascade via FK). It succeeds on
   partial setups — it is the recreate path the incomplete-setup error names —
-  and an absent consumer is a notice-level no-op. `unsubscribe_slot` removes one
+  and an absent consumer is a notice-level no-op. It drops only
+  catalog-registered slots (`partition_slot` rows): a legacy ordinary consumer
+  that merely shares the name shape survives, with its cursor history, and is
+  removed with plain `unsubscribe`. `unsubscribe_slot` removes one
   slot (the `partition_slot` and `partition_block` FKs cascade); on a complete
   consumer it emits a WARNING, because it creates exactly the incomplete-setup
-  state `subscribe_partitioned` rejects. Note `unregister_consumer` cascades
+  state `subscribe_partitioned` rejects; its completeness/last-slot accounting
+  is likewise catalog-driven, so a legacy name-shaped subscription never keeps
+  the pinned-N row alive. Note `unregister_consumer` cascades
   `dead_letter` (`dlq.sql:24`), so dropping a slot drops its DLQ audit —
   documented.
 - **Grants:** producer → `pgque_writer`; `subscribe_partitioned`/`subscribe_slot`/`unsubscribe_slot`/`unsubscribe_partitioned`/
@@ -567,7 +572,11 @@ explicit `subscribed` boolean. A missing engine subscription reports
 known caught-up state, while a missing cursor makes lag unknowable. The
 canonical alert is therefore `pending_events > X or not subscribed` — a
 threshold-only `pending_events > X` alert silently skips the NULL rows, so
-incomplete setup would never fire it. Reading lease
+incomplete setup would never fire it. Classification is catalog-driven, the
+same way the consume API classifies: a slot counts as `subscribed` only when
+its `partition_slot` row AND its engine subscription both exist — a legacy
+ordinary consumer that merely shares the name shape (`"C#k/N"`, creatable on
+older installs) is never attributed to the slot. Reading lease
 columns rather than `pg_locks` means
 the view **works through poolers** (a backend pid behind PgBouncer was meaningless
 anyway). Zombie caveat: lease-expiry ≠ process-death, so a partitioned worker can

--- a/blueprints/partition-keys/SPEC.md
+++ b/blueprints/partition-keys/SPEC.md
@@ -199,14 +199,14 @@ optimization is future (R6).
   base and increments on every takeover of a free/expired lease (the fencing
   token). Revoked from app roles.
 - **`subscribe_partitioned(queue, consumer, n int)`:** the default setup path.
-  Validate `n>=1`, persist N, read one starting tick, then register all generated
+  Validate `1<=n<=256`, persist N, read one starting tick, then register all generated
   consumers `"<consumer>#0/N"` through `"<consumer>#(N-1)/N"` at that shared tick
   and create all lease rows in one transaction. A failure rolls back the whole
   consumer. Repeating a complete setup with the same N is idempotent and does
   not reposition cursors. A pre-existing partial setup raises rather than
   implying that late-created slots can recover history that they already missed.
 - **`subscribe_slot(queue, consumer, k int, n int)`:** alpha-compatible repair
-  API. Validate `n>=1 and 0<=k<n`; upsert persisted `n`, reject a changed `n`
+  API. Validate `1<=n<=256 and 0<=k<n`; upsert persisted `n`, reject a changed `n`
   (D3); register
   `"<consumer>#k/n"`; create the `partition_slot` row for `k` (unleased).
   Idempotent for the same `(k,n)`.

--- a/blueprints/partition-keys/SPEC.md
+++ b/blueprints/partition-keys/SPEC.md
@@ -168,7 +168,7 @@ optimization is future (R6).
 |----|----------|---------------|-------|
 | D1 | Key location | `ev_extra1`, `send()`-sourced queues only | Triggers use `ev_extra1` for table name. |
 | D2 | Failure policy | `skip` default (Phase 1); `pause` is Phase 2 (§11) | `pause` has open mechanics. |
-| D3 | N | Fixed, persisted in `pgque.partition_consumer(queue, consumer, n)` (written inside SECURITY DEFINER `subscribe_partitioned`, with `subscribe_slot` retained for repair; table revoked from app roles); changed `n` rejected | Enforced invariant, not convention. |
+| D3 | N | Fixed, persisted in `pgque.partition_consumer(queue, consumer, n)` (written inside SECURITY DEFINER `subscribe_partitioned`, with `subscribe_slot` retained for forward-only repair — the missed window is lost; table revoked from app roles); changed `n` rejected | Enforced invariant, not convention. |
 | D4 | Assignment | `(hashtextextended(key,0) % N + N) % N` | Stable, sign-safe. |
 | D5 | State budget | **Phase 1 / happy / `skip`: no state, no per-event writes.** **Phase 2 `pause`:** durable `pgque.partition_block(sub_id, partition_key, head_ev_id)` marker (FK `sub_id → subscription on delete cascade`; index `(sub_id, partition_key)`). Blocked keys additionally incur defer churn (§11 O1) — so "no per-event churn" is a Phase-1/non-blocked-key claim only. | Round 3 corrected the churn framing. |
 | D6 | Producer signature | `send(queue, type, payload, partition_key => text)` | Avoids `send(queue,type,payload)` collision. |
@@ -209,20 +209,29 @@ optimization is future (R6).
   API. Validate `1<=n<=256 and 0<=k<n`; upsert persisted `n`, reject a changed `n`
   (D3); register
   `"<consumer>#k/n"`; create the `partition_slot` row for `k` (unleased).
-  Idempotent for the same `(k,n)`.
+  Idempotent for the same `(k,n)`. Repair ≠ recovery: it closes the gap going
+  forward only — the repaired slot starts at the current tick, and events
+  ticked while the slot was missing are **permanently lost** (recreate the
+  consumer via `unsubscribe_partitioned` before producing to avoid the gap).
 - **`claim_slot(queue, consumer, k int, worker text, ttl interval default
-  '30 seconds')` → bigint (epoch):** validate `ttl >= '1 second'`. Under a row
-  lock on the `partition_slot` row: if the lease is live and owned by another
-  worker → return NULL (steered away); if owned by `worker` → renew
+  '30 seconds')` → bigint (epoch):** validate `ttl` is finite and `>= '1 second'`
+  (`'infinity'` rejected). Under a `for update skip locked` row lock on the
+  `partition_slot` row: if the lease is live and owned by another worker → return
+  NULL (steered away); if the row is momentarily locked by another transaction —
+  including the SAME worker's own in-flight `receive`/`ack` lease renewal —
+  → return NULL without blocking; if owned by `worker` → renew
   (`lease_until = clock_timestamp() + ttl`), return the **same** epoch; if free or
   **expired** (`lease_until <= clock_timestamp()` or `lease_owner is null`) → take
   over: set `lease_owner = worker`, `lease_until = clock_timestamp() + ttl`, **bump
-  `epoch`**, return the new epoch. Grace rule: an expired lease that no successor
+  `epoch`**, return the new epoch. NULL therefore means "not claimable right
+  now" (busy or foreign-owned); do NOT infer loss of an existing lease from
+  NULL. Grace rule: an expired lease that no successor
   has taken may be renewed by its own worker (still its epoch — no heir existed, so
   it is safe).
 - **`release_slot(queue, consumer, k int, worker text)` → boolean:** owner-only.
-  If `worker` holds the lease, clear it (`lease_owner = null`) and return true;
-  otherwise return false. Callable only at a batch boundary (§15).
+  If `worker` holds the lease and the slot has no open engine batch, clear it
+  (`lease_owner = null`) and return true; raises if the owner's slot batch is
+  still open — ack first (§15); a non-owner returns false, never raises.
 - **`receive_partitioned(queue, consumer, k int, n int, worker text, …)`:** after
   casting `k,n` to int, **require `worker` to hold the lease on slot `k`** (a
   non-owner raises — server-enforced G2); an expired lease still owned by the same
@@ -362,7 +371,10 @@ optimization is future (R6).
   names.** This is the sharpest operational hazard of the N-slot model and gets
   worse as N grows (more slots → more chances one is behind). Mitigation is
   monitoring + bounding N, not code: a per-slot staleness/lag alert is mandatory
-  for any Tier-B deployment, and N should be the minimum that meets the
+  for any Tier-B deployment — canonical form `pending_events > X or not
+  subscribed` on `partition_slot_status`, because a threshold-only alert skips
+  the NULL-lag rows of unsubscribed slots and misses incomplete setup — and N
+  should be the minimum that meets the
   parallelism target (see R2/R4 — N is also the read-amp multiplier, so the same
   "keep N small" pressure applies from two directions). A `pause`-blocked slot
   does *not* pin rotation (deferred events go to retry, not the held cursor),
@@ -441,8 +453,11 @@ coordinator**, so assignment is pull-based and self-balancing.
 calls `pgque.claim_slot(queue, consumer, k, worker, ttl)` — a **core** function
 (D7, D11) that arbitrates over the shared `partition_slot` rows, so Go/Python/TS/CLI
 cannot silently collide on a slot. A non-NULL return (the lease epoch) means the
-worker owns the slot; NULL means another worker holds a live lease and the worker
-moves to the next slot — it never blocks waiting on a busy slot. The first slot it
+worker owns the slot; NULL means the slot is not claimable right now — another
+worker holds a live lease, or the row is momentarily locked by another
+transaction (possibly this worker's own in-flight `receive`/`ack` renewal) —
+and the worker moves to the next slot; it never blocks waiting on a busy slot,
+and it must not infer loss of an existing lease from NULL. The first slot it
 claims, it owns: it calls `receive_partitioned(queue, consumer, k, N, worker, …)`
 for that slot and keeps it **sticky-until-idle** (re-poll the same slot while it
 has work; each `receive`/`ack` renews the lease, so a working slot never expires).
@@ -549,7 +564,10 @@ lease columns (`lease_owner`/`lease_until`/`epoch`) + subscription cursors
 (per-slot lag) + resize state. It has one row for every expected slot and an
 explicit `subscribed` boolean. A missing engine subscription reports
 `subscribed=false`, `last_tick=NULL`, and `pending_events=NULL`: zero would mean
-known caught-up state, while a missing cursor makes lag unknowable. Reading lease
+known caught-up state, while a missing cursor makes lag unknowable. The
+canonical alert is therefore `pending_events > X or not subscribed` — a
+threshold-only `pending_events > X` alert silently skips the NULL rows, so
+incomplete setup would never fire it. Reading lease
 columns rather than `pg_locks` means
 the view **works through poolers** (a backend pid behind PgBouncer was meaningless
 anyway). Zombie caveat: lease-expiry ≠ process-death, so a partitioned worker can
@@ -754,7 +772,9 @@ fencing) need two sessions and are covered by `tests/two_session_slot_claim.sh`
 - **US-12.6 — Observability.** As an operator, `pgque.partition_slot_status` shows
   each expected slot, whether its engine subscription exists, its `lease_owner`
   (null if unleased), and cursor lag, so I can alert on incomplete setup or a
-  stalled slot (rotation-pinning risk R7) — and it works through a pooler because
+  stalled slot (rotation-pinning risk R7) — canonical alert `pending_events > X
+  or not subscribed`, since a threshold-only alert skips the NULL-lag rows of
+  missing subscriptions — and it works through a pooler because
   it reads lease columns, not `pg_locks`.
   - *Accept:* the view has one row per expected slot with the right `n`,
     `subscribed=true` for materialized subscriptions; missing subscriptions show

--- a/devel/sql/README.md
+++ b/devel/sql/README.md
@@ -87,6 +87,24 @@ create user metrics with password '...';
 grant pgque_reader to metrics;
 ```
 
+## Partitioned consumer setup
+
+Create the whole partitioned consumer before publishing events. One call pins
+the slot count and creates every slot subscription and lease row atomically at
+the same starting tick:
+
+```sql
+select pgque.create_queue('orders');
+select pgque.subscribe_partitioned('orders', 'workers', 4);
+```
+
+Calling `subscribe_partitioned` again with the same slot count is idempotent and
+does not move existing cursors. `subscribe_slot` remains available for explicit
+repair of an incomplete alpha setup; it is not the normal setup path because a
+slot registered after events have been ticked cannot recover that earlier
+history. Check `pgque.partition_slot_status.subscribed`: missing subscriptions
+report `false`, with `pending_events` set to `NULL` because their lag is unknown.
+
 ## pg_tle install
 
 To register PgQue as a `pg_tle` extension instead (requires `pg_tle` in

--- a/devel/sql/README.md
+++ b/devel/sql/README.md
@@ -100,10 +100,16 @@ select pgque.subscribe_partitioned('orders', 'workers', 4);
 
 Calling `subscribe_partitioned` again with the same slot count is idempotent and
 does not move existing cursors. `subscribe_slot` remains available for explicit
-repair of an incomplete alpha setup; it is not the normal setup path because a
-slot registered after events have been ticked cannot recover that earlier
-history. Check `pgque.partition_slot_status.subscribed`: missing subscriptions
-report `false`, with `pending_events` set to `NULL` because their lag is unknown.
+repair of an incomplete setup, but repair closes the gap going forward only: the
+repaired slot starts at the current tick, and events ticked while it was missing
+are permanently lost. To start over instead, tear the whole consumer down with
+`pgque.unsubscribe_partitioned(queue, consumer)` (atomic, safe on partial
+setups, a no-op when the consumer is absent) and recreate it before producing.
+
+Monitor `pgque.partition_slot_status`: missing subscriptions report
+`subscribed = false` with `pending_events = NULL` because their lag is unknown.
+Alert on `pending_events > X or not subscribed` — a threshold-only alert skips
+the `NULL` rows and never notices incomplete setup.
 
 The safety ceiling is 256 slots per partitioned consumer. It is not a target:
 use the smallest slot count that provides the required parallelism. Every slot

--- a/devel/sql/README.md
+++ b/devel/sql/README.md
@@ -105,6 +105,11 @@ slot registered after events have been ticked cannot recover that earlier
 history. Check `pgque.partition_slot_status.subscribed`: missing subscriptions
 report `false`, with `pending_events` set to `NULL` because their lag is unknown.
 
+The safety ceiling is 256 slots per partitioned consumer. It is not a target:
+use the smallest slot count that provides the required parallelism. Every slot
+scans the queue stream and must be polled, so read amplification and the cost of
+a full polling cycle increase with the slot count.
+
 ## pg_tle install
 
 To register PgQue as a `pg_tle` extension instead (requires `pg_tle` in

--- a/devel/sql/pgque-api/partition_keys.sql
+++ b/devel/sql/pgque-api/partition_keys.sql
@@ -68,7 +68,34 @@ create table if not exists pgque.partition_consumer (
     primary key (queue_id, co_name)
 );
 
+/*
+ * Pre-flight guard for the constraint re-add below: a consumer created
+ * before the n cap existed would otherwise abort the install with a bare
+ * check-violation error. Name the row and the fix instead.
+ */
+create or replace function pgque._partition_n_cap_guard()
+returns void as $$
+declare
+    v_bad record;
+begin
+    select q.queue_name, pc.co_name, pc.n into v_bad
+    from pgque.partition_consumer as pc
+    join pgque.queue as q on q.queue_id = pc.queue_id
+    where pc.n not between 1 and 256
+    order by q.queue_name, pc.co_name
+    limit 1;
+    if found then
+        raise exception 'cannot apply the 256-slot cap: partitioned consumer % on queue % has n=%; recreate it with a smaller slot count (drop every slot via pgque.unsubscribe_slot(), then pgque.subscribe_partitioned() with n <= 256), then re-run the install',
+            v_bad.co_name, v_bad.queue_name, v_bad.n;
+    end if;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
 /* Keep the constraint definition synchronized on idempotent installs. */
+do $$
+begin
+    perform pgque._partition_n_cap_guard();
+end $$;
 alter table pgque.partition_consumer
     drop constraint if exists partition_consumer_n_check;
 alter table pgque.partition_consumer
@@ -844,6 +871,7 @@ grant select on pgque.partition_slot_status to pgque_reader;
 grant select on pgque.partition_slot_status to pgque_admin;
 
 -- Internal helpers: SECURITY DEFINER callees only.
+revoke execute on function pgque._partition_n_cap_guard() from public, pgque_reader, pgque_writer;
 revoke execute on function pgque._slot_name(text, int, int) from public, pgque_reader, pgque_writer;
 revoke execute on function pgque._slot_guard(text, text, int, int, text) from public, pgque_reader, pgque_writer;
 revoke execute on function pgque._slot_batch(text, text, int, int) from public, pgque_reader, pgque_writer;

--- a/devel/sql/pgque-api/partition_keys.sql
+++ b/devel/sql/pgque-api/partition_keys.sql
@@ -108,7 +108,7 @@ alter table pgque.partition_consumer
  * takeover of an expired lease. Written only inside SECURITY DEFINER
  * functions (same pattern as partition_consumer); revoked from app roles.
  * One row per subscribed slot, created by subscribe_partitioned or repaired
- * individually by subscribe_slot.
+ * individually by subscribe_slot (forward-only: the missed window is lost).
  */
 create table if not exists pgque.partition_slot (
     queue_id    int4 not null,
@@ -382,6 +382,9 @@ revoke execute on function pgque.subscribe_partitioned(text, text, int) from pub
 /*
  * Alpha-compatible single-slot registration. Prefer subscribe_partitioned for
  * new consumers; use this only for explicit repair or controlled setup work.
+ * Repair closes the gap going forward only: the slot starts at the current
+ * tick, and events ticked while it was missing are permanently lost (recreate
+ * the consumer via unsubscribe_partitioned before producing to avoid that).
  */
 create or replace function pgque.subscribe_slot(
     i_queue text, i_consumer text, i_slot int, i_n int)
@@ -554,15 +557,19 @@ revoke execute on function pgque.unsubscribe_partitioned(text, text) from public
 
 /*
  * Claim (or renew) the lease on a slot for a worker id. Returns the epoch
- * fencing token, or null if the slot is currently leased by another live
- * worker (the caller's claim loop then moves to the next slot). The lease
- * lives in pgque.partition_slot -- plain transactional DML, no session state
- * -- so it survives transaction-mode pooling. Uses clock_timestamp() so a
- * pg_sleep inside a transaction correctly ages a short TTL.
+ * fencing token, or null when the slot is not claimable RIGHT NOW: leased by
+ * another live worker, or the row momentarily locked by another transaction
+ * (skip locked) -- including this worker's own in-flight receive/ack renewal.
+ * The claim loop moves to the next slot on null and must never infer loss of
+ * an existing lease from it. The lease lives in pgque.partition_slot -- plain
+ * transactional DML, no session state -- so it survives transaction-mode
+ * pooling. Uses clock_timestamp() so a pg_sleep inside a transaction
+ * correctly ages a short TTL.
  *
  *   owner re-claim  -- renew the window, epoch UNCHANGED.
  *   free / expired  -- takeover: epoch += 1, return the NEW (fencing) epoch.
  *   live, other own -- return null.
+ *   row busy        -- return null (never blocks, never waits).
  */
 create or replace function pgque.claim_slot(
     i_queue text, i_consumer text, i_slot int, i_worker text,
@@ -855,6 +862,10 @@ revoke execute on function pgque.nack_partitioned(text, text, int, int, text, pg
  *                     filtering (tick_event_seq delta). It over-counts a
  *                     single slot's own share by ~n x, but 0 means "caught
  *                     up" exactly, and growth means the slot is stalling.
+ *
+ * Canonical alert: pending_events > X or not subscribed. A threshold-only
+ * alert (where pending_events > X) skips the NULL-lag rows of unsubscribed
+ * slots, so it never sees incomplete setup.
  */
 create or replace view pgque.partition_slot_status as
 select

--- a/devel/sql/pgque-api/partition_keys.sql
+++ b/devel/sql/pgque-api/partition_keys.sql
@@ -4,6 +4,7 @@
 --
 -- Partition keys (blueprints/partition-keys/SPEC.md, Phase 1A):
 --   pgque.send(queue, type, payload, partition_key)  -- jsonb + text overloads
+--   pgque.subscribe_partitioned(queue, consumer, n)
 --   pgque.subscribe_slot(queue, consumer, slot, n)
 --   pgque.unsubscribe_slot(queue, consumer, slot)
 --   pgque.claim_slot(queue, consumer, slot, worker, ttl)
@@ -71,7 +72,8 @@ create table if not exists pgque.partition_consumer (
  * for a TTL window; epoch is the monotonic fencing token, bumped on every
  * takeover of an expired lease. Written only inside SECURITY DEFINER
  * functions (same pattern as partition_consumer); revoked from app roles.
- * One row per subscribed slot, created by subscribe_slot.
+ * One row per subscribed slot, created by subscribe_partitioned or repaired
+ * individually by subscribe_slot.
  */
 create table if not exists pgque.partition_slot (
     queue_id    int4 not null,
@@ -141,7 +143,7 @@ begin
     where q.queue_name = i_queue
       and pc.co_name = i_consumer;
     if not found then
-        raise exception 'consumer % on queue % is not a partitioned consumer; call pgque.subscribe_slot() first',
+        raise exception 'consumer % on queue % is not a partitioned consumer; call pgque.subscribe_partitioned() first',
             i_consumer, i_queue;
     end if;
 
@@ -240,6 +242,112 @@ revoke execute on function pgque.send(text, text, text, text) from public;
 -- Slot registration (enforced N)
 -- ---------------------------------------------------------------------------
 
+/*
+ * Atomically materialize every slot for a partitioned consumer at one shared
+ * tick. Existing complete setup is idempotent and never repositions cursors;
+ * existing partial setup requires an explicit repair decision.
+ */
+create or replace function pgque.subscribe_partitioned(
+    i_queue text, i_consumer text, i_n int)
+returns void as $$
+declare
+    v_queue_id int4;
+    v_n int4;
+    v_start_tick bigint;
+    v_complete_slots int4;
+    v_registered int4;
+    v_slot int4;
+    v_slot_name text;
+begin
+    if i_queue is null or i_queue = '' then
+        raise exception 'queue name must not be empty';
+    end if;
+    if i_consumer is null or i_consumer = '' then
+        raise exception 'consumer name must not be empty';
+    end if;
+    if position('#' in i_consumer) > 0 then
+        raise exception 'partitioned consumer name must not contain #: %', i_consumer;
+    end if;
+    if i_n is null or i_n < 1 then
+        raise exception 'slot count n must be >= 1, got %', i_n;
+    end if;
+
+    select queue_id into v_queue_id
+    from pgque.queue
+    where queue_name = i_queue;
+    if not found then
+        raise exception 'queue not found: %', i_queue;
+    end if;
+
+    /*
+     * ON CONFLICT waits for a concurrent creator. The follow-up row lock makes
+     * complete-state inspection serialize with subscribe_slot and another
+     * subscribe_partitioned call for the same logical consumer.
+     */
+    insert into pgque.partition_consumer (queue_id, co_name, n)
+    values (v_queue_id, i_consumer, i_n)
+    on conflict (queue_id, co_name) do nothing
+    returning n into v_n;
+    if not found then
+        select pc.n into v_n
+        from pgque.partition_consumer as pc
+        where pc.queue_id = v_queue_id
+          and pc.co_name = i_consumer
+        for update;
+
+        if v_n <> i_n then
+            raise exception 'consumer % on queue % is pinned to n=%; got n=% (unsubscribe all slots to change the slot count)',
+                i_consumer, i_queue, v_n, i_n;
+        end if;
+
+        select count(*) into v_complete_slots
+        from generate_series(0, i_n - 1) as gs(slot)
+        join pgque.partition_slot as ps
+            on ps.queue_id = v_queue_id
+            and ps.co_name = i_consumer
+            and ps.slot = gs.slot
+        join pgque.consumer as c
+            on c.co_name = pgque._slot_name(i_consumer, gs.slot, i_n)
+        join pgque.subscription as s
+            on s.sub_queue = v_queue_id
+            and s.sub_consumer = c.co_id;
+        if v_complete_slots <> i_n then
+            raise exception 'partitioned consumer % on queue % has incomplete setup (% of % slots subscribed); repair with pgque.subscribe_slot() or recreate it before producing',
+                i_consumer, i_queue, v_complete_slots, i_n;
+        end if;
+
+        return;
+    end if;
+
+    select tick_id into v_start_tick
+    from pgque.tick
+    where tick_queue = v_queue_id
+    order by tick_id desc
+    limit 1;
+    if not found then
+        raise exception 'no ticks for queue: %', i_queue;
+    end if;
+
+    for v_slot in 0..i_n - 1 loop
+        v_slot_name := pgque._slot_name(i_consumer, v_slot, i_n);
+        v_registered := pgque.register_consumer_at(
+            i_queue, v_slot_name, v_start_tick);
+        if v_registered <> 1 then
+            raise exception 'consumer name % is already registered on queue %; cannot reuse it for partition slot %/%',
+                v_slot_name, i_queue, v_slot, i_n;
+        end if;
+
+        insert into pgque.partition_slot (queue_id, co_name, slot)
+        values (v_queue_id, i_consumer, v_slot);
+    end loop;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.subscribe_partitioned(text, text, int) from public;
+
+/*
+ * Alpha-compatible single-slot registration. Prefer subscribe_partitioned for
+ * new consumers; use this only for explicit repair or controlled setup work.
+ */
 create or replace function pgque.subscribe_slot(
     i_queue text, i_consumer text, i_slot int, i_n int)
 returns void as $$
@@ -387,7 +495,7 @@ begin
     where q.queue_name = i_queue
       and pc.co_name = i_consumer;
     if not found then
-        raise exception 'consumer % on queue % is not a partitioned consumer; call pgque.subscribe_slot() first',
+        raise exception 'consumer % on queue % is not a partitioned consumer; call pgque.subscribe_partitioned() first',
             i_consumer, i_queue;
     end if;
     if i_slot is null or i_slot < 0 or i_slot >= v_n then
@@ -638,10 +746,12 @@ revoke execute on function pgque.nack_partitioned(text, text, int, int, text, pg
 -- ---------------------------------------------------------------------------
 
 /*
- * One row per slot 0..n-1 of every partitioned consumer (including slots
- * not yet leased -- an unpolled slot is exactly what the R7 rotation-pinning
- * alert must catch).
+ * One row per expected slot 0..n-1 of every partitioned consumer, including
+ * missing subscriptions and slots not yet leased. An unpolled subscribed slot
+ * is exactly what the R7 rotation-pinning alert must catch.
  *
+ *   subscribed     -- true when the engine subscription exists; false means
+ *                     setup is incomplete and cursor lag is unknown.
  *   lease_owner    -- worker holding a LIVE lease on the slot; null when
  *                     unleased OR the lease has expired (lease_until in the
  *                     past). A stale owner is never shown as current.
@@ -659,6 +769,7 @@ select
     pc.co_name as consumer,
     gs.slot,
     pc.n,
+    s.sub_id is not null as subscribed,
     case when ps.lease_owner is not null and ps.lease_until > clock_timestamp()
          then ps.lease_owner
          else null
@@ -666,7 +777,10 @@ select
     ps.lease_until,
     coalesce(ps.epoch, 0) as epoch,
     s.sub_last_tick as last_tick,
-    greatest(coalesce(latest.tick_event_seq - cur.tick_event_seq, 0), 0) as pending_events
+    case
+        when s.sub_id is null then null
+        else greatest(coalesce(latest.tick_event_seq - cur.tick_event_seq, 0), 0)
+    end as pending_events
 from pgque.partition_consumer as pc
 join pgque.queue as q on q.queue_id = pc.queue_id
 cross join lateral generate_series(0, pc.n - 1) as gs(slot)
@@ -710,6 +824,7 @@ grant select on pgque.partition_slot to pgque_admin;
 grant execute on function pgque.send(text, text, jsonb, text)  to pgque_writer;
 grant execute on function pgque.send(text, text, text, text)   to pgque_writer;
 
+grant execute on function pgque.subscribe_partitioned(text, text, int) to pgque_reader;
 grant execute on function pgque.subscribe_slot(text, text, int, int)   to pgque_reader;
 grant execute on function pgque.unsubscribe_slot(text, text, int)      to pgque_reader;
 grant execute on function pgque.claim_slot(text, text, int, text, interval)    to pgque_reader;

--- a/devel/sql/pgque-api/partition_keys.sql
+++ b/devel/sql/pgque-api/partition_keys.sql
@@ -7,6 +7,7 @@
 --   pgque.subscribe_partitioned(queue, consumer, n)
 --   pgque.subscribe_slot(queue, consumer, slot, n)
 --   pgque.unsubscribe_slot(queue, consumer, slot)
+--   pgque.unsubscribe_partitioned(queue, consumer)
 --   pgque.claim_slot(queue, consumer, slot, worker, ttl)
 --   pgque.release_slot(queue, consumer, slot, worker)
 --   pgque.receive_partitioned(queue, consumer, slot, n, worker, max)
@@ -346,7 +347,7 @@ begin
             on s.sub_queue = v_queue_id
             and s.sub_consumer = c.co_id;
         if v_complete_slots <> i_n then
-            raise exception 'partitioned consumer % on queue % has incomplete setup (% of % slots subscribed); repair with pgque.subscribe_slot() or recreate it before producing',
+            raise exception 'partitioned consumer % on queue % has incomplete setup (% of % slots subscribed); repair with pgque.subscribe_slot() (forward-only: events ticked while a slot was missing stay lost) or recreate it via pgque.unsubscribe_partitioned() before producing',
                 i_consumer, i_queue, v_complete_slots, i_n;
         end if;
 
@@ -450,6 +451,7 @@ returns void as $$
 declare
     v_queue_id int4;
     v_n int4;
+    v_subscribed int4;
 begin
     select pc.n, q.queue_id into v_n, v_queue_id
     from pgque.partition_consumer as pc
@@ -464,6 +466,21 @@ begin
     if i_slot is null or i_slot < 0 or i_slot >= v_n then
         raise exception 'slot % out of range for consumer % on queue % (valid: 0..%)',
             i_slot, i_consumer, i_queue, v_n - 1;
+    end if;
+
+    /* Dropping one slot of a complete consumer is the documented repair /
+       controlled path, but it creates the incomplete-setup state that
+       subscribe_partitioned rejects -- never do it silently. */
+    select count(*) into v_subscribed
+    from pgque.subscription as s
+    join pgque.consumer as c on c.co_id = s.sub_consumer
+    where s.sub_queue = v_queue_id
+      and c.co_name in (
+          select pgque._slot_name(i_consumer, g, v_n)
+          from generate_series(0, v_n - 1) as g);
+    if v_n > 1 and v_subscribed = v_n then
+        raise warning 'dropping slot % leaves partitioned consumer % on queue % with incomplete setup; repair forward-only with pgque.subscribe_slot() or tear down with pgque.unsubscribe_partitioned()',
+            i_slot, i_consumer, i_queue;
     end if;
 
     perform pgque.unregister_consumer(i_queue, pgque._slot_name(i_consumer, i_slot, v_n));
@@ -488,6 +505,48 @@ begin
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 revoke execute on function pgque.unsubscribe_slot(text, text, int) from public;
+
+/*
+ * Whole-consumer teardown -- the inverse of subscribe_partitioned. Drops
+ * every slot subscription and the pinned-N row in one transaction. Partial
+ * setups (some slots already gone) tear down cleanly -- this is the recreate
+ * path the incomplete-setup error points to -- and an absent consumer is a
+ * no-op with a notice. NOTE: unregister_consumer cascades each slot's retry
+ * rows and dead_letter audit (SPEC section 8, teardown).
+ */
+create or replace function pgque.unsubscribe_partitioned(
+    i_queue text, i_consumer text)
+returns void as $$
+declare
+    v_queue_id int4;
+    v_n int4;
+    v_slot int4;
+begin
+    select pc.n, q.queue_id into v_n, v_queue_id
+    from pgque.partition_consumer as pc
+    join pgque.queue as q on q.queue_id = pc.queue_id
+    where q.queue_name = i_queue
+      and pc.co_name = i_consumer
+    for update of pc;
+    if not found then
+        raise notice 'partitioned consumer % on queue % does not exist; nothing to tear down',
+            i_consumer, i_queue;
+        return;
+    end if;
+
+    -- unregister_consumer returns 0 for an already-missing slot.
+    for v_slot in 0..v_n - 1 loop
+        perform pgque.unregister_consumer(
+            i_queue, pgque._slot_name(i_consumer, v_slot, v_n));
+    end loop;
+
+    -- Cascades the remaining partition_slot lease rows.
+    delete from pgque.partition_consumer
+    where queue_id = v_queue_id
+      and co_name = i_consumer;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.unsubscribe_partitioned(text, text) from public;
 
 -- ---------------------------------------------------------------------------
 -- Slot lease -- SPEC D7/D8/section 15
@@ -861,6 +920,7 @@ grant execute on function pgque.send(text, text, text, text)   to pgque_writer;
 grant execute on function pgque.subscribe_partitioned(text, text, int) to pgque_reader;
 grant execute on function pgque.subscribe_slot(text, text, int, int)   to pgque_reader;
 grant execute on function pgque.unsubscribe_slot(text, text, int)      to pgque_reader;
+grant execute on function pgque.unsubscribe_partitioned(text, text)    to pgque_reader;
 grant execute on function pgque.claim_slot(text, text, int, text, interval)    to pgque_reader;
 grant execute on function pgque.release_slot(text, text, int, text)            to pgque_reader;
 grant execute on function pgque.receive_partitioned(text, text, int, int, text, int) to pgque_reader;

--- a/devel/sql/pgque-api/partition_keys.sql
+++ b/devel/sql/pgque-api/partition_keys.sql
@@ -331,7 +331,7 @@ begin
         for update;
 
         if v_n <> i_n then
-            raise exception 'consumer % on queue % is pinned to n=%; got n=% (unsubscribe all slots to change the slot count)',
+            raise exception 'consumer % on queue % is pinned to n=%; got n=% (tear down with pgque.unsubscribe_partitioned() to change the slot count)',
                 i_consumer, i_queue, v_n, i_n;
         end if;
 
@@ -368,7 +368,7 @@ begin
         v_registered := pgque.register_consumer_at(
             i_queue, v_slot_name, v_start_tick);
         if v_registered <> 1 then
-            raise exception 'consumer name % is already registered on queue %; cannot reuse it for partition slot %/%',
+            raise exception 'consumer name % is already registered on queue %; cannot reuse it for partition slot %/% (a legacy non-partitioned consumer with that name must be removed first with pgque.unsubscribe())',
                 v_slot_name, i_queue, v_slot, i_n;
         end if;
 
@@ -426,7 +426,7 @@ begin
     on conflict (queue_id, co_name) do update set n = pc.n
     returning pc.n into v_n;
     if v_n <> i_n then
-        raise exception 'consumer % on queue % is pinned to n=%; got n=% (unsubscribe all slots to change the slot count)',
+        raise exception 'consumer % on queue % is pinned to n=%; got n=% (tear down with pgque.unsubscribe_partitioned() to change the slot count)',
             i_consumer, i_queue, v_n, i_n;
     end if;
 
@@ -471,16 +471,22 @@ begin
             i_slot, i_consumer, i_queue, v_n - 1;
     end if;
 
-    /* Dropping one slot of a complete consumer is the documented repair /
-       controlled path, but it creates the incomplete-setup state that
-       subscribe_partitioned rejects -- never do it silently. */
+    /*
+     * Dropping one slot of a complete consumer is the documented repair /
+     * controlled path, but it creates the incomplete-setup state that
+     * subscribe_partitioned rejects -- never do it silently. Genuine slots
+     * are counted catalog-driven (partition_slot row AND subscription): a
+     * legacy consumer that merely shares the name shape does not count.
+     */
     select count(*) into v_subscribed
-    from pgque.subscription as s
-    join pgque.consumer as c on c.co_id = s.sub_consumer
-    where s.sub_queue = v_queue_id
-      and c.co_name in (
-          select pgque._slot_name(i_consumer, g, v_n)
-          from generate_series(0, v_n - 1) as g);
+    from pgque.partition_slot as ps
+    join pgque.consumer as c
+        on c.co_name = pgque._slot_name(i_consumer, ps.slot, v_n)
+    join pgque.subscription as s
+        on s.sub_queue = v_queue_id
+        and s.sub_consumer = c.co_id
+    where ps.queue_id = v_queue_id
+      and ps.co_name = i_consumer;
     if v_n > 1 and v_subscribed = v_n then
         raise warning 'dropping slot % leaves partitioned consumer % on queue % with incomplete setup; repair forward-only with pgque.subscribe_slot() or tear down with pgque.unsubscribe_partitioned()',
             i_slot, i_consumer, i_queue;
@@ -493,13 +499,17 @@ begin
       and co_name = i_consumer
       and slot = i_slot;
 
+    /* Same catalog-driven rule for last-slot cleanup: only genuine slots
+       keep the pinned-N row alive, never a name-shaped legacy consumer. */
     perform 1
-    from pgque.subscription as s
-    join pgque.consumer as c on c.co_id = s.sub_consumer
-    where s.sub_queue = v_queue_id
-      and c.co_name in (
-          select pgque._slot_name(i_consumer, g, v_n)
-          from generate_series(0, v_n - 1) as g);
+    from pgque.partition_slot as ps
+    join pgque.consumer as c
+        on c.co_name = pgque._slot_name(i_consumer, ps.slot, v_n)
+    join pgque.subscription as s
+        on s.sub_queue = v_queue_id
+        and s.sub_consumer = c.co_id
+    where ps.queue_id = v_queue_id
+      and ps.co_name = i_consumer;
     if not found then
         delete from pgque.partition_consumer
         where queue_id = v_queue_id
@@ -514,8 +524,11 @@ revoke execute on function pgque.unsubscribe_slot(text, text, int) from public;
  * every slot subscription and the pinned-N row in one transaction. Partial
  * setups (some slots already gone) tear down cleanly -- this is the recreate
  * path the incomplete-setup error points to -- and an absent consumer is a
- * no-op with a notice. NOTE: unregister_consumer cascades each slot's retry
- * rows and dead_letter audit (SPEC section 8, teardown).
+ * no-op with a notice. Only catalog-registered slots (partition_slot rows)
+ * are dropped: a legacy consumer that merely shares the name shape is left
+ * untouched (remove it with plain pgque.unsubscribe()). NOTE:
+ * unregister_consumer cascades each slot's retry rows and dead_letter audit
+ * (SPEC section 8, teardown).
  */
 create or replace function pgque.unsubscribe_partitioned(
     i_queue text, i_consumer text)
@@ -537,8 +550,14 @@ begin
         return;
     end if;
 
-    -- unregister_consumer returns 0 for an already-missing slot.
-    for v_slot in 0..v_n - 1 loop
+    -- unregister_consumer returns 0 for a slot whose subscription is gone.
+    for v_slot in
+        select ps.slot
+        from pgque.partition_slot as ps
+        where ps.queue_id = v_queue_id
+          and ps.co_name = i_consumer
+        order by ps.slot
+    loop
         perform pgque.unregister_consumer(
             i_queue, pgque._slot_name(i_consumer, v_slot, v_n));
     end loop;
@@ -866,6 +885,11 @@ revoke execute on function pgque.nack_partitioned(text, text, int, int, text, pg
  * Canonical alert: pending_events > X or not subscribed. A threshold-only
  * alert (where pending_events > X) skips the NULL-lag rows of unsubscribed
  * slots, so it never sees incomplete setup.
+ *
+ * Classification is catalog-driven, like the consume API: a slot counts as
+ * subscribed only when its partition_slot row AND its engine subscription
+ * both exist. A legacy ordinary consumer that merely shares the name shape
+ * ("C#k/N") is never attributed to the slot.
  */
 create or replace view pgque.partition_slot_status as
 select
@@ -893,7 +917,8 @@ left join pgque.partition_slot as ps
     and ps.co_name = pc.co_name
     and ps.slot = gs.slot
 left join pgque.consumer as c
-    on c.co_name = pgque._slot_name(pc.co_name, gs.slot, pc.n)
+    on ps.slot is not null
+    and c.co_name = pgque._slot_name(pc.co_name, gs.slot, pc.n)
 left join pgque.subscription as s
     on s.sub_queue = pc.queue_id
     and s.sub_consumer = c.co_id

--- a/devel/sql/pgque-api/partition_keys.sql
+++ b/devel/sql/pgque-api/partition_keys.sql
@@ -63,9 +63,16 @@
 create table if not exists pgque.partition_consumer (
     queue_id    int4    not null references pgque.queue (queue_id) on delete cascade,
     co_name     text    not null,
-    n           int4    not null check (n >= 1),
+    n           int4    not null,
+    constraint partition_consumer_n_check check (n between 1 and 256),
     primary key (queue_id, co_name)
 );
+
+/* Keep the constraint definition synchronized on idempotent installs. */
+alter table pgque.partition_consumer
+    drop constraint if exists partition_consumer_n_check;
+alter table pgque.partition_consumer
+    add constraint partition_consumer_n_check check (n between 1 and 256);
 
 /*
  * Per-slot lease -- SPEC D7/D8/section 15. A slot is owned by a worker id
@@ -268,8 +275,8 @@ begin
     if position('#' in i_consumer) > 0 then
         raise exception 'partitioned consumer name must not contain #: %', i_consumer;
     end if;
-    if i_n is null or i_n < 1 then
-        raise exception 'slot count n must be >= 1, got %', i_n;
+    if i_n is null or i_n < 1 or i_n > 256 then
+        raise exception 'slot count n must be between 1 and 256, got %', i_n;
     end if;
 
     select queue_id into v_queue_id
@@ -364,8 +371,8 @@ begin
     if position('#' in i_consumer) > 0 then
         raise exception 'partitioned consumer name must not contain #: %', i_consumer;
     end if;
-    if i_n is null or i_n < 1 then
-        raise exception 'slot count n must be >= 1, got %', i_n;
+    if i_n is null or i_n < 1 or i_n > 256 then
+        raise exception 'slot count n must be between 1 and 256, got %', i_n;
     end if;
     if i_slot is null or i_slot < 0 or i_slot >= i_n then
         raise exception 'slot % out of range for n=% (valid: 0..%)', i_slot, i_n, i_n - 1;

--- a/devel/sql/pgque-tle.sql
+++ b/devel/sql/pgque-tle.sql
@@ -7250,9 +7250,16 @@ revoke execute on all functions in schema pgque from public;
 create table if not exists pgque.partition_consumer (
     queue_id    int4    not null references pgque.queue (queue_id) on delete cascade,
     co_name     text    not null,
-    n           int4    not null check (n >= 1),
+    n           int4    not null,
+    constraint partition_consumer_n_check check (n between 1 and 256),
     primary key (queue_id, co_name)
 );
+
+/* Keep the constraint definition synchronized on idempotent installs. */
+alter table pgque.partition_consumer
+    drop constraint if exists partition_consumer_n_check;
+alter table pgque.partition_consumer
+    add constraint partition_consumer_n_check check (n between 1 and 256);
 
 /*
  * Per-slot lease -- SPEC D7/D8/section 15. A slot is owned by a worker id
@@ -7455,8 +7462,8 @@ begin
     if position('#' in i_consumer) > 0 then
         raise exception 'partitioned consumer name must not contain #: %', i_consumer;
     end if;
-    if i_n is null or i_n < 1 then
-        raise exception 'slot count n must be >= 1, got %', i_n;
+    if i_n is null or i_n < 1 or i_n > 256 then
+        raise exception 'slot count n must be between 1 and 256, got %', i_n;
     end if;
 
     select queue_id into v_queue_id
@@ -7551,8 +7558,8 @@ begin
     if position('#' in i_consumer) > 0 then
         raise exception 'partitioned consumer name must not contain #: %', i_consumer;
     end if;
-    if i_n is null or i_n < 1 then
-        raise exception 'slot count n must be >= 1, got %', i_n;
+    if i_n is null or i_n < 1 or i_n > 256 then
+        raise exception 'slot count n must be between 1 and 256, got %', i_n;
     end if;
     if i_slot is null or i_slot < 0 or i_slot >= i_n then
         raise exception 'slot % out of range for n=% (valid: 0..%)', i_slot, i_n, i_n - 1;

--- a/devel/sql/pgque-tle.sql
+++ b/devel/sql/pgque-tle.sql
@@ -7295,7 +7295,7 @@ alter table pgque.partition_consumer
  * takeover of an expired lease. Written only inside SECURITY DEFINER
  * functions (same pattern as partition_consumer); revoked from app roles.
  * One row per subscribed slot, created by subscribe_partitioned or repaired
- * individually by subscribe_slot.
+ * individually by subscribe_slot (forward-only: the missed window is lost).
  */
 create table if not exists pgque.partition_slot (
     queue_id    int4 not null,
@@ -7569,6 +7569,9 @@ revoke execute on function pgque.subscribe_partitioned(text, text, int) from pub
 /*
  * Alpha-compatible single-slot registration. Prefer subscribe_partitioned for
  * new consumers; use this only for explicit repair or controlled setup work.
+ * Repair closes the gap going forward only: the slot starts at the current
+ * tick, and events ticked while it was missing are permanently lost (recreate
+ * the consumer via unsubscribe_partitioned before producing to avoid that).
  */
 create or replace function pgque.subscribe_slot(
     i_queue text, i_consumer text, i_slot int, i_n int)
@@ -7741,15 +7744,19 @@ revoke execute on function pgque.unsubscribe_partitioned(text, text) from public
 
 /*
  * Claim (or renew) the lease on a slot for a worker id. Returns the epoch
- * fencing token, or null if the slot is currently leased by another live
- * worker (the caller's claim loop then moves to the next slot). The lease
- * lives in pgque.partition_slot -- plain transactional DML, no session state
- * -- so it survives transaction-mode pooling. Uses clock_timestamp() so a
- * pg_sleep inside a transaction correctly ages a short TTL.
+ * fencing token, or null when the slot is not claimable RIGHT NOW: leased by
+ * another live worker, or the row momentarily locked by another transaction
+ * (skip locked) -- including this worker's own in-flight receive/ack renewal.
+ * The claim loop moves to the next slot on null and must never infer loss of
+ * an existing lease from it. The lease lives in pgque.partition_slot -- plain
+ * transactional DML, no session state -- so it survives transaction-mode
+ * pooling. Uses clock_timestamp() so a pg_sleep inside a transaction
+ * correctly ages a short TTL.
  *
  *   owner re-claim  -- renew the window, epoch UNCHANGED.
  *   free / expired  -- takeover: epoch += 1, return the NEW (fencing) epoch.
  *   live, other own -- return null.
+ *   row busy        -- return null (never blocks, never waits).
  */
 create or replace function pgque.claim_slot(
     i_queue text, i_consumer text, i_slot int, i_worker text,
@@ -8042,6 +8049,10 @@ revoke execute on function pgque.nack_partitioned(text, text, int, int, text, pg
  *                     filtering (tick_event_seq delta). It over-counts a
  *                     single slot's own share by ~n x, but 0 means "caught
  *                     up" exactly, and growth means the slot is stalling.
+ *
+ * Canonical alert: pending_events > X or not subscribed. A threshold-only
+ * alert (where pending_events > X) skips the NULL-lag rows of unsubscribed
+ * slots, so it never sees incomplete setup.
  */
 create or replace view pgque.partition_slot_status as
 select

--- a/devel/sql/pgque-tle.sql
+++ b/devel/sql/pgque-tle.sql
@@ -7194,6 +7194,7 @@ revoke execute on all functions in schema pgque from public;
 --   pgque.subscribe_partitioned(queue, consumer, n)
 --   pgque.subscribe_slot(queue, consumer, slot, n)
 --   pgque.unsubscribe_slot(queue, consumer, slot)
+--   pgque.unsubscribe_partitioned(queue, consumer)
 --   pgque.claim_slot(queue, consumer, slot, worker, ttl)
 --   pgque.release_slot(queue, consumer, slot, worker)
 --   pgque.receive_partitioned(queue, consumer, slot, n, worker, max)
@@ -7533,7 +7534,7 @@ begin
             on s.sub_queue = v_queue_id
             and s.sub_consumer = c.co_id;
         if v_complete_slots <> i_n then
-            raise exception 'partitioned consumer % on queue % has incomplete setup (% of % slots subscribed); repair with pgque.subscribe_slot() or recreate it before producing',
+            raise exception 'partitioned consumer % on queue % has incomplete setup (% of % slots subscribed); repair with pgque.subscribe_slot() (forward-only: events ticked while a slot was missing stay lost) or recreate it via pgque.unsubscribe_partitioned() before producing',
                 i_consumer, i_queue, v_complete_slots, i_n;
         end if;
 
@@ -7637,6 +7638,7 @@ returns void as $$
 declare
     v_queue_id int4;
     v_n int4;
+    v_subscribed int4;
 begin
     select pc.n, q.queue_id into v_n, v_queue_id
     from pgque.partition_consumer as pc
@@ -7651,6 +7653,21 @@ begin
     if i_slot is null or i_slot < 0 or i_slot >= v_n then
         raise exception 'slot % out of range for consumer % on queue % (valid: 0..%)',
             i_slot, i_consumer, i_queue, v_n - 1;
+    end if;
+
+    /* Dropping one slot of a complete consumer is the documented repair /
+       controlled path, but it creates the incomplete-setup state that
+       subscribe_partitioned rejects -- never do it silently. */
+    select count(*) into v_subscribed
+    from pgque.subscription as s
+    join pgque.consumer as c on c.co_id = s.sub_consumer
+    where s.sub_queue = v_queue_id
+      and c.co_name in (
+          select pgque._slot_name(i_consumer, g, v_n)
+          from generate_series(0, v_n - 1) as g);
+    if v_n > 1 and v_subscribed = v_n then
+        raise warning 'dropping slot % leaves partitioned consumer % on queue % with incomplete setup; repair forward-only with pgque.subscribe_slot() or tear down with pgque.unsubscribe_partitioned()',
+            i_slot, i_consumer, i_queue;
     end if;
 
     perform pgque.unregister_consumer(i_queue, pgque._slot_name(i_consumer, i_slot, v_n));
@@ -7675,6 +7692,48 @@ begin
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 revoke execute on function pgque.unsubscribe_slot(text, text, int) from public;
+
+/*
+ * Whole-consumer teardown -- the inverse of subscribe_partitioned. Drops
+ * every slot subscription and the pinned-N row in one transaction. Partial
+ * setups (some slots already gone) tear down cleanly -- this is the recreate
+ * path the incomplete-setup error points to -- and an absent consumer is a
+ * no-op with a notice. NOTE: unregister_consumer cascades each slot's retry
+ * rows and dead_letter audit (SPEC section 8, teardown).
+ */
+create or replace function pgque.unsubscribe_partitioned(
+    i_queue text, i_consumer text)
+returns void as $$
+declare
+    v_queue_id int4;
+    v_n int4;
+    v_slot int4;
+begin
+    select pc.n, q.queue_id into v_n, v_queue_id
+    from pgque.partition_consumer as pc
+    join pgque.queue as q on q.queue_id = pc.queue_id
+    where q.queue_name = i_queue
+      and pc.co_name = i_consumer
+    for update of pc;
+    if not found then
+        raise notice 'partitioned consumer % on queue % does not exist; nothing to tear down',
+            i_consumer, i_queue;
+        return;
+    end if;
+
+    -- unregister_consumer returns 0 for an already-missing slot.
+    for v_slot in 0..v_n - 1 loop
+        perform pgque.unregister_consumer(
+            i_queue, pgque._slot_name(i_consumer, v_slot, v_n));
+    end loop;
+
+    -- Cascades the remaining partition_slot lease rows.
+    delete from pgque.partition_consumer
+    where queue_id = v_queue_id
+      and co_name = i_consumer;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.unsubscribe_partitioned(text, text) from public;
 
 -- ---------------------------------------------------------------------------
 -- Slot lease -- SPEC D7/D8/section 15
@@ -8048,6 +8107,7 @@ grant execute on function pgque.send(text, text, text, text)   to pgque_writer;
 grant execute on function pgque.subscribe_partitioned(text, text, int) to pgque_reader;
 grant execute on function pgque.subscribe_slot(text, text, int, int)   to pgque_reader;
 grant execute on function pgque.unsubscribe_slot(text, text, int)      to pgque_reader;
+grant execute on function pgque.unsubscribe_partitioned(text, text)    to pgque_reader;
 grant execute on function pgque.claim_slot(text, text, int, text, interval)    to pgque_reader;
 grant execute on function pgque.release_slot(text, text, int, text)            to pgque_reader;
 grant execute on function pgque.receive_partitioned(text, text, int, int, text, int) to pgque_reader;

--- a/devel/sql/pgque-tle.sql
+++ b/devel/sql/pgque-tle.sql
@@ -7255,7 +7255,34 @@ create table if not exists pgque.partition_consumer (
     primary key (queue_id, co_name)
 );
 
+/*
+ * Pre-flight guard for the constraint re-add below: a consumer created
+ * before the n cap existed would otherwise abort the install with a bare
+ * check-violation error. Name the row and the fix instead.
+ */
+create or replace function pgque._partition_n_cap_guard()
+returns void as $$
+declare
+    v_bad record;
+begin
+    select q.queue_name, pc.co_name, pc.n into v_bad
+    from pgque.partition_consumer as pc
+    join pgque.queue as q on q.queue_id = pc.queue_id
+    where pc.n not between 1 and 256
+    order by q.queue_name, pc.co_name
+    limit 1;
+    if found then
+        raise exception 'cannot apply the 256-slot cap: partitioned consumer % on queue % has n=%; recreate it with a smaller slot count (drop every slot via pgque.unsubscribe_slot(), then pgque.subscribe_partitioned() with n <= 256), then re-run the install',
+            v_bad.co_name, v_bad.queue_name, v_bad.n;
+    end if;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
 /* Keep the constraint definition synchronized on idempotent installs. */
+do $$
+begin
+    perform pgque._partition_n_cap_guard();
+end $$;
 alter table pgque.partition_consumer
     drop constraint if exists partition_consumer_n_check;
 alter table pgque.partition_consumer
@@ -8031,6 +8058,7 @@ grant select on pgque.partition_slot_status to pgque_reader;
 grant select on pgque.partition_slot_status to pgque_admin;
 
 -- Internal helpers: SECURITY DEFINER callees only.
+revoke execute on function pgque._partition_n_cap_guard() from public, pgque_reader, pgque_writer;
 revoke execute on function pgque._slot_name(text, int, int) from public, pgque_reader, pgque_writer;
 revoke execute on function pgque._slot_guard(text, text, int, int, text) from public, pgque_reader, pgque_writer;
 revoke execute on function pgque._slot_batch(text, text, int, int) from public, pgque_reader, pgque_writer;

--- a/devel/sql/pgque-tle.sql
+++ b/devel/sql/pgque-tle.sql
@@ -7518,7 +7518,7 @@ begin
         for update;
 
         if v_n <> i_n then
-            raise exception 'consumer % on queue % is pinned to n=%; got n=% (unsubscribe all slots to change the slot count)',
+            raise exception 'consumer % on queue % is pinned to n=%; got n=% (tear down with pgque.unsubscribe_partitioned() to change the slot count)',
                 i_consumer, i_queue, v_n, i_n;
         end if;
 
@@ -7555,7 +7555,7 @@ begin
         v_registered := pgque.register_consumer_at(
             i_queue, v_slot_name, v_start_tick);
         if v_registered <> 1 then
-            raise exception 'consumer name % is already registered on queue %; cannot reuse it for partition slot %/%',
+            raise exception 'consumer name % is already registered on queue %; cannot reuse it for partition slot %/% (a legacy non-partitioned consumer with that name must be removed first with pgque.unsubscribe())',
                 v_slot_name, i_queue, v_slot, i_n;
         end if;
 
@@ -7613,7 +7613,7 @@ begin
     on conflict (queue_id, co_name) do update set n = pc.n
     returning pc.n into v_n;
     if v_n <> i_n then
-        raise exception 'consumer % on queue % is pinned to n=%; got n=% (unsubscribe all slots to change the slot count)',
+        raise exception 'consumer % on queue % is pinned to n=%; got n=% (tear down with pgque.unsubscribe_partitioned() to change the slot count)',
             i_consumer, i_queue, v_n, i_n;
     end if;
 
@@ -7658,16 +7658,22 @@ begin
             i_slot, i_consumer, i_queue, v_n - 1;
     end if;
 
-    /* Dropping one slot of a complete consumer is the documented repair /
-       controlled path, but it creates the incomplete-setup state that
-       subscribe_partitioned rejects -- never do it silently. */
+    /*
+     * Dropping one slot of a complete consumer is the documented repair /
+     * controlled path, but it creates the incomplete-setup state that
+     * subscribe_partitioned rejects -- never do it silently. Genuine slots
+     * are counted catalog-driven (partition_slot row AND subscription): a
+     * legacy consumer that merely shares the name shape does not count.
+     */
     select count(*) into v_subscribed
-    from pgque.subscription as s
-    join pgque.consumer as c on c.co_id = s.sub_consumer
-    where s.sub_queue = v_queue_id
-      and c.co_name in (
-          select pgque._slot_name(i_consumer, g, v_n)
-          from generate_series(0, v_n - 1) as g);
+    from pgque.partition_slot as ps
+    join pgque.consumer as c
+        on c.co_name = pgque._slot_name(i_consumer, ps.slot, v_n)
+    join pgque.subscription as s
+        on s.sub_queue = v_queue_id
+        and s.sub_consumer = c.co_id
+    where ps.queue_id = v_queue_id
+      and ps.co_name = i_consumer;
     if v_n > 1 and v_subscribed = v_n then
         raise warning 'dropping slot % leaves partitioned consumer % on queue % with incomplete setup; repair forward-only with pgque.subscribe_slot() or tear down with pgque.unsubscribe_partitioned()',
             i_slot, i_consumer, i_queue;
@@ -7680,13 +7686,17 @@ begin
       and co_name = i_consumer
       and slot = i_slot;
 
+    /* Same catalog-driven rule for last-slot cleanup: only genuine slots
+       keep the pinned-N row alive, never a name-shaped legacy consumer. */
     perform 1
-    from pgque.subscription as s
-    join pgque.consumer as c on c.co_id = s.sub_consumer
-    where s.sub_queue = v_queue_id
-      and c.co_name in (
-          select pgque._slot_name(i_consumer, g, v_n)
-          from generate_series(0, v_n - 1) as g);
+    from pgque.partition_slot as ps
+    join pgque.consumer as c
+        on c.co_name = pgque._slot_name(i_consumer, ps.slot, v_n)
+    join pgque.subscription as s
+        on s.sub_queue = v_queue_id
+        and s.sub_consumer = c.co_id
+    where ps.queue_id = v_queue_id
+      and ps.co_name = i_consumer;
     if not found then
         delete from pgque.partition_consumer
         where queue_id = v_queue_id
@@ -7701,8 +7711,11 @@ revoke execute on function pgque.unsubscribe_slot(text, text, int) from public;
  * every slot subscription and the pinned-N row in one transaction. Partial
  * setups (some slots already gone) tear down cleanly -- this is the recreate
  * path the incomplete-setup error points to -- and an absent consumer is a
- * no-op with a notice. NOTE: unregister_consumer cascades each slot's retry
- * rows and dead_letter audit (SPEC section 8, teardown).
+ * no-op with a notice. Only catalog-registered slots (partition_slot rows)
+ * are dropped: a legacy consumer that merely shares the name shape is left
+ * untouched (remove it with plain pgque.unsubscribe()). NOTE:
+ * unregister_consumer cascades each slot's retry rows and dead_letter audit
+ * (SPEC section 8, teardown).
  */
 create or replace function pgque.unsubscribe_partitioned(
     i_queue text, i_consumer text)
@@ -7724,8 +7737,14 @@ begin
         return;
     end if;
 
-    -- unregister_consumer returns 0 for an already-missing slot.
-    for v_slot in 0..v_n - 1 loop
+    -- unregister_consumer returns 0 for a slot whose subscription is gone.
+    for v_slot in
+        select ps.slot
+        from pgque.partition_slot as ps
+        where ps.queue_id = v_queue_id
+          and ps.co_name = i_consumer
+        order by ps.slot
+    loop
         perform pgque.unregister_consumer(
             i_queue, pgque._slot_name(i_consumer, v_slot, v_n));
     end loop;
@@ -8053,6 +8072,11 @@ revoke execute on function pgque.nack_partitioned(text, text, int, int, text, pg
  * Canonical alert: pending_events > X or not subscribed. A threshold-only
  * alert (where pending_events > X) skips the NULL-lag rows of unsubscribed
  * slots, so it never sees incomplete setup.
+ *
+ * Classification is catalog-driven, like the consume API: a slot counts as
+ * subscribed only when its partition_slot row AND its engine subscription
+ * both exist. A legacy ordinary consumer that merely shares the name shape
+ * ("C#k/N") is never attributed to the slot.
  */
 create or replace view pgque.partition_slot_status as
 select
@@ -8080,7 +8104,8 @@ left join pgque.partition_slot as ps
     and ps.co_name = pc.co_name
     and ps.slot = gs.slot
 left join pgque.consumer as c
-    on c.co_name = pgque._slot_name(pc.co_name, gs.slot, pc.n)
+    on ps.slot is not null
+    and c.co_name = pgque._slot_name(pc.co_name, gs.slot, pc.n)
 left join pgque.subscription as s
     on s.sub_queue = pc.queue_id
     and s.sub_consumer = c.co_id

--- a/devel/sql/pgque-tle.sql
+++ b/devel/sql/pgque-tle.sql
@@ -7191,6 +7191,7 @@ revoke execute on all functions in schema pgque from public;
 --
 -- Partition keys (blueprints/partition-keys/SPEC.md, Phase 1A):
 --   pgque.send(queue, type, payload, partition_key)  -- jsonb + text overloads
+--   pgque.subscribe_partitioned(queue, consumer, n)
 --   pgque.subscribe_slot(queue, consumer, slot, n)
 --   pgque.unsubscribe_slot(queue, consumer, slot)
 --   pgque.claim_slot(queue, consumer, slot, worker, ttl)
@@ -7258,7 +7259,8 @@ create table if not exists pgque.partition_consumer (
  * for a TTL window; epoch is the monotonic fencing token, bumped on every
  * takeover of an expired lease. Written only inside SECURITY DEFINER
  * functions (same pattern as partition_consumer); revoked from app roles.
- * One row per subscribed slot, created by subscribe_slot.
+ * One row per subscribed slot, created by subscribe_partitioned or repaired
+ * individually by subscribe_slot.
  */
 create table if not exists pgque.partition_slot (
     queue_id    int4 not null,
@@ -7328,7 +7330,7 @@ begin
     where q.queue_name = i_queue
       and pc.co_name = i_consumer;
     if not found then
-        raise exception 'consumer % on queue % is not a partitioned consumer; call pgque.subscribe_slot() first',
+        raise exception 'consumer % on queue % is not a partitioned consumer; call pgque.subscribe_partitioned() first',
             i_consumer, i_queue;
     end if;
 
@@ -7427,6 +7429,112 @@ revoke execute on function pgque.send(text, text, text, text) from public;
 -- Slot registration (enforced N)
 -- ---------------------------------------------------------------------------
 
+/*
+ * Atomically materialize every slot for a partitioned consumer at one shared
+ * tick. Existing complete setup is idempotent and never repositions cursors;
+ * existing partial setup requires an explicit repair decision.
+ */
+create or replace function pgque.subscribe_partitioned(
+    i_queue text, i_consumer text, i_n int)
+returns void as $$
+declare
+    v_queue_id int4;
+    v_n int4;
+    v_start_tick bigint;
+    v_complete_slots int4;
+    v_registered int4;
+    v_slot int4;
+    v_slot_name text;
+begin
+    if i_queue is null or i_queue = '' then
+        raise exception 'queue name must not be empty';
+    end if;
+    if i_consumer is null or i_consumer = '' then
+        raise exception 'consumer name must not be empty';
+    end if;
+    if position('#' in i_consumer) > 0 then
+        raise exception 'partitioned consumer name must not contain #: %', i_consumer;
+    end if;
+    if i_n is null or i_n < 1 then
+        raise exception 'slot count n must be >= 1, got %', i_n;
+    end if;
+
+    select queue_id into v_queue_id
+    from pgque.queue
+    where queue_name = i_queue;
+    if not found then
+        raise exception 'queue not found: %', i_queue;
+    end if;
+
+    /*
+     * ON CONFLICT waits for a concurrent creator. The follow-up row lock makes
+     * complete-state inspection serialize with subscribe_slot and another
+     * subscribe_partitioned call for the same logical consumer.
+     */
+    insert into pgque.partition_consumer (queue_id, co_name, n)
+    values (v_queue_id, i_consumer, i_n)
+    on conflict (queue_id, co_name) do nothing
+    returning n into v_n;
+    if not found then
+        select pc.n into v_n
+        from pgque.partition_consumer as pc
+        where pc.queue_id = v_queue_id
+          and pc.co_name = i_consumer
+        for update;
+
+        if v_n <> i_n then
+            raise exception 'consumer % on queue % is pinned to n=%; got n=% (unsubscribe all slots to change the slot count)',
+                i_consumer, i_queue, v_n, i_n;
+        end if;
+
+        select count(*) into v_complete_slots
+        from generate_series(0, i_n - 1) as gs(slot)
+        join pgque.partition_slot as ps
+            on ps.queue_id = v_queue_id
+            and ps.co_name = i_consumer
+            and ps.slot = gs.slot
+        join pgque.consumer as c
+            on c.co_name = pgque._slot_name(i_consumer, gs.slot, i_n)
+        join pgque.subscription as s
+            on s.sub_queue = v_queue_id
+            and s.sub_consumer = c.co_id;
+        if v_complete_slots <> i_n then
+            raise exception 'partitioned consumer % on queue % has incomplete setup (% of % slots subscribed); repair with pgque.subscribe_slot() or recreate it before producing',
+                i_consumer, i_queue, v_complete_slots, i_n;
+        end if;
+
+        return;
+    end if;
+
+    select tick_id into v_start_tick
+    from pgque.tick
+    where tick_queue = v_queue_id
+    order by tick_id desc
+    limit 1;
+    if not found then
+        raise exception 'no ticks for queue: %', i_queue;
+    end if;
+
+    for v_slot in 0..i_n - 1 loop
+        v_slot_name := pgque._slot_name(i_consumer, v_slot, i_n);
+        v_registered := pgque.register_consumer_at(
+            i_queue, v_slot_name, v_start_tick);
+        if v_registered <> 1 then
+            raise exception 'consumer name % is already registered on queue %; cannot reuse it for partition slot %/%',
+                v_slot_name, i_queue, v_slot, i_n;
+        end if;
+
+        insert into pgque.partition_slot (queue_id, co_name, slot)
+        values (v_queue_id, i_consumer, v_slot);
+    end loop;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.subscribe_partitioned(text, text, int) from public;
+
+/*
+ * Alpha-compatible single-slot registration. Prefer subscribe_partitioned for
+ * new consumers; use this only for explicit repair or controlled setup work.
+ */
 create or replace function pgque.subscribe_slot(
     i_queue text, i_consumer text, i_slot int, i_n int)
 returns void as $$
@@ -7574,7 +7682,7 @@ begin
     where q.queue_name = i_queue
       and pc.co_name = i_consumer;
     if not found then
-        raise exception 'consumer % on queue % is not a partitioned consumer; call pgque.subscribe_slot() first',
+        raise exception 'consumer % on queue % is not a partitioned consumer; call pgque.subscribe_partitioned() first',
             i_consumer, i_queue;
     end if;
     if i_slot is null or i_slot < 0 or i_slot >= v_n then
@@ -7825,10 +7933,12 @@ revoke execute on function pgque.nack_partitioned(text, text, int, int, text, pg
 -- ---------------------------------------------------------------------------
 
 /*
- * One row per slot 0..n-1 of every partitioned consumer (including slots
- * not yet leased -- an unpolled slot is exactly what the R7 rotation-pinning
- * alert must catch).
+ * One row per expected slot 0..n-1 of every partitioned consumer, including
+ * missing subscriptions and slots not yet leased. An unpolled subscribed slot
+ * is exactly what the R7 rotation-pinning alert must catch.
  *
+ *   subscribed     -- true when the engine subscription exists; false means
+ *                     setup is incomplete and cursor lag is unknown.
  *   lease_owner    -- worker holding a LIVE lease on the slot; null when
  *                     unleased OR the lease has expired (lease_until in the
  *                     past). A stale owner is never shown as current.
@@ -7846,6 +7956,7 @@ select
     pc.co_name as consumer,
     gs.slot,
     pc.n,
+    s.sub_id is not null as subscribed,
     case when ps.lease_owner is not null and ps.lease_until > clock_timestamp()
          then ps.lease_owner
          else null
@@ -7853,7 +7964,10 @@ select
     ps.lease_until,
     coalesce(ps.epoch, 0) as epoch,
     s.sub_last_tick as last_tick,
-    greatest(coalesce(latest.tick_event_seq - cur.tick_event_seq, 0), 0) as pending_events
+    case
+        when s.sub_id is null then null
+        else greatest(coalesce(latest.tick_event_seq - cur.tick_event_seq, 0), 0)
+    end as pending_events
 from pgque.partition_consumer as pc
 join pgque.queue as q on q.queue_id = pc.queue_id
 cross join lateral generate_series(0, pc.n - 1) as gs(slot)
@@ -7897,6 +8011,7 @@ grant select on pgque.partition_slot to pgque_admin;
 grant execute on function pgque.send(text, text, jsonb, text)  to pgque_writer;
 grant execute on function pgque.send(text, text, text, text)   to pgque_writer;
 
+grant execute on function pgque.subscribe_partitioned(text, text, int) to pgque_reader;
 grant execute on function pgque.subscribe_slot(text, text, int, int)   to pgque_reader;
 grant execute on function pgque.unsubscribe_slot(text, text, int)      to pgque_reader;
 grant execute on function pgque.claim_slot(text, text, int, text, interval)    to pgque_reader;

--- a/devel/sql/pgque.sql
+++ b/devel/sql/pgque.sql
@@ -7104,6 +7104,7 @@ revoke execute on all functions in schema pgque from public;
 --   pgque.subscribe_partitioned(queue, consumer, n)
 --   pgque.subscribe_slot(queue, consumer, slot, n)
 --   pgque.unsubscribe_slot(queue, consumer, slot)
+--   pgque.unsubscribe_partitioned(queue, consumer)
 --   pgque.claim_slot(queue, consumer, slot, worker, ttl)
 --   pgque.release_slot(queue, consumer, slot, worker)
 --   pgque.receive_partitioned(queue, consumer, slot, n, worker, max)
@@ -7443,7 +7444,7 @@ begin
             on s.sub_queue = v_queue_id
             and s.sub_consumer = c.co_id;
         if v_complete_slots <> i_n then
-            raise exception 'partitioned consumer % on queue % has incomplete setup (% of % slots subscribed); repair with pgque.subscribe_slot() or recreate it before producing',
+            raise exception 'partitioned consumer % on queue % has incomplete setup (% of % slots subscribed); repair with pgque.subscribe_slot() (forward-only: events ticked while a slot was missing stay lost) or recreate it via pgque.unsubscribe_partitioned() before producing',
                 i_consumer, i_queue, v_complete_slots, i_n;
         end if;
 
@@ -7547,6 +7548,7 @@ returns void as $$
 declare
     v_queue_id int4;
     v_n int4;
+    v_subscribed int4;
 begin
     select pc.n, q.queue_id into v_n, v_queue_id
     from pgque.partition_consumer as pc
@@ -7561,6 +7563,21 @@ begin
     if i_slot is null or i_slot < 0 or i_slot >= v_n then
         raise exception 'slot % out of range for consumer % on queue % (valid: 0..%)',
             i_slot, i_consumer, i_queue, v_n - 1;
+    end if;
+
+    /* Dropping one slot of a complete consumer is the documented repair /
+       controlled path, but it creates the incomplete-setup state that
+       subscribe_partitioned rejects -- never do it silently. */
+    select count(*) into v_subscribed
+    from pgque.subscription as s
+    join pgque.consumer as c on c.co_id = s.sub_consumer
+    where s.sub_queue = v_queue_id
+      and c.co_name in (
+          select pgque._slot_name(i_consumer, g, v_n)
+          from generate_series(0, v_n - 1) as g);
+    if v_n > 1 and v_subscribed = v_n then
+        raise warning 'dropping slot % leaves partitioned consumer % on queue % with incomplete setup; repair forward-only with pgque.subscribe_slot() or tear down with pgque.unsubscribe_partitioned()',
+            i_slot, i_consumer, i_queue;
     end if;
 
     perform pgque.unregister_consumer(i_queue, pgque._slot_name(i_consumer, i_slot, v_n));
@@ -7585,6 +7602,48 @@ begin
 end;
 $$ language plpgsql security definer set search_path = pgque, pg_catalog;
 revoke execute on function pgque.unsubscribe_slot(text, text, int) from public;
+
+/*
+ * Whole-consumer teardown -- the inverse of subscribe_partitioned. Drops
+ * every slot subscription and the pinned-N row in one transaction. Partial
+ * setups (some slots already gone) tear down cleanly -- this is the recreate
+ * path the incomplete-setup error points to -- and an absent consumer is a
+ * no-op with a notice. NOTE: unregister_consumer cascades each slot's retry
+ * rows and dead_letter audit (SPEC section 8, teardown).
+ */
+create or replace function pgque.unsubscribe_partitioned(
+    i_queue text, i_consumer text)
+returns void as $$
+declare
+    v_queue_id int4;
+    v_n int4;
+    v_slot int4;
+begin
+    select pc.n, q.queue_id into v_n, v_queue_id
+    from pgque.partition_consumer as pc
+    join pgque.queue as q on q.queue_id = pc.queue_id
+    where q.queue_name = i_queue
+      and pc.co_name = i_consumer
+    for update of pc;
+    if not found then
+        raise notice 'partitioned consumer % on queue % does not exist; nothing to tear down',
+            i_consumer, i_queue;
+        return;
+    end if;
+
+    -- unregister_consumer returns 0 for an already-missing slot.
+    for v_slot in 0..v_n - 1 loop
+        perform pgque.unregister_consumer(
+            i_queue, pgque._slot_name(i_consumer, v_slot, v_n));
+    end loop;
+
+    -- Cascades the remaining partition_slot lease rows.
+    delete from pgque.partition_consumer
+    where queue_id = v_queue_id
+      and co_name = i_consumer;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.unsubscribe_partitioned(text, text) from public;
 
 -- ---------------------------------------------------------------------------
 -- Slot lease -- SPEC D7/D8/section 15
@@ -7958,6 +8017,7 @@ grant execute on function pgque.send(text, text, text, text)   to pgque_writer;
 grant execute on function pgque.subscribe_partitioned(text, text, int) to pgque_reader;
 grant execute on function pgque.subscribe_slot(text, text, int, int)   to pgque_reader;
 grant execute on function pgque.unsubscribe_slot(text, text, int)      to pgque_reader;
+grant execute on function pgque.unsubscribe_partitioned(text, text)    to pgque_reader;
 grant execute on function pgque.claim_slot(text, text, int, text, interval)    to pgque_reader;
 grant execute on function pgque.release_slot(text, text, int, text)            to pgque_reader;
 grant execute on function pgque.receive_partitioned(text, text, int, int, text, int) to pgque_reader;

--- a/devel/sql/pgque.sql
+++ b/devel/sql/pgque.sql
@@ -7160,9 +7160,16 @@ revoke execute on all functions in schema pgque from public;
 create table if not exists pgque.partition_consumer (
     queue_id    int4    not null references pgque.queue (queue_id) on delete cascade,
     co_name     text    not null,
-    n           int4    not null check (n >= 1),
+    n           int4    not null,
+    constraint partition_consumer_n_check check (n between 1 and 256),
     primary key (queue_id, co_name)
 );
+
+/* Keep the constraint definition synchronized on idempotent installs. */
+alter table pgque.partition_consumer
+    drop constraint if exists partition_consumer_n_check;
+alter table pgque.partition_consumer
+    add constraint partition_consumer_n_check check (n between 1 and 256);
 
 /*
  * Per-slot lease -- SPEC D7/D8/section 15. A slot is owned by a worker id
@@ -7365,8 +7372,8 @@ begin
     if position('#' in i_consumer) > 0 then
         raise exception 'partitioned consumer name must not contain #: %', i_consumer;
     end if;
-    if i_n is null or i_n < 1 then
-        raise exception 'slot count n must be >= 1, got %', i_n;
+    if i_n is null or i_n < 1 or i_n > 256 then
+        raise exception 'slot count n must be between 1 and 256, got %', i_n;
     end if;
 
     select queue_id into v_queue_id
@@ -7461,8 +7468,8 @@ begin
     if position('#' in i_consumer) > 0 then
         raise exception 'partitioned consumer name must not contain #: %', i_consumer;
     end if;
-    if i_n is null or i_n < 1 then
-        raise exception 'slot count n must be >= 1, got %', i_n;
+    if i_n is null or i_n < 1 or i_n > 256 then
+        raise exception 'slot count n must be between 1 and 256, got %', i_n;
     end if;
     if i_slot is null or i_slot < 0 or i_slot >= i_n then
         raise exception 'slot % out of range for n=% (valid: 0..%)', i_slot, i_n, i_n - 1;

--- a/devel/sql/pgque.sql
+++ b/devel/sql/pgque.sql
@@ -7101,6 +7101,7 @@ revoke execute on all functions in schema pgque from public;
 --
 -- Partition keys (blueprints/partition-keys/SPEC.md, Phase 1A):
 --   pgque.send(queue, type, payload, partition_key)  -- jsonb + text overloads
+--   pgque.subscribe_partitioned(queue, consumer, n)
 --   pgque.subscribe_slot(queue, consumer, slot, n)
 --   pgque.unsubscribe_slot(queue, consumer, slot)
 --   pgque.claim_slot(queue, consumer, slot, worker, ttl)
@@ -7168,7 +7169,8 @@ create table if not exists pgque.partition_consumer (
  * for a TTL window; epoch is the monotonic fencing token, bumped on every
  * takeover of an expired lease. Written only inside SECURITY DEFINER
  * functions (same pattern as partition_consumer); revoked from app roles.
- * One row per subscribed slot, created by subscribe_slot.
+ * One row per subscribed slot, created by subscribe_partitioned or repaired
+ * individually by subscribe_slot.
  */
 create table if not exists pgque.partition_slot (
     queue_id    int4 not null,
@@ -7238,7 +7240,7 @@ begin
     where q.queue_name = i_queue
       and pc.co_name = i_consumer;
     if not found then
-        raise exception 'consumer % on queue % is not a partitioned consumer; call pgque.subscribe_slot() first',
+        raise exception 'consumer % on queue % is not a partitioned consumer; call pgque.subscribe_partitioned() first',
             i_consumer, i_queue;
     end if;
 
@@ -7337,6 +7339,112 @@ revoke execute on function pgque.send(text, text, text, text) from public;
 -- Slot registration (enforced N)
 -- ---------------------------------------------------------------------------
 
+/*
+ * Atomically materialize every slot for a partitioned consumer at one shared
+ * tick. Existing complete setup is idempotent and never repositions cursors;
+ * existing partial setup requires an explicit repair decision.
+ */
+create or replace function pgque.subscribe_partitioned(
+    i_queue text, i_consumer text, i_n int)
+returns void as $$
+declare
+    v_queue_id int4;
+    v_n int4;
+    v_start_tick bigint;
+    v_complete_slots int4;
+    v_registered int4;
+    v_slot int4;
+    v_slot_name text;
+begin
+    if i_queue is null or i_queue = '' then
+        raise exception 'queue name must not be empty';
+    end if;
+    if i_consumer is null or i_consumer = '' then
+        raise exception 'consumer name must not be empty';
+    end if;
+    if position('#' in i_consumer) > 0 then
+        raise exception 'partitioned consumer name must not contain #: %', i_consumer;
+    end if;
+    if i_n is null or i_n < 1 then
+        raise exception 'slot count n must be >= 1, got %', i_n;
+    end if;
+
+    select queue_id into v_queue_id
+    from pgque.queue
+    where queue_name = i_queue;
+    if not found then
+        raise exception 'queue not found: %', i_queue;
+    end if;
+
+    /*
+     * ON CONFLICT waits for a concurrent creator. The follow-up row lock makes
+     * complete-state inspection serialize with subscribe_slot and another
+     * subscribe_partitioned call for the same logical consumer.
+     */
+    insert into pgque.partition_consumer (queue_id, co_name, n)
+    values (v_queue_id, i_consumer, i_n)
+    on conflict (queue_id, co_name) do nothing
+    returning n into v_n;
+    if not found then
+        select pc.n into v_n
+        from pgque.partition_consumer as pc
+        where pc.queue_id = v_queue_id
+          and pc.co_name = i_consumer
+        for update;
+
+        if v_n <> i_n then
+            raise exception 'consumer % on queue % is pinned to n=%; got n=% (unsubscribe all slots to change the slot count)',
+                i_consumer, i_queue, v_n, i_n;
+        end if;
+
+        select count(*) into v_complete_slots
+        from generate_series(0, i_n - 1) as gs(slot)
+        join pgque.partition_slot as ps
+            on ps.queue_id = v_queue_id
+            and ps.co_name = i_consumer
+            and ps.slot = gs.slot
+        join pgque.consumer as c
+            on c.co_name = pgque._slot_name(i_consumer, gs.slot, i_n)
+        join pgque.subscription as s
+            on s.sub_queue = v_queue_id
+            and s.sub_consumer = c.co_id;
+        if v_complete_slots <> i_n then
+            raise exception 'partitioned consumer % on queue % has incomplete setup (% of % slots subscribed); repair with pgque.subscribe_slot() or recreate it before producing',
+                i_consumer, i_queue, v_complete_slots, i_n;
+        end if;
+
+        return;
+    end if;
+
+    select tick_id into v_start_tick
+    from pgque.tick
+    where tick_queue = v_queue_id
+    order by tick_id desc
+    limit 1;
+    if not found then
+        raise exception 'no ticks for queue: %', i_queue;
+    end if;
+
+    for v_slot in 0..i_n - 1 loop
+        v_slot_name := pgque._slot_name(i_consumer, v_slot, i_n);
+        v_registered := pgque.register_consumer_at(
+            i_queue, v_slot_name, v_start_tick);
+        if v_registered <> 1 then
+            raise exception 'consumer name % is already registered on queue %; cannot reuse it for partition slot %/%',
+                v_slot_name, i_queue, v_slot, i_n;
+        end if;
+
+        insert into pgque.partition_slot (queue_id, co_name, slot)
+        values (v_queue_id, i_consumer, v_slot);
+    end loop;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+revoke execute on function pgque.subscribe_partitioned(text, text, int) from public;
+
+/*
+ * Alpha-compatible single-slot registration. Prefer subscribe_partitioned for
+ * new consumers; use this only for explicit repair or controlled setup work.
+ */
 create or replace function pgque.subscribe_slot(
     i_queue text, i_consumer text, i_slot int, i_n int)
 returns void as $$
@@ -7484,7 +7592,7 @@ begin
     where q.queue_name = i_queue
       and pc.co_name = i_consumer;
     if not found then
-        raise exception 'consumer % on queue % is not a partitioned consumer; call pgque.subscribe_slot() first',
+        raise exception 'consumer % on queue % is not a partitioned consumer; call pgque.subscribe_partitioned() first',
             i_consumer, i_queue;
     end if;
     if i_slot is null or i_slot < 0 or i_slot >= v_n then
@@ -7735,10 +7843,12 @@ revoke execute on function pgque.nack_partitioned(text, text, int, int, text, pg
 -- ---------------------------------------------------------------------------
 
 /*
- * One row per slot 0..n-1 of every partitioned consumer (including slots
- * not yet leased -- an unpolled slot is exactly what the R7 rotation-pinning
- * alert must catch).
+ * One row per expected slot 0..n-1 of every partitioned consumer, including
+ * missing subscriptions and slots not yet leased. An unpolled subscribed slot
+ * is exactly what the R7 rotation-pinning alert must catch.
  *
+ *   subscribed     -- true when the engine subscription exists; false means
+ *                     setup is incomplete and cursor lag is unknown.
  *   lease_owner    -- worker holding a LIVE lease on the slot; null when
  *                     unleased OR the lease has expired (lease_until in the
  *                     past). A stale owner is never shown as current.
@@ -7756,6 +7866,7 @@ select
     pc.co_name as consumer,
     gs.slot,
     pc.n,
+    s.sub_id is not null as subscribed,
     case when ps.lease_owner is not null and ps.lease_until > clock_timestamp()
          then ps.lease_owner
          else null
@@ -7763,7 +7874,10 @@ select
     ps.lease_until,
     coalesce(ps.epoch, 0) as epoch,
     s.sub_last_tick as last_tick,
-    greatest(coalesce(latest.tick_event_seq - cur.tick_event_seq, 0), 0) as pending_events
+    case
+        when s.sub_id is null then null
+        else greatest(coalesce(latest.tick_event_seq - cur.tick_event_seq, 0), 0)
+    end as pending_events
 from pgque.partition_consumer as pc
 join pgque.queue as q on q.queue_id = pc.queue_id
 cross join lateral generate_series(0, pc.n - 1) as gs(slot)
@@ -7807,6 +7921,7 @@ grant select on pgque.partition_slot to pgque_admin;
 grant execute on function pgque.send(text, text, jsonb, text)  to pgque_writer;
 grant execute on function pgque.send(text, text, text, text)   to pgque_writer;
 
+grant execute on function pgque.subscribe_partitioned(text, text, int) to pgque_reader;
 grant execute on function pgque.subscribe_slot(text, text, int, int)   to pgque_reader;
 grant execute on function pgque.unsubscribe_slot(text, text, int)      to pgque_reader;
 grant execute on function pgque.claim_slot(text, text, int, text, interval)    to pgque_reader;

--- a/devel/sql/pgque.sql
+++ b/devel/sql/pgque.sql
@@ -7428,7 +7428,7 @@ begin
         for update;
 
         if v_n <> i_n then
-            raise exception 'consumer % on queue % is pinned to n=%; got n=% (unsubscribe all slots to change the slot count)',
+            raise exception 'consumer % on queue % is pinned to n=%; got n=% (tear down with pgque.unsubscribe_partitioned() to change the slot count)',
                 i_consumer, i_queue, v_n, i_n;
         end if;
 
@@ -7465,7 +7465,7 @@ begin
         v_registered := pgque.register_consumer_at(
             i_queue, v_slot_name, v_start_tick);
         if v_registered <> 1 then
-            raise exception 'consumer name % is already registered on queue %; cannot reuse it for partition slot %/%',
+            raise exception 'consumer name % is already registered on queue %; cannot reuse it for partition slot %/% (a legacy non-partitioned consumer with that name must be removed first with pgque.unsubscribe())',
                 v_slot_name, i_queue, v_slot, i_n;
         end if;
 
@@ -7523,7 +7523,7 @@ begin
     on conflict (queue_id, co_name) do update set n = pc.n
     returning pc.n into v_n;
     if v_n <> i_n then
-        raise exception 'consumer % on queue % is pinned to n=%; got n=% (unsubscribe all slots to change the slot count)',
+        raise exception 'consumer % on queue % is pinned to n=%; got n=% (tear down with pgque.unsubscribe_partitioned() to change the slot count)',
             i_consumer, i_queue, v_n, i_n;
     end if;
 
@@ -7568,16 +7568,22 @@ begin
             i_slot, i_consumer, i_queue, v_n - 1;
     end if;
 
-    /* Dropping one slot of a complete consumer is the documented repair /
-       controlled path, but it creates the incomplete-setup state that
-       subscribe_partitioned rejects -- never do it silently. */
+    /*
+     * Dropping one slot of a complete consumer is the documented repair /
+     * controlled path, but it creates the incomplete-setup state that
+     * subscribe_partitioned rejects -- never do it silently. Genuine slots
+     * are counted catalog-driven (partition_slot row AND subscription): a
+     * legacy consumer that merely shares the name shape does not count.
+     */
     select count(*) into v_subscribed
-    from pgque.subscription as s
-    join pgque.consumer as c on c.co_id = s.sub_consumer
-    where s.sub_queue = v_queue_id
-      and c.co_name in (
-          select pgque._slot_name(i_consumer, g, v_n)
-          from generate_series(0, v_n - 1) as g);
+    from pgque.partition_slot as ps
+    join pgque.consumer as c
+        on c.co_name = pgque._slot_name(i_consumer, ps.slot, v_n)
+    join pgque.subscription as s
+        on s.sub_queue = v_queue_id
+        and s.sub_consumer = c.co_id
+    where ps.queue_id = v_queue_id
+      and ps.co_name = i_consumer;
     if v_n > 1 and v_subscribed = v_n then
         raise warning 'dropping slot % leaves partitioned consumer % on queue % with incomplete setup; repair forward-only with pgque.subscribe_slot() or tear down with pgque.unsubscribe_partitioned()',
             i_slot, i_consumer, i_queue;
@@ -7590,13 +7596,17 @@ begin
       and co_name = i_consumer
       and slot = i_slot;
 
+    /* Same catalog-driven rule for last-slot cleanup: only genuine slots
+       keep the pinned-N row alive, never a name-shaped legacy consumer. */
     perform 1
-    from pgque.subscription as s
-    join pgque.consumer as c on c.co_id = s.sub_consumer
-    where s.sub_queue = v_queue_id
-      and c.co_name in (
-          select pgque._slot_name(i_consumer, g, v_n)
-          from generate_series(0, v_n - 1) as g);
+    from pgque.partition_slot as ps
+    join pgque.consumer as c
+        on c.co_name = pgque._slot_name(i_consumer, ps.slot, v_n)
+    join pgque.subscription as s
+        on s.sub_queue = v_queue_id
+        and s.sub_consumer = c.co_id
+    where ps.queue_id = v_queue_id
+      and ps.co_name = i_consumer;
     if not found then
         delete from pgque.partition_consumer
         where queue_id = v_queue_id
@@ -7611,8 +7621,11 @@ revoke execute on function pgque.unsubscribe_slot(text, text, int) from public;
  * every slot subscription and the pinned-N row in one transaction. Partial
  * setups (some slots already gone) tear down cleanly -- this is the recreate
  * path the incomplete-setup error points to -- and an absent consumer is a
- * no-op with a notice. NOTE: unregister_consumer cascades each slot's retry
- * rows and dead_letter audit (SPEC section 8, teardown).
+ * no-op with a notice. Only catalog-registered slots (partition_slot rows)
+ * are dropped: a legacy consumer that merely shares the name shape is left
+ * untouched (remove it with plain pgque.unsubscribe()). NOTE:
+ * unregister_consumer cascades each slot's retry rows and dead_letter audit
+ * (SPEC section 8, teardown).
  */
 create or replace function pgque.unsubscribe_partitioned(
     i_queue text, i_consumer text)
@@ -7634,8 +7647,14 @@ begin
         return;
     end if;
 
-    -- unregister_consumer returns 0 for an already-missing slot.
-    for v_slot in 0..v_n - 1 loop
+    -- unregister_consumer returns 0 for a slot whose subscription is gone.
+    for v_slot in
+        select ps.slot
+        from pgque.partition_slot as ps
+        where ps.queue_id = v_queue_id
+          and ps.co_name = i_consumer
+        order by ps.slot
+    loop
         perform pgque.unregister_consumer(
             i_queue, pgque._slot_name(i_consumer, v_slot, v_n));
     end loop;
@@ -7963,6 +7982,11 @@ revoke execute on function pgque.nack_partitioned(text, text, int, int, text, pg
  * Canonical alert: pending_events > X or not subscribed. A threshold-only
  * alert (where pending_events > X) skips the NULL-lag rows of unsubscribed
  * slots, so it never sees incomplete setup.
+ *
+ * Classification is catalog-driven, like the consume API: a slot counts as
+ * subscribed only when its partition_slot row AND its engine subscription
+ * both exist. A legacy ordinary consumer that merely shares the name shape
+ * ("C#k/N") is never attributed to the slot.
  */
 create or replace view pgque.partition_slot_status as
 select
@@ -7990,7 +8014,8 @@ left join pgque.partition_slot as ps
     and ps.co_name = pc.co_name
     and ps.slot = gs.slot
 left join pgque.consumer as c
-    on c.co_name = pgque._slot_name(pc.co_name, gs.slot, pc.n)
+    on ps.slot is not null
+    and c.co_name = pgque._slot_name(pc.co_name, gs.slot, pc.n)
 left join pgque.subscription as s
     on s.sub_queue = pc.queue_id
     and s.sub_consumer = c.co_id

--- a/devel/sql/pgque.sql
+++ b/devel/sql/pgque.sql
@@ -7165,7 +7165,34 @@ create table if not exists pgque.partition_consumer (
     primary key (queue_id, co_name)
 );
 
+/*
+ * Pre-flight guard for the constraint re-add below: a consumer created
+ * before the n cap existed would otherwise abort the install with a bare
+ * check-violation error. Name the row and the fix instead.
+ */
+create or replace function pgque._partition_n_cap_guard()
+returns void as $$
+declare
+    v_bad record;
+begin
+    select q.queue_name, pc.co_name, pc.n into v_bad
+    from pgque.partition_consumer as pc
+    join pgque.queue as q on q.queue_id = pc.queue_id
+    where pc.n not between 1 and 256
+    order by q.queue_name, pc.co_name
+    limit 1;
+    if found then
+        raise exception 'cannot apply the 256-slot cap: partitioned consumer % on queue % has n=%; recreate it with a smaller slot count (drop every slot via pgque.unsubscribe_slot(), then pgque.subscribe_partitioned() with n <= 256), then re-run the install',
+            v_bad.co_name, v_bad.queue_name, v_bad.n;
+    end if;
+end;
+$$ language plpgsql security definer set search_path = pgque, pg_catalog;
+
 /* Keep the constraint definition synchronized on idempotent installs. */
+do $$
+begin
+    perform pgque._partition_n_cap_guard();
+end $$;
 alter table pgque.partition_consumer
     drop constraint if exists partition_consumer_n_check;
 alter table pgque.partition_consumer
@@ -7941,6 +7968,7 @@ grant select on pgque.partition_slot_status to pgque_reader;
 grant select on pgque.partition_slot_status to pgque_admin;
 
 -- Internal helpers: SECURITY DEFINER callees only.
+revoke execute on function pgque._partition_n_cap_guard() from public, pgque_reader, pgque_writer;
 revoke execute on function pgque._slot_name(text, int, int) from public, pgque_reader, pgque_writer;
 revoke execute on function pgque._slot_guard(text, text, int, int, text) from public, pgque_reader, pgque_writer;
 revoke execute on function pgque._slot_batch(text, text, int, int) from public, pgque_reader, pgque_writer;

--- a/devel/sql/pgque.sql
+++ b/devel/sql/pgque.sql
@@ -7205,7 +7205,7 @@ alter table pgque.partition_consumer
  * takeover of an expired lease. Written only inside SECURITY DEFINER
  * functions (same pattern as partition_consumer); revoked from app roles.
  * One row per subscribed slot, created by subscribe_partitioned or repaired
- * individually by subscribe_slot.
+ * individually by subscribe_slot (forward-only: the missed window is lost).
  */
 create table if not exists pgque.partition_slot (
     queue_id    int4 not null,
@@ -7479,6 +7479,9 @@ revoke execute on function pgque.subscribe_partitioned(text, text, int) from pub
 /*
  * Alpha-compatible single-slot registration. Prefer subscribe_partitioned for
  * new consumers; use this only for explicit repair or controlled setup work.
+ * Repair closes the gap going forward only: the slot starts at the current
+ * tick, and events ticked while it was missing are permanently lost (recreate
+ * the consumer via unsubscribe_partitioned before producing to avoid that).
  */
 create or replace function pgque.subscribe_slot(
     i_queue text, i_consumer text, i_slot int, i_n int)
@@ -7651,15 +7654,19 @@ revoke execute on function pgque.unsubscribe_partitioned(text, text) from public
 
 /*
  * Claim (or renew) the lease on a slot for a worker id. Returns the epoch
- * fencing token, or null if the slot is currently leased by another live
- * worker (the caller's claim loop then moves to the next slot). The lease
- * lives in pgque.partition_slot -- plain transactional DML, no session state
- * -- so it survives transaction-mode pooling. Uses clock_timestamp() so a
- * pg_sleep inside a transaction correctly ages a short TTL.
+ * fencing token, or null when the slot is not claimable RIGHT NOW: leased by
+ * another live worker, or the row momentarily locked by another transaction
+ * (skip locked) -- including this worker's own in-flight receive/ack renewal.
+ * The claim loop moves to the next slot on null and must never infer loss of
+ * an existing lease from it. The lease lives in pgque.partition_slot -- plain
+ * transactional DML, no session state -- so it survives transaction-mode
+ * pooling. Uses clock_timestamp() so a pg_sleep inside a transaction
+ * correctly ages a short TTL.
  *
  *   owner re-claim  -- renew the window, epoch UNCHANGED.
  *   free / expired  -- takeover: epoch += 1, return the NEW (fencing) epoch.
  *   live, other own -- return null.
+ *   row busy        -- return null (never blocks, never waits).
  */
 create or replace function pgque.claim_slot(
     i_queue text, i_consumer text, i_slot int, i_worker text,
@@ -7952,6 +7959,10 @@ revoke execute on function pgque.nack_partitioned(text, text, int, int, text, pg
  *                     filtering (tick_event_seq delta). It over-counts a
  *                     single slot's own share by ~n x, but 0 means "caught
  *                     up" exactly, and growth means the slot is stalling.
+ *
+ * Canonical alert: pending_events > X or not subscribed. A threshold-only
+ * alert (where pending_events > X) skips the NULL-lag rows of unsubscribed
+ * slots, so it never sees incomplete setup.
  */
 create or replace view pgque.partition_slot_status as
 select

--- a/tests/acceptance/us12_partition_keys.sql
+++ b/tests/acceptance/us12_partition_keys.sql
@@ -451,24 +451,24 @@ begin
     where queue_name = 'us12_claim'
       and consumer = 'partial'
       and slot = 0
-  ), 'US-12.6: materialized alpha slot must report subscribed';
+  ), 'materialized alpha slot must report subscribed';
   assert (
     select not subscribed and last_tick is null and pending_events is null
     from pgque.partition_slot_status
     where queue_name = 'us12_claim'
       and consumer = 'partial'
       and slot = 1
-  ), 'US-12.6: missing alpha slot must report unknown lag';
+  ), 'missing alpha slot must report unknown lag';
 
   begin
     perform pgque.subscribe_partitioned('us12_claim', 'partial', 2);
   exception when others then
     v_raised := true;
     assert sqlerrm like '%incomplete%',
-      format('US-12.6: unexpected partial setup error: %s', sqlerrm);
+      format('unexpected partial setup error: %s', sqlerrm);
   end;
-  assert v_raised, 'US-12.6: atomic setup must reject partial existing state';
-  raise notice 'PASS: US-12.6 partition_slot_status flags incomplete setup';
+  assert v_raised, 'atomic setup must reject partial existing state';
+  raise notice 'PASS: partition_slot_status flags incomplete setup';
 end $$;
 
 -- Leased by worker acc-a: lease_owner == 'acc-a' for slot 0 only

--- a/tests/acceptance/us12_partition_keys.sql
+++ b/tests/acceptance/us12_partition_keys.sql
@@ -88,8 +88,7 @@ create temporary table _us12_order_recv (
 -- Setup: two slots on one consumer
 do $$ begin
   perform pgque.create_queue('us12_order');
-  perform pgque.subscribe_slot('us12_order', 'cw', 0, 2);
-  perform pgque.subscribe_slot('us12_order', 'cw', 1, 2);
+  perform pgque.subscribe_partitioned('us12_order', 'cw', 2);
 end $$;
 
 -- Action: interleave two keys A,B,A,B,A -> 3x tenant-A, 2x tenant-B
@@ -191,9 +190,7 @@ create temporary table _us12_par_recv (
 
 do $$ begin
   perform pgque.create_queue('us12_parallel');
-  perform pgque.subscribe_slot('us12_parallel', 'cw', 0, 3);
-  perform pgque.subscribe_slot('us12_parallel', 'cw', 1, 3);
-  perform pgque.subscribe_slot('us12_parallel', 'cw', 2, 3);
+  perform pgque.subscribe_partitioned('us12_parallel', 'cw', 3);
 end $$;
 
 -- Action: 6 keys x 2 events = 12 events spread across the key space
@@ -284,7 +281,7 @@ drop table if exists _us12_par_recv;
 
 do $$ begin
   perform pgque.create_queue('us12_batch');
-  perform pgque.subscribe_slot('us12_batch', 'cw', 0, 1);
+  perform pgque.subscribe_partitioned('us12_batch', 'cw', 1);
 end $$;
 
 do $$ begin
@@ -340,8 +337,7 @@ end $$;
 
 do $$ begin
   perform pgque.create_queue('us12_claim');
-  perform pgque.subscribe_slot('us12_claim', 'cw', 0, 2);
-  perform pgque.subscribe_slot('us12_claim', 'cw', 1, 2);
+  perform pgque.subscribe_partitioned('us12_claim', 'cw', 2);
 end $$;
 
 do $$
@@ -419,6 +415,7 @@ begin
   where queue_name = 'us12_claim'
     and consumer = 'cw'
     and n = 2
+    and subscribed
     and slot in (0, 1);
   assert v_rows = 2,
     format('US-12.6: expected 2 slot rows for (us12_claim, cw), got %s', v_rows);
@@ -440,6 +437,38 @@ begin
       and pending_events < 0
   ), 'US-12.6: pending_events (lag) must be non-negative';
   raise notice 'PASS: US-12.6 partition_slot_status unleased view';
+end $$;
+
+-- Alpha-compatible single-slot setup remains visible as incomplete.
+do $$
+declare
+  v_raised boolean := false;
+begin
+  perform pgque.subscribe_slot('us12_claim', 'partial', 0, 2);
+  assert (
+    select subscribed and pending_events is not null
+    from pgque.partition_slot_status
+    where queue_name = 'us12_claim'
+      and consumer = 'partial'
+      and slot = 0
+  ), 'US-12.6: materialized alpha slot must report subscribed';
+  assert (
+    select not subscribed and last_tick is null and pending_events is null
+    from pgque.partition_slot_status
+    where queue_name = 'us12_claim'
+      and consumer = 'partial'
+      and slot = 1
+  ), 'US-12.6: missing alpha slot must report unknown lag';
+
+  begin
+    perform pgque.subscribe_partitioned('us12_claim', 'partial', 2);
+  exception when others then
+    v_raised := true;
+    assert sqlerrm like '%incomplete%',
+      format('US-12.6: unexpected partial setup error: %s', sqlerrm);
+  end;
+  assert v_raised, 'US-12.6: atomic setup must reject partial existing state';
+  raise notice 'PASS: US-12.6 partition_slot_status flags incomplete setup';
 end $$;
 
 -- Leased by worker acc-a: lease_owner == 'acc-a' for slot 0 only
@@ -482,6 +511,7 @@ end $$;
 
 -- Cleanup us12_claim (shared by US-12.5 and US-12.6)
 do $$ begin
+  perform pgque.unsubscribe_slot('us12_claim', 'partial', 0);
   perform pgque.unsubscribe_slot('us12_claim', 'cw', 0);
   perform pgque.unsubscribe_slot('us12_claim', 'cw', 1);
   perform pgque.drop_queue('us12_claim');

--- a/tests/run_all.sql
+++ b/tests/run_all.sql
@@ -142,6 +142,9 @@
 \echo 'Running: test_partition_setup'
 \i tests/test_partition_setup.sql
 
+\echo 'Running: test_partition_slot_limit'
+\i tests/test_partition_slot_limit.sql
+
 \echo 'Running: test_partition_keys'
 \i tests/test_partition_keys.sql
 

--- a/tests/run_all.sql
+++ b/tests/run_all.sql
@@ -139,6 +139,9 @@
 \echo 'Running: test_uninstall_guard'
 \i tests/test_uninstall_guard.sql
 
+\echo 'Running: test_partition_setup'
+\i tests/test_partition_setup.sql
+
 \echo 'Running: test_partition_keys'
 \i tests/test_partition_keys.sql
 

--- a/tests/test_partition_keys.sql
+++ b/tests/test_partition_keys.sql
@@ -688,8 +688,9 @@ begin
   end;
   assert v_raised, 'guard: claim_slot with ttl < 1 second must raise';
 
-  -- Infinite leases cannot recover after a crashed worker (PG19+ syntax).
-  if current_setting('server_version_num')::int >= 190000 then
+  -- Infinite leases cannot recover after a crashed worker
+  -- ('infinity'::interval requires PG 17+).
+  if current_setting('server_version_num')::int >= 170000 then
     v_raised := false;
     begin
       execute $sql$

--- a/tests/test_partition_keys.sql
+++ b/tests/test_partition_keys.sql
@@ -108,7 +108,7 @@ begin
   perform 1
   from pgque.partition_slot_status
   where queue_name = 'pk_q' and consumer = 'w' and not subscribed;
-  assert not found, 'US-12.6: atomic setup must subscribe every slot';
+  assert not found, 'atomic setup must subscribe every slot';
 
   perform 1
   from pgque.partition_slot_status

--- a/tests/test_partition_keys.sql
+++ b/tests/test_partition_keys.sql
@@ -53,10 +53,9 @@ end $$;
 do $$
 begin
   perform pgque.create_queue('pk_q');
-  perform pgque.subscribe_slot('pk_q', 'w', 0, 2);
-  perform pgque.subscribe_slot('pk_q', 'w', 1, 2);
-  -- Idempotent re-subscribe with the same (slot, n) must not raise.
-  perform pgque.subscribe_slot('pk_q', 'w', 0, 2);
+  perform pgque.subscribe_partitioned('pk_q', 'w', 2);
+  -- Idempotent whole-consumer setup must not reposition slot cursors.
+  perform pgque.subscribe_partitioned('pk_q', 'w', 2);
 end $$;
 
 -- Pin the hash routing (T-G1a): concrete (key, expected slot) pairs.
@@ -105,6 +104,11 @@ begin
   from pgque.partition_slot_status
   where queue_name = 'pk_q' and consumer = 'w' and n <> 2;
   assert not found, 'US-12.6: all slot rows must show n = 2';
+
+  perform 1
+  from pgque.partition_slot_status
+  where queue_name = 'pk_q' and consumer = 'w' and not subscribed;
+  assert not found, 'US-12.6: atomic setup must subscribe every slot';
 
   perform 1
   from pgque.partition_slot_status

--- a/tests/test_partition_setup.sql
+++ b/tests/test_partition_setup.sql
@@ -1,0 +1,267 @@
+\set ON_ERROR_STOP on
+
+-- Regression coverage for atomic partitioned-consumer setup.
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+-- A partial alpha-style setup must be visible as incomplete, not caught up.
+do $$
+declare
+  v_key text;
+begin
+  perform pgque.create_queue('partition_setup_partial');
+  perform pgque.subscribe_slot('partition_setup_partial', 'workers', 0, 2);
+
+  select format('partial-key-%s', g) into v_key
+  from generate_series(1, 10000) as g
+  where (pg_catalog.hashtextextended(format('partial-key-%s', g), 0) % 2 + 2) % 2 = 1
+  limit 1;
+  assert v_key is not null, 'partial setup test needs a key for slot 1';
+  perform pgque.send('partition_setup_partial', 'partial.event', '{}'::jsonb, v_key);
+end $$;
+
+do $$
+begin
+  perform pgque.force_next_tick('partition_setup_partial');
+  perform pgque.ticker();
+end $$;
+
+do $$
+begin
+  assert (
+    select count(*) = 2
+    from pgque.partition_slot_status
+    where queue_name = 'partition_setup_partial'
+      and consumer = 'workers'
+  ), 'partial setup must expose every expected slot';
+  assert (
+    select subscribed and last_tick is not null and pending_events > 0
+    from pgque.partition_slot_status
+    where queue_name = 'partition_setup_partial'
+      and consumer = 'workers'
+      and slot = 0
+  ), 'the materialized slot must report subscribed with known lag';
+  assert (
+    select not subscribed and last_tick is null and pending_events is null
+    from pgque.partition_slot_status
+    where queue_name = 'partition_setup_partial'
+      and consumer = 'workers'
+      and slot = 1
+  ), 'the missing slot must report subscribed=false and unknown lag';
+end $$;
+
+-- Completing an already-late setup through the atomic API would imply safety.
+do $$
+declare
+  v_raised boolean := false;
+begin
+  begin
+    perform pgque.subscribe_partitioned('partition_setup_partial', 'workers', 2);
+  exception when others then
+    v_raised := true;
+    assert sqlerrm like '%incomplete%',
+      format('partial setup rejection must identify incomplete state, got: %s', sqlerrm);
+  end;
+  assert v_raised, 'atomic setup must reject a pre-existing partial consumer';
+  assert (
+    select not subscribed and pending_events is null
+    from pgque.partition_slot_status
+    where queue_name = 'partition_setup_partial'
+      and consumer = 'workers'
+      and slot = 1
+  ), 'rejected atomic setup must leave the missing slot unmistakably incomplete';
+
+  perform pgque.unsubscribe_slot('partition_setup_partial', 'workers', 0);
+  perform pgque.drop_queue('partition_setup_partial');
+  raise notice 'PASS: partial partition setup is explicit and rejected by atomic setup';
+end $$;
+
+-- Atomic setup creates every slot at one cursor before any later event exists.
+do $$
+begin
+  perform pgque.create_queue('partition_setup_atomic');
+end $$;
+
+set role pgque_reader;
+select pgque.subscribe_partitioned('partition_setup_atomic', 'workers', 3);
+reset role;
+
+do $$
+declare
+  v_key text;
+  v_raised boolean := false;
+  v_slot int;
+begin
+  assert (
+    select count(*) = 3 and bool_and(subscribed)
+    from pgque.partition_slot_status
+    where queue_name = 'partition_setup_atomic'
+      and consumer = 'workers'
+  ), 'atomic setup must materialize all slots and subscriptions';
+  assert (
+    select count(distinct s.sub_last_tick) = 1
+    from pgque.subscription as s
+    join pgque.queue as q on q.queue_id = s.sub_queue
+    join pgque.consumer as c on c.co_id = s.sub_consumer
+    where q.queue_name = 'partition_setup_atomic'
+      and c.co_name like 'workers#%/3'
+  ), 'atomic setup must start every slot from one shared tick';
+
+  begin
+    perform pgque.subscribe_partitioned(
+      'partition_setup_atomic', 'workers', 4);
+  exception when others then
+    v_raised := true;
+    assert sqlerrm like '%pinned to n=3%',
+      format('changed slot count got unexpected error: %s', sqlerrm);
+  end;
+  assert v_raised, 'atomic setup must reject a changed slot count';
+
+  for v_slot in 0..2 loop
+    select format('atomic-key-%s', g) into v_key
+    from generate_series(1, 10000) as g
+    where (pg_catalog.hashtextextended(format('atomic-key-%s', g), 0) % 3 + 3) % 3 = v_slot
+    limit 1;
+    assert v_key is not null, format('atomic setup test needs a key for slot %s', v_slot);
+    perform pgque.send('partition_setup_atomic', 'atomic.event', '{}'::jsonb, v_key);
+  end loop;
+end $$;
+
+do $$
+begin
+  perform pgque.force_next_tick('partition_setup_atomic');
+  perform pgque.ticker();
+end $$;
+
+/*
+ * Idempotent setup after events are visible must not reposition the existing
+ * subscriptions to the latest tick and skip those events.
+ */
+select pgque.subscribe_partitioned('partition_setup_atomic', 'workers', 3);
+
+create temporary table partition_setup_received (
+  slot int not null,
+  msg_id bigint not null,
+  partition_key text not null
+);
+
+do $$
+declare
+  v_msg pgque.message;
+  v_slot int;
+begin
+  for v_slot in 0..2 loop
+    assert pgque.claim_slot(
+      'partition_setup_atomic', 'workers', v_slot, 'setup-worker') is not null,
+      format('atomic setup slot %s must be claimable', v_slot);
+    for v_msg in
+      select *
+      from pgque.receive_partitioned(
+        'partition_setup_atomic', 'workers', v_slot, 3, 'setup-worker', 100)
+    loop
+      insert into partition_setup_received (slot, msg_id, partition_key)
+      values (v_slot, v_msg.msg_id, v_msg.extra1);
+    end loop;
+    assert pgque.ack_partitioned(
+      'partition_setup_atomic', 'workers', v_slot, 3, 'setup-worker') = 1,
+      format('atomic setup slot %s batch must be finishable', v_slot);
+    perform pgque.release_slot(
+      'partition_setup_atomic', 'workers', v_slot, 'setup-worker');
+  end loop;
+end $$;
+
+do $$
+declare
+  v_slot int;
+begin
+  assert (
+    select count(*) = 3 and count(distinct slot) = 3
+    from partition_setup_received
+  ), 'events produced after atomic setup must remain reachable on every slot';
+  for v_slot in 0..2 loop
+    assert not exists (
+      select 1
+      from partition_setup_received
+      where slot <> v_slot
+        and (pg_catalog.hashtextextended(partition_key, 0) % 3 + 3) % 3 = v_slot
+    ), format('slot %s events must not be delivered by another slot', v_slot);
+    perform pgque.unsubscribe_slot('partition_setup_atomic', 'workers', v_slot);
+  end loop;
+  perform pgque.drop_queue('partition_setup_atomic');
+  raise notice 'PASS: atomic setup preserves all post-setup slot histories';
+end $$;
+
+-- A failure after one generated slot is created must roll back the whole setup.
+do $$
+begin
+  perform pgque.create_queue('partition_setup_rollback');
+  perform pgque.register_consumer(
+    'partition_setup_rollback', 'workers#1/3');
+  perform pgque.send(
+    'partition_setup_rollback', 'collision.event', '{}'::jsonb, 'collision');
+end $$;
+
+do $$
+begin
+  perform pgque.force_next_tick('partition_setup_rollback');
+  perform pgque.ticker();
+end $$;
+
+do $$
+declare
+  v_before bigint;
+  v_after bigint;
+  v_raised boolean := false;
+begin
+  select s.sub_last_tick into v_before
+  from pgque.subscription as s
+  join pgque.queue as q on q.queue_id = s.sub_queue
+  join pgque.consumer as c on c.co_id = s.sub_consumer
+  where q.queue_name = 'partition_setup_rollback'
+    and c.co_name = 'workers#1/3';
+
+  begin
+    perform pgque.subscribe_partitioned(
+      'partition_setup_rollback', 'workers', 3);
+  exception when others then
+    v_raised := true;
+    assert sqlerrm like '%already registered%',
+      format('atomic rollback test got unexpected error: %s', sqlerrm);
+  end;
+  assert v_raised, 'a generated-name collision must abort atomic setup';
+  assert not exists (
+    select 1
+    from pgque.partition_consumer as pc
+    join pgque.queue as q on q.queue_id = pc.queue_id
+    where q.queue_name = 'partition_setup_rollback'
+      and pc.co_name = 'workers'
+  ), 'failed atomic setup must roll back partition_consumer';
+  assert not exists (
+    select 1
+    from pgque.partition_slot as ps
+    join pgque.queue as q on q.queue_id = ps.queue_id
+    where q.queue_name = 'partition_setup_rollback'
+      and ps.co_name = 'workers'
+  ), 'failed atomic setup must roll back every lease row';
+  assert not exists (
+    select 1
+    from pgque.subscription as s
+    join pgque.queue as q on q.queue_id = s.sub_queue
+    join pgque.consumer as c on c.co_id = s.sub_consumer
+    where q.queue_name = 'partition_setup_rollback'
+      and c.co_name in ('workers#0/3', 'workers#2/3')
+  ), 'failed atomic setup must roll back generated subscriptions';
+
+  select s.sub_last_tick into v_after
+  from pgque.subscription as s
+  join pgque.queue as q on q.queue_id = s.sub_queue
+  join pgque.consumer as c on c.co_id = s.sub_consumer
+  where q.queue_name = 'partition_setup_rollback'
+    and c.co_name = 'workers#1/3';
+  assert v_after = v_before,
+    'failed atomic setup must not reposition the colliding subscription';
+
+  perform pgque.unregister_consumer(
+    'partition_setup_rollback', 'workers#1/3');
+  perform pgque.drop_queue('partition_setup_rollback');
+  raise notice 'PASS: failed atomic setup rolls back all partial state';
+end $$;

--- a/tests/test_partition_setup.sql
+++ b/tests/test_partition_setup.sql
@@ -184,8 +184,8 @@ begin
       where slot <> v_slot
         and (pg_catalog.hashtextextended(partition_key, 0) % 3 + 3) % 3 = v_slot
     ), format('slot %s events must not be delivered by another slot', v_slot);
-    perform pgque.unsubscribe_slot('partition_setup_atomic', 'workers', v_slot);
   end loop;
+  perform pgque.unsubscribe_partitioned('partition_setup_atomic', 'workers');
   perform pgque.drop_queue('partition_setup_atomic');
   raise notice 'PASS: atomic setup preserves all post-setup slot histories';
 end $$;
@@ -264,4 +264,87 @@ begin
     'partition_setup_rollback', 'workers#1/3');
   perform pgque.drop_queue('partition_setup_rollback');
   raise notice 'PASS: failed atomic setup rolls back all partial state';
+end $$;
+
+/*
+ * Whole-consumer teardown: unsubscribe_partitioned is the inverse of
+ * subscribe_partitioned. A complete consumer tears down atomically, and a
+ * fresh setup with a different slot count works afterward.
+ */
+do $$
+begin
+  perform pgque.create_queue('partition_teardown');
+  perform pgque.subscribe_partitioned('partition_teardown', 'workers', 3);
+end $$;
+
+set role pgque_reader;
+select pgque.unsubscribe_partitioned('partition_teardown', 'workers');
+reset role;
+
+do $$
+begin
+  assert not exists (
+    select 1
+    from pgque.partition_consumer as pc
+    join pgque.queue as q on q.queue_id = pc.queue_id
+    where q.queue_name = 'partition_teardown'
+      and pc.co_name = 'workers'
+  ), 'teardown must remove the pinned-N row';
+  assert not exists (
+    select 1
+    from pgque.subscription as s
+    join pgque.queue as q on q.queue_id = s.sub_queue
+    join pgque.consumer as c on c.co_id = s.sub_consumer
+    where q.queue_name = 'partition_teardown'
+      and c.co_name like 'workers#%/3'
+  ), 'teardown must remove every slot subscription';
+  assert not exists (
+    select 1
+    from pgque.partition_slot as ps
+    join pgque.queue as q on q.queue_id = ps.queue_id
+    where q.queue_name = 'partition_teardown'
+      and ps.co_name = 'workers'
+  ), 'teardown must remove every lease row';
+
+  perform pgque.subscribe_partitioned('partition_teardown', 'workers', 2);
+  assert (
+    select count(*) = 2 and bool_and(subscribed)
+    from pgque.partition_slot_status
+    where queue_name = 'partition_teardown'
+      and consumer = 'workers'
+  ), 'teardown must allow a fresh setup with a new slot count';
+end $$;
+
+/*
+ * Partial state (a slot already missing) must still tear down cleanly:
+ * teardown is the escape hatch the incomplete-setup error points to. An
+ * absent consumer is a no-op, never an error.
+ */
+do $$
+begin
+  -- Warns: this leaves the complete consumer with incomplete setup.
+  perform pgque.unsubscribe_slot('partition_teardown', 'workers', 1);
+  perform pgque.unsubscribe_partitioned('partition_teardown', 'workers');
+  assert not exists (
+    select 1
+    from pgque.partition_consumer as pc
+    join pgque.queue as q on q.queue_id = pc.queue_id
+    where q.queue_name = 'partition_teardown'
+      and pc.co_name = 'workers'
+  ), 'partial teardown must remove the pinned-N row';
+  assert not exists (
+    select 1
+    from pgque.subscription as s
+    join pgque.queue as q on q.queue_id = s.sub_queue
+    join pgque.consumer as c on c.co_id = s.sub_consumer
+    where q.queue_name = 'partition_teardown'
+      and c.co_name like 'workers#%/2'
+  ), 'partial teardown must remove the surviving slot subscriptions';
+
+  -- Absent consumer (just torn down, and one that never existed): no-op.
+  perform pgque.unsubscribe_partitioned('partition_teardown', 'workers');
+  perform pgque.unsubscribe_partitioned('partition_teardown', 'no_such');
+
+  perform pgque.drop_queue('partition_teardown');
+  raise notice 'PASS: whole-consumer teardown is atomic, partial-safe, idempotent';
 end $$;

--- a/tests/test_partition_setup.sql
+++ b/tests/test_partition_setup.sql
@@ -348,3 +348,106 @@ begin
   perform pgque.drop_queue('partition_teardown');
   raise notice 'PASS: whole-consumer teardown is atomic, partial-safe, idempotent';
 end $$;
+
+/*
+ * Legacy name-shaped consumers: an ordinary engine consumer literally named
+ * 'workers#0/2' (creatable on older installs) must never be classified as a
+ * partition slot. Classification is catalog-driven -- partition_consumer AND
+ * the exact partition_slot row -- the same way the consume API classifies,
+ * never by name shape alone.
+ */
+do $$
+begin
+  perform pgque.create_queue('partition_legacy');
+  -- The legacy ordinary consumer, name-shaped like slot 0 of workers/2.
+  perform pgque.register_consumer('partition_legacy', 'workers#0/2');
+  -- A genuine repair-path slot pins n=2 alongside it.
+  perform pgque.subscribe_slot('partition_legacy', 'workers', 1, 2);
+end $$;
+
+do $$
+declare
+  v_raised boolean := false;
+begin
+  assert (
+    select not subscribed and last_tick is null and pending_events is null
+    from pgque.partition_slot_status
+    where queue_name = 'partition_legacy'
+      and consumer = 'workers'
+      and slot = 0
+  ), 'a legacy name-shaped consumer must not report as a subscribed slot';
+  assert (
+    select subscribed
+    from pgque.partition_slot_status
+    where queue_name = 'partition_legacy'
+      and consumer = 'workers'
+      and slot = 1
+  ), 'the genuine slot must stay subscribed';
+
+  -- The view and the API must give the same answer: incomplete (1 of 2).
+  begin
+    perform pgque.subscribe_partitioned('partition_legacy', 'workers', 2);
+  exception when others then
+    v_raised := true;
+    assert sqlerrm like '%incomplete%'
+      and sqlerrm like '%1 of 2%',
+      format('legacy state must read as incomplete, got: %s', sqlerrm);
+  end;
+  assert v_raised, 'the view and the API must agree the setup is incomplete';
+end $$;
+
+/*
+ * Teardown must drop only catalog-registered slots: the legacy consumer (and
+ * its cursor history) survives and is removed with plain pgque.unsubscribe().
+ */
+do $$
+begin
+  perform pgque.unsubscribe_partitioned('partition_legacy', 'workers');
+  assert not exists (
+    select 1
+    from pgque.partition_consumer as pc
+    join pgque.queue as q on q.queue_id = pc.queue_id
+    where q.queue_name = 'partition_legacy'
+      and pc.co_name = 'workers'
+  ), 'teardown must remove the pinned-N row despite the legacy consumer';
+  assert exists (
+    select 1
+    from pgque.subscription as s
+    join pgque.queue as q on q.queue_id = s.sub_queue
+    join pgque.consumer as c on c.co_id = s.sub_consumer
+    where q.queue_name = 'partition_legacy'
+      and c.co_name = 'workers#0/2'
+  ), 'teardown must not destroy a legacy consumer that shares the name shape';
+end $$;
+
+/*
+ * Same catalog-driven rule for last-slot cleanup in unsubscribe_slot: after
+ * the only genuine slot is dropped, a legacy name-shaped subscription must
+ * not keep the pinned-N row alive (that state gave only circular advice).
+ */
+do $$
+begin
+  perform pgque.subscribe_slot('partition_legacy', 'workers', 1, 2);
+  perform pgque.unsubscribe_slot('partition_legacy', 'workers', 1);
+  assert not exists (
+    select 1
+    from pgque.partition_consumer as pc
+    join pgque.queue as q on q.queue_id = pc.queue_id
+    where q.queue_name = 'partition_legacy'
+      and pc.co_name = 'workers'
+  ), 'a legacy name-shaped subscription must not keep the pinned-N row alive';
+
+  -- Removing the legacy consumer clears the way for atomic setup.
+  perform pgque.unsubscribe('partition_legacy', 'workers#0/2');
+  perform pgque.subscribe_partitioned('partition_legacy', 'workers', 2);
+  assert (
+    select count(*) = 2 and bool_and(subscribed)
+    from pgque.partition_slot_status
+    where queue_name = 'partition_legacy'
+      and consumer = 'workers'
+  ), 'plain unsubscribe of the legacy consumer must unblock atomic setup';
+
+  perform pgque.unsubscribe_partitioned('partition_legacy', 'workers');
+  perform pgque.drop_queue('partition_legacy');
+  raise notice 'PASS: legacy name-shaped consumers are never classified as slots';
+end $$;

--- a/tests/test_partition_slot_limit.sql
+++ b/tests/test_partition_slot_limit.sql
@@ -1,0 +1,93 @@
+\set ON_ERROR_STOP on
+
+-- Bound partition setup and status expansion at the supported slot ceiling.
+-- Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+do $$
+begin
+  perform pgque.create_queue('partition_limit_boundary');
+  perform pgque.subscribe_partitioned(
+    'partition_limit_boundary', 'workers', 256);
+
+  assert (
+    select count(*) = 256 and bool_and(subscribed)
+    from pgque.partition_slot_status
+    where queue_name = 'partition_limit_boundary'
+      and consumer = 'workers'
+  ), 'the maximum supported slot count must materialize completely';
+
+  perform pgque.drop_queue('partition_limit_boundary', true);
+end $$;
+
+do $$
+declare
+  v_raised boolean := false;
+begin
+  perform pgque.create_queue('partition_limit_atomic_reject');
+
+  begin
+    perform pgque.subscribe_partitioned(
+      'partition_limit_atomic_reject', 'workers', 257);
+    raise exception 'expected subscribe_partitioned slot-limit rejection';
+  exception
+    when others then
+      if sqlerrm = 'expected subscribe_partitioned slot-limit rejection' then
+        raise;
+      end if;
+      v_raised := true;
+      assert sqlstate = 'P0001'
+        and sqlerrm = 'slot count n must be between 1 and 256, got 257',
+        format('unexpected subscribe_partitioned error [%s] %s',
+          sqlstate, sqlerrm);
+  end;
+
+  assert v_raised, 'subscribe_partitioned must reject max+1';
+  assert not exists (
+    select 1
+    from pgque.partition_consumer as pc
+    join pgque.queue as q on q.queue_id = pc.queue_id
+    where q.queue_name = 'partition_limit_atomic_reject'
+      and pc.co_name = 'workers'
+  ), 'rejected atomic setup must not leave partition metadata';
+  assert not exists (
+    select 1
+    from pgque.consumer
+    where co_name like 'workers#%/257'
+  ), 'rejected atomic setup must not leave generated consumers';
+
+  perform pgque.drop_queue('partition_limit_atomic_reject', true);
+end $$;
+
+do $$
+declare
+  v_raised boolean := false;
+begin
+  perform pgque.create_queue('partition_limit_repair_reject');
+
+  begin
+    perform pgque.subscribe_slot(
+      'partition_limit_repair_reject', 'workers', 0, 257);
+    raise exception 'expected subscribe_slot slot-limit rejection';
+  exception
+    when others then
+      if sqlerrm = 'expected subscribe_slot slot-limit rejection' then
+        raise;
+      end if;
+      v_raised := true;
+      assert sqlstate = 'P0001'
+        and sqlerrm = 'slot count n must be between 1 and 256, got 257',
+        format('unexpected subscribe_slot error [%s] %s', sqlstate, sqlerrm);
+  end;
+
+  assert v_raised, 'subscribe_slot must reject max+1';
+  assert not exists (
+    select 1
+    from pgque.partition_consumer as pc
+    join pgque.queue as q on q.queue_id = pc.queue_id
+    where q.queue_name = 'partition_limit_repair_reject'
+      and pc.co_name = 'workers'
+  ), 'rejected repair setup must not leave partition metadata';
+
+  perform pgque.drop_queue('partition_limit_repair_reject', true);
+  raise notice 'PASS: partition slot count ceiling';
+end $$;

--- a/tests/test_partition_slot_limit.sql
+++ b/tests/test_partition_slot_limit.sql
@@ -58,6 +58,53 @@ begin
   perform pgque.drop_queue('partition_limit_atomic_reject', true);
 end $$;
 
+/*
+ * Idempotent re-install must not abort with a bare check violation on rows
+ * created before the n cap existed: the install's pre-flight guard has to
+ * name the offending consumer and tell the operator how to fix it.
+ */
+do $$
+declare
+  v_raised boolean := false;
+begin
+  perform pgque.create_queue('partition_limit_precap');
+  alter table pgque.partition_consumer
+    drop constraint partition_consumer_n_check;
+  insert into pgque.partition_consumer (queue_id, co_name, n)
+  select queue_id, 'precap_workers', 300
+  from pgque.queue
+  where queue_name = 'partition_limit_precap';
+
+  begin
+    perform pgque._partition_n_cap_guard();
+  exception
+    when others then
+      v_raised := true;
+      assert sqlstate = 'P0001'
+        and sqlerrm like '%precap_workers%'
+        and sqlerrm like '%partition_limit_precap%'
+        and sqlerrm like '%n=300%'
+        and sqlerrm like '%256%'
+        and sqlerrm like '%recreate%',
+        format('n-cap guard error must be actionable, got [%s] %s',
+          sqlstate, sqlerrm);
+  end;
+  assert v_raised, 'n-cap guard must reject a pre-cap row';
+
+  delete from pgque.partition_consumer as pc
+  using pgque.queue as q
+  where pc.queue_id = q.queue_id
+    and q.queue_name = 'partition_limit_precap';
+  alter table pgque.partition_consumer
+    add constraint partition_consumer_n_check check (n between 1 and 256);
+
+  -- Clean data passes the guard silently.
+  perform pgque._partition_n_cap_guard();
+
+  perform pgque.drop_queue('partition_limit_precap', true);
+  raise notice 'PASS: pre-cap n rows are caught by the install guard';
+end $$;
+
 do $$
 declare
   v_raised boolean := false;

--- a/tests/two_session_slot_claim.sh
+++ b/tests/two_session_slot_claim.sh
@@ -54,8 +54,7 @@ cleanup() {
   local exit_code=$?
 
   "${psql_base[@]}" --quiet --no-align --tuples-only --command="
-    select pgque.unsubscribe_slot('${queue_name}', 'w', 0);
-    select pgque.unsubscribe_slot('${queue_name}', 'w', 1);
+    select pgque.unsubscribe_partitioned('${queue_name}', 'w');
     select pgque.drop_queue('${queue_name}', true);
   " >/dev/null 2>&1 || true
   rm -rf -- "${workdir}" || true
@@ -272,4 +271,32 @@ if (( session3_status != 0 )); then
   exit 1
 fi
 
-echo "PASS: lease is exclusive across backends (outlives a dead one for its TTL); dead worker's slot recovered after TTL expiry; epoch bumped on takeover (fencing)"
+# --- partial unsubscribe must be non-silent --------------------------------
+# Dropping one slot of a COMPLETE consumer creates exactly the incomplete
+# setup subscribe_partitioned rejects; it must succeed but WARN.
+set +e
+unsub_warn=$("${psql_base[@]}" --quiet --no-align --tuples-only \
+  --command="select pgque.unsubscribe_slot('${queue_name}', 'w', 0)" \
+  2>&1 >/dev/null)
+unsub_status=$?
+set -e
+if (( unsub_status != 0 )); then
+  echo "FAIL: unsubscribe_slot on a complete consumer must succeed" >&2
+  echo "${unsub_warn}" >&2
+  exit 1
+fi
+if ! grep -q "WARNING.*incomplete" <<<"${unsub_warn}"; then
+  echo "FAIL: partial unsubscribe of a complete consumer must warn about incomplete setup" >&2
+  echo "captured stderr: ${unsub_warn}" >&2
+  exit 1
+fi
+
+# Whole-consumer teardown succeeds on the now-partial consumer.
+"${psql_base[@]}" --quiet --no-align --tuples-only \
+  --command="select pgque.unsubscribe_partitioned('${queue_name}', 'w')" \
+  >/dev/null || {
+  echo "FAIL: unsubscribe_partitioned must tear down a partial consumer" >&2
+  exit 1
+}
+
+echo "PASS: lease is exclusive across backends (outlives a dead one for its TTL); dead worker's slot recovered after TTL expiry; epoch bumped on takeover (fencing); partial unsubscribe warns; whole-consumer teardown works on partial state"

--- a/tests/two_session_slot_claim.sh
+++ b/tests/two_session_slot_claim.sh
@@ -4,6 +4,7 @@
 # Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 # Includes code derived from PgQ (ISC license, Marko Kreen / Skype Technologies OU).
 set -Eeuo pipefail
+IFS=$'\n\t'
 
 # Usage:
 #   PGQUE_TEST_DSN=postgresql://postgres:***@localhost/pgque_test \
@@ -39,21 +40,37 @@ if [[ -z "${PGQUE_TEST_DSN:-}" ]]; then
   exit 2
 fi
 
-psql_base=(psql --no-psqlrc -v ON_ERROR_STOP=1 "${PGQUE_TEST_DSN}")
+export PAGER=cat
+psql_base=(psql --no-psqlrc --set=ON_ERROR_STOP=1 "${PGQUE_TEST_DSN}")
 queue_name="two_session_slot_claim_${$}_$(date +%s)"
 s1_ttl="3 seconds"
 workdir="$(mktemp -d)"
+
+# Remove database and filesystem fixtures while preserving the script status.
+# Globals: psql_base, queue_name, workdir
+# Args: none
+# Returns: the status that triggered the EXIT trap
 cleanup() {
-  "${psql_base[@]}" -qAtc "
+  local exit_code=$?
+
+  "${psql_base[@]}" --quiet --no-align --tuples-only --command="
     select pgque.unsubscribe_slot('${queue_name}', 'w', 0);
     select pgque.unsubscribe_slot('${queue_name}', 'w', 1);
     select pgque.drop_queue('${queue_name}', true);
   " >/dev/null 2>&1 || true
-  rm -rf "${workdir}"
+  rm -rf -- "${workdir}" || true
+  exit "${exit_code}"
 }
 trap cleanup EXIT
 
+# Print captured session output after a harness failure.
+# Globals: workdir
+# Args: none
+# Outputs: captured files to STDERR
+# Returns: zero
 print_debug() {
+  local f
+
   for f in setup.out lock_holder.out lock_holder.err contender.out \
            contender.err session1.out session1.err session2.out session2.err \
            session3.out session3.err; do
@@ -69,7 +86,7 @@ select pgque.subscribe_slot('${queue_name}', 'w', 0, 2);
 select pgque.subscribe_slot('${queue_name}', 'w', 1, 2);
 SQL
 
-"${psql_base[@]}" -f "${workdir}/setup.sql" \
+"${psql_base[@]}" --file="${workdir}/setup.sql" \
   >"${workdir}/setup.out" 2>&1 || {
   echo "FAIL: setup failed" >&2
   print_debug
@@ -85,13 +102,13 @@ select pg_sleep(10);
 rollback;
 SQL
 
-PGAPPNAME="${lock_app}" "${psql_base[@]}" -f "${workdir}/lock_holder.sql" \
+PGAPPNAME="${lock_app}" "${psql_base[@]}" --file="${workdir}/lock_holder.sql" \
   >"${workdir}/lock_holder.out" 2>"${workdir}/lock_holder.err" &
 lock_holder_pid=$!
 
 lock_ready=0
 for _ in $(seq 1 50); do
-  if "${psql_base[@]}" -qAtc "
+  if "${psql_base[@]}" --quiet --no-align --tuples-only --command="
     select 1
     from pg_stat_activity
     where application_name = '${lock_app}'
@@ -114,12 +131,13 @@ if (( lock_ready != 1 )); then
 fi
 
 set +e
-PGOPTIONS='-c statement_timeout=750ms' "${psql_base[@]}" -qAtc \
+PGOPTIONS='-c statement_timeout=750ms' "${psql_base[@]}" \
+  --quiet --no-align --tuples-only --command \
   "select coalesce(pgque.claim_slot('${queue_name}', 'w', 0, 'contender')::text, 'NULL')" \
   >"${workdir}/contender.out" 2>"${workdir}/contender.err"
 contender_status=$?
 set -e
-"${psql_base[@]}" -qAtc "
+"${psql_base[@]}" --quiet --no-align --tuples-only --command="
   select pg_terminate_backend(pid)
   from pg_stat_activity
   where application_name = '${lock_app}'
@@ -132,7 +150,7 @@ wait "${lock_holder_pid}" >/dev/null 2>&1 || true
 # crash-recovery scenario below starts from a genuinely free slot.
 holder_gone=0
 for _ in $(seq 1 50); do
-  if [[ "$("${psql_base[@]}" -qAtc "
+  if [[ "$("${psql_base[@]}" --quiet --no-align --tuples-only --command="
     select count(*)
     from pg_stat_activity
     where application_name = '${lock_app}'
@@ -164,7 +182,7 @@ echo "non-blocking claim: contender returned NULL behind an uncommitted slot row
 # No release_slot call: the backend dies with the lease still held. The lease
 # is committed transactional state, so it survives the backend's exit.
 s1_epoch="$(
-  "${psql_base[@]}" -qAtc \
+  "${psql_base[@]}" --quiet --no-align --tuples-only --command \
     "select pgque.claim_slot('${queue_name}', 'w', 0, 'w1', interval '${s1_ttl}')"
 )"
 if [[ -z "${s1_epoch}" || ! "${s1_epoch}" =~ ^[0-9]+$ ]]; then
@@ -208,7 +226,7 @@ select 's2_checks=ok';
 SQL
 
 set +e
-"${psql_base[@]}" -f "${workdir}/session2.sql" \
+"${psql_base[@]}" --file="${workdir}/session2.sql" \
   >"${workdir}/session2.out" 2>"${workdir}/session2.err"
 session2_status=$?
 set -e
@@ -244,7 +262,7 @@ select 's3_reclaim=ok';
 SQL
 
 set +e
-"${psql_base[@]}" -f "${workdir}/session3.sql" \
+"${psql_base[@]}" --file="${workdir}/session3.sql" \
   >"${workdir}/session3.out" 2>"${workdir}/session3.err"
 session3_status=$?
 set -e


### PR DESCRIPTION
## Summary

- add `subscribe_partitioned(queue, consumer, n)` as the atomic whole-consumer setup path
- create every slot subscription at one shared tick in one transaction
- reject pre-existing partial setup instead of implying lost history can be recovered
- expose `partition_slot_status.subscribed` and report unknown lag as `NULL`
- retain and document `subscribe_slot` only as an explicit repair path — now explicitly forward-only (the missed window is permanently lost) in the error hint, comments, SPEC, and README

Review follow-ups folded in (from the design+empirical review):

- **n-cap upgrade guard (finding 1):** `pgque._partition_n_cap_guard()` runs before the idempotent constraint re-add; a pre-cap consumer with `n > 256` now aborts the install with an actionable error naming the queue/consumer/n and the recreate path, instead of a bare check violation
- **whole-consumer teardown (finding 3):** `pgque.unsubscribe_partitioned(queue, consumer)` — one transaction drops every slot subscription and the pinned-N row; succeeds on partial setups (the escape hatch the incomplete-setup error points to); absent consumer is a notice-level no-op; granted to `pgque_reader`. `unsubscribe_slot` on a complete consumer now emits a WARNING that it creates incomplete setup
- **canonical alert (finding 2):** documented as `pending_events > X or not subscribed` in the view header, SPEC (R7 / §15 / US-12.6), and `devel/sql/README.md` — a threshold-only alert skips the `NULL`-lag rows and never sees incomplete setup
- **repair ≠ recovery wording (finding 4):** see `subscribe_slot` bullet above
- **SPEC contract sync for the base PRs:** `release_slot` raises on an open owner batch (ack first); `claim_slot` NULL means "not claimable right now" (busy or foreign-owned — including the same worker's in-flight receive/ack renewal; never infer lease loss from NULL); claim TTL must be finite (`'infinity'` rejected)
- **test gate fix:** the infinite-TTL guard test now runs on PG 17+ (`'infinity'::interval` is PG 17+ syntax, not PG 19+), so the 17/18 CI lanes exercise it
- **catalog-driven slot classification (from the PR #322 adversarial review):** a legacy ordinary consumer literally named like a slot (`workers#0/2`, creatable on older installs) is never classified as a partition slot by name shape. `partition_slot_status` now reports `subscribed` only when both the `partition_slot` row and the engine subscription exist (no more contradictory view-vs-API signals); `unsubscribe_slot`'s completeness warning and last-slot cleanup use the same rule, so a legacy subscription cannot keep the pinned-N row alive; `unsubscribe_partitioned` drops only catalog-registered slots and leaves a legacy same-named consumer (and its cursor history) intact. Pinned-n hints now point at `unsubscribe_partitioned`; the slot-name collision error names plain `pgque.unsubscribe()` as the legacy-removal path. (The `subscribe_slot`-side collision error lives on the #322 branch, not here.)

Fixes #307.

## Stack

- base: #321 (`agent/fix-claim-slot-nonblocking`)
- #321 is stacked on #311

## Validation

- focused atomic setup regression: PostgreSQL 14, 17, and 19beta1
- old partial-state upgrade/status check passed
- pre-cap (`n=300`) re-install simulation: guard raises the actionable error; `--single-transaction` re-install rolls back cleanly (PG 18.3)
- teardown regression (complete / partial / absent / re-setup with a new n) in `tests/test_partition_setup.sql` passed
- partial-unsubscribe WARNING emission + teardown-of-partial asserted in `tests/two_session_slot_claim.sh`
- infinite-TTL guard exercised on PG 18.3 under the lowered gate
- existing partition-key suite passed
- US-12 acceptance passed
- full regression suite passed (`tests/run_all.sql`)
- full acceptance suite passed (`tests/acceptance/run_acceptance.sql`)
- stacked two-session nonblocking/TTL/fencing harness passed
- deterministic generator/assembly (`build/transform.sh`) and `git diff --check` passed
- legacy name-shaped consumer regression (view classification, teardown survival, last-slot cleanup, plain-unsubscribe unblock) in `tests/test_partition_setup.sql` passed
- idempotent re-install of the regenerated `devel/sql/pgque.sql` on a populated database passed
