### PR TITLE
fix(clients): define nullable message behavior

### DIFF
--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -97,6 +97,12 @@ func main() {
 | `WithUnknownHandlerPolicy(p)`           | `NackUnknown`  | `AckUnknown` logs and skips messages with no registered handler.      |
 | `WithRetryAfter(d time.Duration)`       | `60s`          | Retry delay for Consumer-issued `Nack` calls on handler failure or unknown type. |
 
+PgQ permits SQL `NULL` in `ev_type` and `ev_data` for direct SQL and trigger
+producers. To preserve the existing Go API, `Receive` and `ReceiveCoop`
+normalize either value to the empty string. An empty `Message.Type` never
+matches a handler (including one registered with `Handle("", ...)`); the
+high-level Consumer applies `UnknownHandlerPolicy` instead.
+
 ## Manual ticking
 
 For tests, demos, or manual operation without `pg_cron`, use

--- a/clients/go/consumer.go
+++ b/clients/go/consumer.go
@@ -152,7 +152,13 @@ func (c *Consumer) Start(ctx context.Context) error {
 		nackFailed := false
 		for _, msg := range msgs {
 			batchID = msg.BatchID
-			handler, ok := c.handlers[msg.Type]
+			// SQL NULL is normalized to "" by Receive. Keep it on the
+			// unknown-type path instead of dispatching an empty-string key.
+			var handler HandlerFunc
+			var ok bool
+			if msg.Type != "" {
+				handler, ok = c.handlers[msg.Type]
+			}
 			if !ok {
 				if c.unknownPolicy == AckUnknown {
 					log.Printf("pgque: no handler registered for event type %q, skipping message %d (AckUnknown policy)", msg.Type, msg.MsgID)

--- a/clients/go/consumer_internal_test.go
+++ b/clients/go/consumer_internal_test.go
@@ -154,6 +154,33 @@ func TestConsumer_AckUnknownPolicy_SkipsNack(t *testing.T) {
 	}
 }
 
+func TestConsumer_NullTypeAlwaysUsesUnknownPolicy(t *testing.T) {
+	client := &Client{}
+	stub := &stubBackend{
+		msg: Message{MsgID: 1, BatchID: 100, Type: "", Payload: ""},
+	}
+	var handlerCount int32
+
+	c := client.NewConsumer("dummy_queue", "dummy_consumer",
+		WithPollInterval(10*time.Millisecond))
+	c.backend = stub
+	c.Handle("", func(_ context.Context, _ Message) error {
+		atomic.AddInt32(&handlerCount, 1)
+		return nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_ = c.Start(ctx)
+
+	if got := atomic.LoadInt32(&handlerCount); got != 0 {
+		t.Fatalf("NULL/empty type invoked an empty-string handler %d times", got)
+	}
+	if got := atomic.LoadInt32(&stub.nackCount); got != 1 {
+		t.Fatalf("NULL/empty type must follow NackUnknown, got %d Nacks", got)
+	}
+}
+
 func TestConsumer_DefaultMaxMessagesRequestsWholeBatch(t *testing.T) {
 	client := &Client{}
 	stub := &stubBackend{}

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -85,6 +85,12 @@ registered handler and no `"*"` catch-all. The message is retried (or
 dead-lettered once `queue_max_retries` is exhausted) so unknown types
 are never silently dropped.
 
+Direct SQL and trigger producers can store SQL `NULL` for `ev_type` or
+`ev_data`. `receive()` and `receive_coop()` preserve these as
+`Message.type is None` and `Message.payload is None`. A null type never
+matches a named handler: the `"*"` catch-all receives it when registered,
+otherwise `unknown_handler_policy` applies.
+
 To ack unknown types instead, pass `unknown_handler_policy="ack"`:
 
 ```python

--- a/clients/python/pgque/consumer.py
+++ b/clients/python/pgque/consumer.py
@@ -322,7 +322,14 @@ class Consumer:
             nack_failed = False
 
             for msg in msgs:
-                handler = self._handlers.get(msg.type, self._default_handler)
+                # SQL NULL is not a named event type. It may be handled by
+                # the explicit "*" catch-all, but never by a None key that a
+                # caller inserted despite the public str annotation.
+                handler = (
+                    self._default_handler
+                    if msg.type is None
+                    else self._handlers.get(msg.type, self._default_handler)
+                )
                 if handler is None:
                     if self._unknown_handler_policy == "ack":
                         self._log.warning(

--- a/clients/python/pgque/types.py
+++ b/clients/python/pgque/types.py
@@ -16,8 +16,9 @@ class Message:
     Maps to the ``pgque.message`` composite type:
         msg_id      -- ev_id
         batch_id    -- batch containing this message
-        type        -- ev_type
-        payload     -- ev_data (jsonb auto-decoded by psycopg, otherwise text)
+        type        -- ev_type (None when SQL NULL)
+        payload     -- ev_data (None when SQL NULL; otherwise jsonb
+                       auto-decoded by psycopg or text)
         retry_count -- ev_retry (None for first delivery)
         created_at  -- ev_time
         extra1..4   -- ev_extra1..ev_extra4
@@ -25,7 +26,7 @@ class Message:
 
     msg_id: int
     batch_id: int
-    type: str
+    type: Optional[str]
     payload: Any
     retry_count: Optional[int]
     created_at: datetime

--- a/clients/python/tests/test_null_event.py
+++ b/clients/python/tests/test_null_event.py
@@ -1,0 +1,116 @@
+# Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+"""NULL ``ev_type`` / ``ev_data`` client contract."""
+
+from datetime import datetime, timezone
+from typing import Optional, get_type_hints
+
+from unittest import mock
+from unittest.mock import MagicMock
+
+import pgque
+
+
+def _tick(conn, queue: str) -> None:
+    conn.execute("select pgque.force_next_tick(%s)", (queue,))
+    conn.execute("select pgque.ticker(%s)", (queue,))
+    conn.commit()
+
+
+def _null_message() -> pgque.Message:
+    return pgque.Message(
+        msg_id=1,
+        batch_id=2,
+        type=None,
+        payload=None,
+        retry_count=None,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+def test_message_type_annotation_preserves_sql_nullability():
+    assert get_type_hints(pgque.Message)["type"] == Optional[str]
+
+
+def test_receive_preserves_null_type_and_payload(conn, setup_queue):
+    queue, consumer = setup_queue
+    client = pgque.PgqueClient(conn)
+
+    event_id = conn.execute(
+        "select pgque.insert_event(%s, null, null)", (queue,)
+    ).fetchone()[0]
+    conn.commit()
+    _tick(conn, queue)
+
+    [msg] = client.receive(queue, consumer, max_messages=1)
+    assert msg.msg_id == event_id
+    assert msg.type is None
+    assert msg.payload is None
+    client.ack(msg.batch_id)
+    conn.commit()
+
+
+def test_receive_coop_preserves_null_type_and_payload(
+    conn, queue_name, consumer_name
+):
+    client = pgque.PgqueClient(conn)
+    conn.execute("select pgque.create_queue(%s)", (queue_name,))
+    conn.commit()
+    try:
+        client.subscribe_subconsumer(queue_name, consumer_name, "worker-1")
+        conn.commit()
+        event_id = conn.execute(
+            "select pgque.insert_event(%s, null, null)", (queue_name,)
+        ).fetchone()[0]
+        conn.commit()
+        _tick(conn, queue_name)
+
+        [msg] = client.receive_coop(
+            queue_name, consumer_name, "worker-1", max_messages=1
+        )
+        assert msg.msg_id == event_id
+        assert msg.type is None
+        assert msg.payload is None
+        client.ack(msg.batch_id)
+        conn.commit()
+    finally:
+        conn.rollback()
+        client.unsubscribe_subconsumer(
+            queue_name, consumer_name, "worker-1", batch_handling=1
+        )
+        conn.execute("select pgque.drop_queue(%s, true)", (queue_name,))
+        conn.commit()
+
+
+def test_consumer_routes_null_type_as_unknown_even_if_none_handler_registered(dsn):
+    msg = _null_message()
+    consumer = pgque.Consumer(dsn=dsn, queue="q", name="c")
+    handler = MagicMock()
+    consumer.on(None)(handler)  # type: ignore[arg-type]
+    conn = MagicMock()
+
+    with mock.patch.object(pgque.PgqueClient, "receive", return_value=[msg]), \
+         mock.patch.object(pgque.PgqueClient, "nack") as nack, \
+         mock.patch.object(pgque.PgqueClient, "ack", return_value=1) as ack:
+        assert consumer._poll_once(conn) is True
+
+    handler.assert_not_called()
+    nack.assert_called_once()
+    ack.assert_called_once_with(msg.batch_id)
+
+
+def test_consumer_routes_null_type_to_explicit_catch_all(dsn):
+    msg = _null_message()
+    consumer = pgque.Consumer(dsn=dsn, queue="q", name="c")
+    catch_all = MagicMock()
+    consumer.on("*")(catch_all)
+    conn = MagicMock()
+
+    with mock.patch.object(pgque.PgqueClient, "receive", return_value=[msg]), \
+         mock.patch.object(pgque.PgqueClient, "nack") as nack, \
+         mock.patch.object(pgque.PgqueClient, "ack", return_value=1) as ack:
+        assert consumer._poll_once(conn) is True
+
+    catch_all.assert_called_once_with(msg)
+    nack.assert_not_called()
+    ack.assert_called_once_with(msg.batch_id)

--- a/clients/python/tests/test_null_event.py
+++ b/clients/python/tests/test_null_event.py
@@ -82,9 +82,9 @@ def test_receive_coop_preserves_null_type_and_payload(
         conn.commit()
 
 
-def test_consumer_routes_null_type_as_unknown_even_if_none_handler_registered(dsn):
+def test_consumer_routes_null_type_as_unknown_even_if_none_handler_registered():
     msg = _null_message()
-    consumer = pgque.Consumer(dsn=dsn, queue="q", name="c")
+    consumer = pgque.Consumer(dsn="postgresql:///unused", queue="q", name="c")
     handler = MagicMock()
     consumer.on(None)(handler)  # type: ignore[arg-type]
     conn = MagicMock()
@@ -99,9 +99,9 @@ def test_consumer_routes_null_type_as_unknown_even_if_none_handler_registered(ds
     ack.assert_called_once_with(msg.batch_id)
 
 
-def test_consumer_routes_null_type_to_explicit_catch_all(dsn):
+def test_consumer_routes_null_type_to_explicit_catch_all():
     msg = _null_message()
-    consumer = pgque.Consumer(dsn=dsn, queue="q", name="c")
+    consumer = pgque.Consumer(dsn="postgresql:///unused", queue="q", name="c")
     catch_all = MagicMock()
     consumer.on("*")(catch_all)
     conn = MagicMock()

--- a/clients/ruby/README.md
+++ b/clients/ruby/README.md
@@ -107,6 +107,12 @@ registered handler and no `"*"` catch-all. The message is retried (or
 dead-lettered once `queue_max_retries` is exhausted) so unknown types
 are never silently dropped.
 
+Direct SQL and trigger producers can store SQL `NULL` for `ev_type` or
+`ev_data`. `receive` and `receive_coop` preserve these as a message with
+`nil` `type` and `payload`. A nil type never matches a named handler: the
+`"*"` catch-all receives it when registered, otherwise
+`unknown_handler_policy` applies.
+
 To ack unknown types instead, pass `unknown_handler_policy: "ack"`:
 
 ```ruby

--- a/clients/ruby/lib/pgque/consumer.rb
+++ b/clients/ruby/lib/pgque/consumer.rb
@@ -169,7 +169,13 @@ module Pgque
     def dispatch_batch(client, batch_id, msgs)
       nack_failed = false
       msgs.each do |msg|
-        handler = @handlers[msg.type] || @default_handler
+        # SQL NULL is not a named event type. It may be handled by the
+        # explicit "*" catch-all, but never by a nil hash key.
+        handler = if msg.type.nil?
+          @default_handler
+        else
+          @handlers[msg.type] || @default_handler
+        end
 
         if handler.nil?
           if @unknown_handler_policy == "ack"

--- a/clients/ruby/lib/pgque/message.rb
+++ b/clients/ruby/lib/pgque/message.rb
@@ -1,6 +1,8 @@
 # Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
 
 module Pgque
+  # A received PgQue event. +type+ and +payload+ are +nil+ when the
+  # corresponding SQL +ev_type+ or +ev_data+ value is NULL.
   class Message
     attr_reader :msg_id, :batch_id, :type, :payload, :retry_count,
                 :created_at, :extra1, :extra2, :extra3, :extra4

--- a/clients/ruby/test/test_consumer.rb
+++ b/clients/ruby/test/test_consumer.rb
@@ -32,6 +32,32 @@ class TestConsumerUnit < Minitest::Test
     def nack(*); end
   end
 
+  class NullTypeSpyClient < SpyClient
+    attr_reader :ack_calls, :nack_calls
+
+    def initialize(*)
+      super
+      @ack_calls = []
+      @nack_calls = []
+    end
+
+    def receive(*)
+      [Pgque::Message.new(
+        msg_id: 1, batch_id: 2, type: nil, payload: nil,
+        retry_count: nil, created_at: Time.now,
+      )]
+    end
+
+    def ack(batch_id)
+      @ack_calls << batch_id
+      1
+    end
+
+    def nack(batch_id, msg, **)
+      @nack_calls << [batch_id, msg]
+    end
+  end
+
   def test_consumer_default_max_messages_requests_whole_batch
     cons = Pgque::Consumer.new(dsn, queue: "q", name: "c")
     assert_equal 2_147_483_647, cons.max_messages
@@ -58,6 +84,36 @@ class TestConsumerUnit < Minitest::Test
       cons.poll_once(FakeTxConn.new)
     end
     assert_equal [["q", "c", 123]], spy.receive_calls
+  end
+
+  def test_consumer_routes_null_type_as_unknown_even_with_nil_handler
+    cons = Pgque::Consumer.new(dsn, queue: "q", name: "c")
+    handler_calls = 0
+    cons.on(nil) { handler_calls += 1 }
+    spy = NullTypeSpyClient.new
+
+    Pgque::Client.stub :new, ->(*) { spy } do
+      cons.poll_once(FakeTxConn.new)
+    end
+
+    assert_equal 0, handler_calls
+    assert_equal 1, spy.nack_calls.size
+    assert_equal [2], spy.ack_calls
+  end
+
+  def test_consumer_routes_null_type_to_explicit_catch_all
+    cons = Pgque::Consumer.new(dsn, queue: "q", name: "c")
+    catch_all_calls = 0
+    cons.on("*") { catch_all_calls += 1 }
+    spy = NullTypeSpyClient.new
+
+    Pgque::Client.stub :new, ->(*) { spy } do
+      cons.poll_once(FakeTxConn.new)
+    end
+
+    assert_equal 1, catch_all_calls
+    assert_empty spy.nack_calls
+    assert_equal [2], spy.ack_calls
   end
 
   def test_consumer_rejects_invalid_unknown_handler_policy

--- a/clients/ruby/test/test_coop.rb
+++ b/clients/ruby/test/test_coop.rb
@@ -94,6 +94,25 @@ class TestCoop < Minitest::Test
     end
   end
 
+  def test_receive_coop_preserves_null_type_and_payload
+    with_coop_queue do |q, conn|
+      client = Pgque::Client.new(conn)
+      client.subscribe_subconsumer(q, consumer_n, "worker-1")
+      event_id = conn.exec_params(
+        "select pgque.insert_event($1, null, null)", [q]
+      ).getvalue(0, 0).to_i
+      tick(conn, q)
+
+      msg = client.receive_coop(
+        q, consumer_n, "worker-1", max_messages: 1
+      ).fetch(0)
+      assert_equal event_id, msg.msg_id
+      assert_nil msg.type
+      assert_nil msg.payload
+      client.ack(msg.batch_id)
+    end
+  end
+
   def test_two_subconsumers_split_batches_no_duplicates
     with_coop_queue do |q, conn|
       Pgque.connect(dsn) do |producer|

--- a/clients/ruby/test/test_receive.rb
+++ b/clients/ruby/test/test_receive.rb
@@ -70,6 +70,23 @@ class TestReceive < Minitest::Test
     end
   end
 
+  def test_receive_preserves_null_type_and_payload
+    with_queue do |queue, consumer, conn|
+      client = Pgque::Client.new(conn)
+      event_id = conn.exec_params(
+        "select pgque.insert_event($1, null, null)", [queue]
+      ).getvalue(0, 0).to_i
+      conn.exec_params("select pgque.force_next_tick($1)", [queue])
+      conn.exec_params("select pgque.ticker($1)", [queue])
+
+      msg = client.receive(queue, consumer, 1).fetch(0)
+      assert_equal event_id, msg.msg_id
+      assert_nil msg.type
+      assert_nil msg.payload
+      client.ack(msg.batch_id)
+    end
+  end
+
   def test_message_timestamp_round_trip
     with_queue do |queue, consumer, conn|
       client = Pgque::Client.new(conn)

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -52,9 +52,10 @@ try {
   console.log('published', eventId, batchIds);
 
   // High-level consumer with per-event-type dispatch.
-  // msg.payload is raw JSON text — call JSON.parse() to get the object back.
+  // msg.payload is raw JSON text, or null for SQL NULL.
   const consumer = client.newConsumer('orders', 'order_worker');
   consumer.handle('order.created', async (msg) => {
+    if (msg.payload === null) throw new Error('order.created payload is NULL');
     const data = JSON.parse(msg.payload) as { id: number };
     console.log('got', msg.type, data);
   });
@@ -90,6 +91,12 @@ try {
 `Message.msgId`, `Message.batchId`, and the return values of `send()`,
 `sendBatch()`, `ticker(queue)`, and `forceNextTick(queue)` are JS `bigint` to
 match PostgreSQL `bigint` losslessly.
+
+`Message.type` and `Message.payload` are `string | null`. Low-level producers
+such as direct `pgque.insert_event` calls and triggers can store SQL `NULL`,
+which `receive` and `receiveCoop` preserve as JavaScript `null`. The high-level
+`Consumer` never dispatches a null type to a per-type handler; it applies
+`unknownHandlerPolicy` (`'nack'` by default, or `'ack'`).
 
 ## Experimental: cooperative consumers
 

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -45,8 +45,8 @@ export const pgqueTypes: pg.CustomTypesConfig = {
 interface RawMessageRow {
   msg_id: bigint;
   batch_id: bigint;
-  type: string;
-  payload: string;
+  type: string | null;
+  payload: string | null;
   retry_count: number | null;
   created_at: Date;
   extra1: string | null;

--- a/clients/typescript/src/consumer.ts
+++ b/clients/typescript/src/consumer.ts
@@ -101,7 +101,9 @@ export class Consumer {
       let anyNackFailed = false;
       for (const msg of msgs) {
         batchId = msg.batchId;
-        const handler = this.handlers.get(msg.type);
+        // SQL NULL is not an event type applications can register through
+        // handle(string, ...); always apply the unknown-type policy.
+        const handler = msg.type === null ? undefined : this.handlers.get(msg.type);
         if (!handler) {
           if (this.unknownHandlerPolicy === 'ack') {
             this.logger.warn(

--- a/clients/typescript/src/smoke.ts
+++ b/clients/typescript/src/smoke.ts
@@ -44,6 +44,9 @@ async function run(): Promise<void> {
       throw new Error(`expected 1 message, got ${msgs.length}`);
     }
     const msg = msgs[0]!;
+    if (msg.payload === null) {
+      throw new Error('expected a JSON payload, got SQL NULL');
+    }
     const parsed = JSON.parse(msg.payload) as { ok: boolean };
     if (!parsed.ok) {
       throw new Error(`unexpected payload: ${msg.payload}`);

--- a/clients/typescript/src/types.ts
+++ b/clients/typescript/src/types.ts
@@ -11,9 +11,10 @@
 export interface Message {
   msgId: bigint;
   batchId: bigint;
-  type: string;
-  /** Raw `ev_data` text. Caller may `JSON.parse()` if the producer used `Event.payload`. */
-  payload: string;
+  /** Raw `ev_type`. SQL `NULL` is preserved as JavaScript `null`. */
+  type: string | null;
+  /** Raw `ev_data` text. SQL `NULL` is preserved as JavaScript `null`. */
+  payload: string | null;
   /** Number of prior retry attempts. `null` on the first delivery. */
   retryCount: number | null;
   createdAt: Date;
@@ -74,6 +75,9 @@ export interface ConsumerOptions {
   retryAfter?: number;
   /**
    * What to do with messages whose `type` has no registered handler:
+   * A SQL `NULL` type is always treated as unknown and cannot match a
+   * per-type handler.
+   *
    * - `'nack'` (default) — nack each unknown message with a reason; PgQ
    *   routes to the retry queue or DLQ per the queue's `queue_max_retries`.
    * - `'ack'` — log a warning and let the batch ack absorb them (silent

--- a/clients/typescript/test/client.test.ts
+++ b/clients/typescript/test/client.test.ts
@@ -56,7 +56,7 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
     expect(msgs).toHaveLength(1);
     const m = msgs[0]!;
     expect(m.type).toBe('created');
-    expect(JSON.parse(m.payload)).toEqual({ id: 42, hello: 'world' });
+    expect(JSON.parse(m.payload!)).toEqual({ id: 42, hello: 'world' });
     expect(typeof m.msgId).toBe('bigint');
     expect(typeof m.batchId).toBe('bigint');
     expect(m.createdAt).toBeInstanceOf(Date);
@@ -84,7 +84,7 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
     const msgs = await env.client.receive(env.queue, env.consumer, 10);
     expect(msgs).toHaveLength(3);
     expect(msgs.map((m) => m.type)).toEqual(['batch.test', 'batch.test', 'batch.test']);
-    expect(msgs.map((m) => JSON.parse(m.payload))).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
+    expect(msgs.map((m) => JSON.parse(m.payload!))).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
     await env.client.ack(msgs[0]!.batchId);
   });
 
@@ -221,7 +221,7 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
     for (const [type, payload] of cases) {
       const m = byType.get(type);
       expect(m, `missing message of type ${type}`).toBeDefined();
-      expect(JSON.parse(m!.payload)).toEqual(payload);
+      expect(JSON.parse(m!.payload!)).toEqual(payload);
     }
     await env.client.ack(msgs[0]!.batchId);
   });
@@ -237,7 +237,7 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
     expect(m!.type).toBe('undef.explicit');
     // Strong assertion: the stored value is the JSON literal `null`.
     expect(m!.payload).toBe('null');
-    expect(JSON.parse(m!.payload)).toBeNull();
+    expect(JSON.parse(m!.payload!)).toBeNull();
     await env.client.ack(m!.batchId);
   });
 
@@ -249,7 +249,7 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
     expect(m).toBeDefined();
     expect(m!.type).toBe('undef.omitted');
     expect(m!.payload).toBe('null');
-    expect(JSON.parse(m!.payload)).toBeNull();
+    expect(JSON.parse(m!.payload!)).toBeNull();
     await env.client.ack(m!.batchId);
   });
 
@@ -262,7 +262,7 @@ describe('Client (env-gated, requires PGQUE_TEST_DSN)', () => {
     const [m] = await env.client.receive(env.queue, env.consumer, 10);
     expect(m).toBeDefined();
     expect(m!.type).toBe('undef.nested');
-    expect(JSON.parse(m!.payload)).toEqual({ a: 1 });
+    expect(JSON.parse(m!.payload!)).toEqual({ a: 1 });
     await env.client.ack(m!.batchId);
   });
 

--- a/clients/typescript/test/consumer.test.ts
+++ b/clients/typescript/test/consumer.test.ts
@@ -33,11 +33,11 @@ describe('Consumer (env-gated)', () => {
     });
     const seen: Array<{ type: string; v: number }> = [];
     consumer.handle('a', async (msg) => {
-      const p = JSON.parse(msg.payload) as { v: number };
+      const p = JSON.parse(msg.payload!) as { v: number };
       seen.push({ type: 'a', v: p.v });
     });
     consumer.handle('b', async (msg) => {
-      const p = JSON.parse(msg.payload) as { v: number };
+      const p = JSON.parse(msg.payload!) as { v: number };
       seen.push({ type: 'b', v: p.v });
     });
 
@@ -296,6 +296,49 @@ describe('Consumer (env-gated)', () => {
 });
 
 describe('Consumer (in-memory mocks)', () => {
+  it('routes a null type as unknown even if a JS caller registers null', async () => {
+    const msg: Message = {
+      msgId: 9n,
+      batchId: 109n,
+      type: null,
+      payload: null,
+      retryCount: null,
+      createdAt: new Date(),
+      extra1: null,
+      extra2: null,
+      extra3: null,
+      extra4: null,
+    };
+    let receiveCalls = 0;
+    const fakeClient = {
+      receive: vi.fn(async () => {
+        receiveCalls += 1;
+        return receiveCalls === 1 ? [msg] : [];
+      }),
+      ack: vi.fn(async () => 1),
+      nack: vi.fn(async () => undefined),
+    };
+    const handler = vi.fn(async () => undefined);
+    const consumer = new Consumer(fakeClient as unknown as Client, 'q', 'c', {
+      pollInterval: 10,
+      logger: { warn: () => undefined, error: () => undefined },
+    });
+    consumer.handle(null as unknown as string, handler);
+
+    const ac = new AbortController();
+    const start = consumer.start(ac.signal);
+    const deadline = Date.now() + 4000;
+    while (Date.now() < deadline && fakeClient.nack.mock.calls.length === 0) {
+      await sleep(10);
+    }
+    ac.abort();
+    await start;
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(fakeClient.nack).toHaveBeenCalledTimes(1);
+    expect(fakeClient.ack).toHaveBeenCalledTimes(1);
+  });
+
   it('does not call ack when nack fails for a handler error', async () => {
     const msg: Message = {
       msgId: 1n,

--- a/clients/typescript/test/coop.test.ts
+++ b/clients/typescript/test/coop.test.ts
@@ -215,7 +215,7 @@ describe('Consumer with subconsumer (env-gated)', () => {
     });
     const seen: number[] = [];
     consumer.handle('job', async (msg) => {
-      const p = JSON.parse(msg.payload) as { v: number };
+      const p = JSON.parse(msg.payload!) as { v: number };
       seen.push(p.v);
     });
 

--- a/clients/typescript/test/null-event.test.ts
+++ b/clients/typescript/test/null-event.test.ts
@@ -1,0 +1,89 @@
+// pgque -- TypeScript client for PgQue
+// Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it } from 'vitest';
+import { connect, type Message } from '../src/index.js';
+import {
+  TEST_DSN,
+  advanceQueue,
+  randomSuffix,
+  setupTestQueue,
+  teardownCoopTestQueue,
+  teardownTestQueue,
+  type TestEnv,
+} from './helpers.js';
+
+const skipIfNoDb = TEST_DSN ? it : it.skip;
+
+describe('nullable message contract', () => {
+  it('declares type and payload as nullable', () => {
+    expectTypeOf<Message['type']>().toEqualTypeOf<string | null>();
+    expectTypeOf<Message['payload']>().toEqualTypeOf<string | null>();
+  });
+});
+
+describe('nullable messages (normal receive)', () => {
+  let env: TestEnv;
+
+  beforeEach(async () => {
+    if (!TEST_DSN) return;
+    env = await setupTestQueue();
+  });
+
+  afterEach(async () => {
+    if (!TEST_DSN) return;
+    await teardownTestQueue(env);
+  });
+
+  skipIfNoDb('preserves SQL NULL type and payload', async () => {
+    const inserted = await env.client.rawPool.query<{ insert_event: bigint }>(
+      'select pgque.insert_event($1, null, null) as insert_event',
+      [env.queue],
+    );
+    await advanceQueue(env.client, env.queue);
+
+    const [msg] = await env.client.receive(env.queue, env.consumer, 1);
+    expect(msg?.msgId).toBe(inserted.rows[0]?.insert_event);
+    expect(msg?.type).toBeNull();
+    expect(msg?.payload).toBeNull();
+    await env.client.ack(msg!.batchId);
+  });
+});
+
+describe('nullable messages (cooperative receive)', () => {
+  let env: TestEnv;
+
+  beforeEach(async () => {
+    if (!TEST_DSN) return;
+    const client = await connect(TEST_DSN);
+    const suffix = randomSuffix();
+    env = {
+      client,
+      queue: `tsnull_${suffix}`,
+      consumer: `tsnullconsumer_${suffix}`,
+    };
+    await client.rawPool.query('select pgque.create_queue($1)', [env.queue]);
+  });
+
+  afterEach(async () => {
+    if (!TEST_DSN) return;
+    await teardownCoopTestQueue(env);
+  });
+
+  skipIfNoDb('preserves SQL NULL type and payload', async () => {
+    await env.client.subscribeSubconsumer(env.queue, env.consumer, 'worker-1');
+    const inserted = await env.client.rawPool.query<{ insert_event: bigint }>(
+      'select pgque.insert_event($1, null, null) as insert_event',
+      [env.queue],
+    );
+    await advanceQueue(env.client, env.queue);
+
+    const [msg] = await env.client.receiveCoop(env.queue, env.consumer, 'worker-1', {
+      maxMessages: 1,
+    });
+    expect(msg?.msgId).toBe(inserted.rows[0]?.insert_event);
+    expect(msg?.type).toBeNull();
+    expect(msg?.payload).toBeNull();
+    await env.client.ack(msg!.batchId);
+  });
+});


### PR DESCRIPTION
## Summary

- preserve SQL NULL honestly in Python, TypeScript, and Ruby message values/types
- retain Go's existing NULL-to-empty-string compatibility contract
- prevent NULL from dispatching to an illicit null/empty named handler
- define wildcard/unknown-policy behavior explicitly
- add real normal and cooperative receive coverage across all four clients

Fixes #316.

## Validation

- Go: `go test -race -count=1 ./...` passed
- Python: `81 passed`
- TypeScript: `89 passed`; type-check and build passed
- Ruby: `80 runs, 205 assertions, 0 failures, 0 errors`
- focused red/green tests covered public types, per-type dispatch, wildcard dispatch, and DB round trips
- `git diff --check` and language syntax checks passed