### PR TITLE
fix(ci): fail closed on Postgres readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,17 +21,14 @@ jobs:
 
       - name: Start PostgreSQL ${{ matrix.pg_version }}
         run: |
+          set -Eeuo pipefail
           docker run -d --name pgque-test \
             -e POSTGRES_PASSWORD=pgque_test \
             -e POSTGRES_DB=pgque_test \
             -p 5432:5432 \
             postgres:${{ matrix.pg_version }}
 
-          # Wait for PG to be ready
-          for i in $(seq 1 30); do
-            docker exec pgque-test pg_isready -U postgres && break
-            sleep 1
-          done || { echo "PG not ready after 30 seconds"; exit 1; }
+          bash ci/wait-for-postgres.sh pgque-test
 
       - name: Build pgque
         run: bash build/transform.sh
@@ -110,10 +107,7 @@ jobs:
             -p 5432:5432 \
             postgres:19beta1
 
-          for _ in $(seq 1 30); do
-            docker exec pgque-stable-smoke pg_isready -U postgres && break
-            sleep 1
-          done || { echo "PG not ready after 30 seconds"; exit 1; }
+          bash ci/wait-for-postgres.sh pgque-stable-smoke
 
       - name: Install frozen stable pgque
         run: |
@@ -459,7 +453,7 @@ jobs:
           docker run -d --name "${PG_CONTAINER}" --network "${PGTT_NET}" \
             -e POSTGRES_PASSWORD=pgque_test \
             -e POSTGRES_DB=pgque_test \
-            postgres:${PG_VERSION}
+            "postgres:${PG_VERSION}"
 
           ready=0
           for _ in $(seq 1 60); do
@@ -533,12 +527,9 @@ jobs:
             -e POSTGRES_PASSWORD=pgque_test \
             -e POSTGRES_DB=pgque_test \
             -p 5432:5432 \
-            postgres:${PG_VERSION}
+            "postgres:${PG_VERSION}"
 
-          for i in $(seq 1 30); do
-            docker exec pgque-python-test pg_isready -U postgres && break
-            sleep 1
-          done || { echo "PG not ready after 30 seconds"; exit 1; }
+          bash ci/wait-for-postgres.sh pgque-python-test
 
       - name: Build pgque
         run: bash build/transform.sh
@@ -590,12 +581,9 @@ jobs:
             -e POSTGRES_PASSWORD=pgque_test \
             -e POSTGRES_DB=pgque_test \
             -p 5432:5432 \
-            postgres:${PG_VERSION}
+            "postgres:${PG_VERSION}"
 
-          for i in $(seq 1 30); do
-            docker exec pgque-go-test pg_isready -U postgres && break
-            sleep 1
-          done || { echo "PG not ready after 30 seconds"; exit 1; }
+          bash ci/wait-for-postgres.sh pgque-go-test
 
       - name: Build pgque
         run: bash build/transform.sh
@@ -634,12 +622,9 @@ jobs:
             -e POSTGRES_PASSWORD=pgque_test \
             -e POSTGRES_DB=pgque_test \
             -p 5432:5432 \
-            postgres:${PG_VERSION}
+            "postgres:${PG_VERSION}"
 
-          for i in $(seq 1 30); do
-            docker exec pgque-ts-test pg_isready -U postgres && break
-            sleep 1
-          done || { echo "PG not ready after 30 seconds"; exit 1; }
+          bash ci/wait-for-postgres.sh pgque-ts-test
 
       - name: Build pgque
         run: bash build/transform.sh
@@ -692,12 +677,9 @@ jobs:
             -e POSTGRES_PASSWORD=pgque_test \
             -e POSTGRES_DB=pgque_test \
             -p 5432:5432 \
-            postgres:${PG_VERSION}
+            "postgres:${PG_VERSION}"
 
-          for i in $(seq 1 30); do
-            docker exec pgque-ruby-test pg_isready -U postgres && break
-            sleep 1
-          done || { echo "PG not ready after 30 seconds"; exit 1; }
+          bash ci/wait-for-postgres.sh pgque-ruby-test
 
       - name: Build pgque
         run: bash build/transform.sh
@@ -737,6 +719,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Verify PostgreSQL readiness checks
+        run: bash tests/test_ci_readiness.sh
 
       - name: Build
         run: bash build/transform.sh

--- a/ci/wait-for-postgres.sh
+++ b/ci/wait-for-postgres.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+set -Eeuo pipefail
+
+container=${1:?usage: wait-for-postgres.sh CONTAINER [ATTEMPTS]}
+attempts=${2:-30}
+
+if [[ ! "${attempts}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ATTEMPTS must be a positive integer" >&2
+  exit 2
+fi
+
+ready=0
+for _ in $(seq 1 "${attempts}"); do
+  if docker exec -e PGPASSWORD=pgque_test "${container}" \
+    psql -U postgres -d pgque_test -c 'select 1' >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  sleep 1
+done
+
+if [[ "${ready}" -ne 1 ]]; then
+  echo "PG not ready after ${attempts} seconds"
+  docker logs "${container}"
+  exit 1
+fi

--- a/ci/wait-for-postgres.sh
+++ b/ci/wait-for-postgres.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
-# Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 set -Eeuo pipefail
+IFS=$'\n\t'
 
-container=${1:?usage: wait-for-postgres.sh CONTAINER [ATTEMPTS]}
-attempts=${2:-30}
+# Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+# Wait for the PgQue CI target database or fail with container diagnostics.
+
+container="${1:?usage: wait-for-postgres.sh CONTAINER [ATTEMPTS]}"
+attempts="${2:-30}"
 
 if [[ ! "${attempts}" =~ ^[1-9][0-9]*$ ]]; then
   echo "ATTEMPTS must be a positive integer" >&2
@@ -11,9 +14,17 @@ if [[ ! "${attempts}" =~ ^[1-9][0-9]*$ ]]; then
 fi
 
 ready=0
-for _ in $(seq 1 "${attempts}"); do
-  if docker exec -e PGPASSWORD=pgque_test "${container}" \
-    psql -U postgres -d pgque_test -c 'select 1' >/dev/null 2>&1; then
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+  if docker exec \
+    -e PGPASSWORD=pgque_test \
+    -e PAGER=cat \
+    "${container}" \
+    psql \
+    --no-psqlrc \
+    --username=postgres \
+    --dbname=pgque_test \
+    --command='select 1' \
+    >/dev/null 2>&1; then
     ready=1
     break
   fi
@@ -21,7 +32,7 @@ for _ in $(seq 1 "${attempts}"); do
 done
 
 if [[ "${ready}" -ne 1 ]]; then
-  echo "PG not ready after ${attempts} seconds"
-  docker logs "${container}"
+  echo "Postgres not ready after ${attempts} seconds" >&2
+  docker logs "${container}" >&2
   exit 1
 fi

--- a/tests/test_ci_readiness.sh
+++ b/tests/test_ci_readiness.sh
@@ -1,71 +1,88 @@
 #!/usr/bin/env bash
-# Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 set -Eeuo pipefail
+IFS=$'\n\t'
 
-repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-cd "${repo_root}"
+# Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+# Regression checks for the shared CI Postgres readiness helper.
 
-workflow=${1:-.github/workflows/ci.yml}
-if grep -nE 'done[[:space:]]*\|\|' "${workflow}"; then
-  echo "FAIL: readiness loop can exit successfully after its final sleep"
-  exit 1
-fi
+main() {
+  local repo_root
+  local workflow
+  local container
+  local output
 
-containers=(
-  pgque-test
-  pgque-stable-smoke
-  pgque-python-test
-  pgque-go-test
-  pgque-ts-test
-  pgque-ruby-test
-)
-for container in "${containers[@]}"; do
-  if ! grep -Fq "bash ci/wait-for-postgres.sh ${container}" "${workflow}"; then
-    echo "FAIL: ${container} does not use the tested readiness helper"
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  cd "${repo_root}"
+
+  workflow="${1:-.github/workflows/ci.yml}"
+  if grep -nE 'done[[:space:]]*\|\|' "${workflow}"; then
+    echo "FAIL: readiness loop can exit successfully after its final sleep" >&2
     exit 1
   fi
-done
 
-# These functions are invoked by the helper's child Bash process.
-# shellcheck disable=SC2329
-docker() {
-  [[ "$#" -eq 11 \
-    && "$1" == exec \
-    && "$2" == -e \
-    && "$3" == PGPASSWORD=pgque_test \
-    && "$4" == pgque-ready \
-    && "$5" == psql \
-    && "$6" == -U \
-    && "$7" == postgres \
-    && "$8" == -d \
-    && "$9" == pgque_test \
-    && "${10}" == -c \
-    && "${11}" == 'select 1' ]]
-}
+  local -a containers=(
+    pgque-test
+    pgque-stable-smoke
+    pgque-python-test
+    pgque-go-test
+    pgque-ts-test
+    pgque-ruby-test
+  )
+  for container in "${containers[@]}"; do
+    if ! grep -Fq "bash ci/wait-for-postgres.sh ${container}" "${workflow}"; then
+      echo "FAIL: ${container} does not use the tested readiness helper" >&2
+      exit 1
+    fi
+  done
 
-# shellcheck disable=SC2329
-sleep() {
-  :
-}
-
-export -f docker sleep
-bash ci/wait-for-postgres.sh pgque-ready 1
-
-# shellcheck disable=SC2329
-docker() {
-  if [[ "$1" == logs && "$2" == pgque-timeout ]]; then
-    echo "expected container log"
-    return 0
+  if ! grep -Fq "IFS=\$'\\n\\t'" ci/wait-for-postgres.sh; then
+    echo "FAIL: readiness helper must set the safe shell IFS" >&2
+    exit 1
   fi
-  return 1
+
+  # These functions are invoked by the helper's child Bash process.
+  # shellcheck disable=SC2329
+  docker() {
+    [[ "${#}" -eq 11 \
+      && "${1}" == exec \
+      && "${2}" == -e \
+      && "${3}" == PGPASSWORD=pgque_test \
+      && "${4}" == -e \
+      && "${5}" == PAGER=cat \
+      && "${6}" == pgque-ready \
+      && "${7}" == psql \
+      && "${8}" == --no-psqlrc \
+      && "${9}" == --username=postgres \
+      && "${10}" == --dbname=pgque_test \
+      && "${11}" == --command=select\ 1 ]]
+  }
+
+  # shellcheck disable=SC2329
+  sleep() {
+    :
+  }
+
+  export -f docker sleep
+  bash ci/wait-for-postgres.sh pgque-ready 1
+
+  # shellcheck disable=SC2329
+  docker() {
+    if [[ "${1}" == logs && "${2}" == pgque-timeout ]]; then
+      echo "expected container log"
+      return 0
+    fi
+    return 1
+  }
+  export -f docker
+
+  if output=$(bash ci/wait-for-postgres.sh pgque-timeout 2 2>&1); then
+    echo "FAIL: readiness helper accepted an unavailable target database" >&2
+    exit 1
+  fi
+  grep -Fq 'Postgres not ready after 2 seconds' <<<"${output}"
+  grep -Fq 'expected container log' <<<"${output}"
+
+  echo "PASS: Postgres readiness checks fail closed"
 }
-export -f docker
 
-if output=$(bash ci/wait-for-postgres.sh pgque-timeout 2 2>&1); then
-  echo "FAIL: readiness helper accepted an unavailable target database"
-  exit 1
-fi
-grep -Fq 'PG not ready after 2 seconds' <<<"${output}"
-grep -Fq 'expected container log' <<<"${output}"
-
-echo "PASS: PostgreSQL readiness checks fail closed"
+main "$@"

--- a/tests/test_ci_readiness.sh
+++ b/tests/test_ci_readiness.sh
@@ -82,6 +82,15 @@ main() {
   grep -Fq 'Postgres not ready after 2 seconds' <<<"${output}"
   grep -Fq 'expected container log' <<<"${output}"
 
+  for invalid_attempts in 0 not-a-number; do
+    if output=$(bash ci/wait-for-postgres.sh \
+      pgque-timeout "${invalid_attempts}" 2>&1); then
+      echo "FAIL: readiness helper accepted invalid attempts" >&2
+      exit 1
+    fi
+    grep -Fq 'ATTEMPTS must be a positive integer' <<<"${output}"
+  done
+
   echo "PASS: Postgres readiness checks fail closed"
 }
 

--- a/tests/test_ci_readiness.sh
+++ b/tests/test_ci_readiness.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+set -Eeuo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "${repo_root}"
+
+workflow=${1:-.github/workflows/ci.yml}
+if grep -nE 'done[[:space:]]*\|\|' "${workflow}"; then
+  echo "FAIL: readiness loop can exit successfully after its final sleep"
+  exit 1
+fi
+
+containers=(
+  pgque-test
+  pgque-stable-smoke
+  pgque-python-test
+  pgque-go-test
+  pgque-ts-test
+  pgque-ruby-test
+)
+for container in "${containers[@]}"; do
+  if ! grep -Fq "bash ci/wait-for-postgres.sh ${container}" "${workflow}"; then
+    echo "FAIL: ${container} does not use the tested readiness helper"
+    exit 1
+  fi
+done
+
+# These functions are invoked by the helper's child Bash process.
+# shellcheck disable=SC2329
+docker() {
+  [[ "$#" -eq 11 \
+    && "$1" == exec \
+    && "$2" == -e \
+    && "$3" == PGPASSWORD=pgque_test \
+    && "$4" == pgque-ready \
+    && "$5" == psql \
+    && "$6" == -U \
+    && "$7" == postgres \
+    && "$8" == -d \
+    && "$9" == pgque_test \
+    && "${10}" == -c \
+    && "${11}" == 'select 1' ]]
+}
+
+# shellcheck disable=SC2329
+sleep() {
+  :
+}
+
+export -f docker sleep
+bash ci/wait-for-postgres.sh pgque-ready 1
+
+# shellcheck disable=SC2329
+docker() {
+  if [[ "$1" == logs && "$2" == pgque-timeout ]]; then
+    echo "expected container log"
+    return 0
+  fi
+  return 1
+}
+export -f docker
+
+if output=$(bash ci/wait-for-postgres.sh pgque-timeout 2 2>&1); then
+  echo "FAIL: readiness helper accepted an unavailable target database"
+  exit 1
+fi
+grep -Fq 'PG not ready after 2 seconds' <<<"${output}"
+grep -Fq 'expected container log' <<<"${output}"
+
+echo "PASS: PostgreSQL readiness checks fail closed"


### PR DESCRIPTION
## Summary

- replace all six ineffective `done || fail` readiness loops with one tested helper
- probe the actual `pgque_test` database, not just socket readiness
- fail in the startup step with container logs when initialization times out
- add static and behavioral regression coverage to the verify job

Fixes #335.

## Validation

- red regression identified exactly the six old broken loops
- helper success, timeout, and log paths passed with stubbed Docker
- old workflow is rejected as a negative fixture
- real PostgreSQL 18 target-database readiness passed
- real wrong-database container failed closed and printed the expected server error
- `bash -n`, `shellcheck`, `actionlint`, YAML parsing, and `git diff --check` passed