### PR TITLE
docs: document idempotency and partition keys

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -8,6 +8,8 @@ on:
   push:
     branches: [main]
     paths:
+      - 'README.md'
+      - 'build/check-docs-contract.sh'
       - 'web/**'
       - 'docs/**'
       - '.github/workflows/deploy-pages.yml'
@@ -28,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Check documentation release contract
+        run: bash build/check-docs-contract.sh
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.5

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'README.md'
       - 'build/check-docs-contract.sh'
+      - 'tests/test_docs_contract.sh'
       - 'web/**'
       - 'docs/**'
       - '.github/workflows/web-ci.yml'
@@ -18,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check documentation release contract
-        run: bash build/check-docs-contract.sh
+        run: bash tests/test_docs_contract.sh
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.5

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -6,6 +6,8 @@ name: Website build check
 on:
   pull_request:
     paths:
+      - 'README.md'
+      - 'build/check-docs-contract.sh'
       - 'web/**'
       - 'docs/**'
       - '.github/workflows/web-ci.yml'
@@ -15,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Check documentation release contract
+        run: bash build/check-docs-contract.sh
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.5

--- a/README.md
+++ b/README.md
@@ -165,7 +165,11 @@ commit;
 Or from the shell, same single-transaction guarantee via `psql --single-transaction`:
 
 ```bash
-PAGER=cat psql --no-psqlrc --single-transaction -d mydb -f devel/sql/pgque.sql
+PAGER=cat psql \
+  --no-psqlrc \
+  --single-transaction \
+  --dbname=mydb \
+  --file=devel/sql/pgque.sql
 ```
 
 With `pg_cron` available in the same database as PgQue, `pgque.start()` creates the default ticker and maintenance jobs. The ticker uses a one-second pg_cron slot and calls `pgque.ticker_loop()`, which ticks every 100 ms by default (10 ticks/sec) with a commit between ticks:
@@ -552,8 +556,8 @@ PgQue keeps PgQ's proven core architecture — snapshot-based batch isolation, t
 | Modern `send`, `receive`, `ack`, `nack` API | ✅ |
 | `send_batch` API | ✅ |
 | Improved `send_batch` performance | ✅ |
-| Producer idempotency (`send_idem`) | ✅ |
-| Partition keys and leased slot consumers | ✅ |
+| Producer idempotency (`send_idem`) | Yes |
+| Partition keys and leased slot consumers | Yes |
 | Dead-letter queue after retry limit | ✅ |
 | Go library | ✅ |
 | TypeScript library | ✅ |

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Discussion on [Hacker News](https://news.ycombinator.com/item?id=47817349).
 - [Project status](#project-status)
 - [Docs](#docs)
 - [Quick start](#quick-start)
+- [Retry-safe publishing and per-key order](#retry-safe-publishing-and-per-key-order)
 - [Client libraries](#client-libraries)
 - [Benchmarks](#benchmarks)
 - [Subconsumers / cooperative consumers](#subconsumers--cooperative-consumers)
@@ -41,6 +42,11 @@ PgQue brings back [PgQ](https://github.com/pgq/pgq) — one of the longest-runni
 PgQ was designed at Skype in 2006 to run messaging for hundreds of millions of users, and it ran on large self-managed Postgres deployments for over a decade. Standard PgQ depends on a C extension (`pgq`) and an external daemon (`pgqd`), neither of which run on most managed Postgres providers.
 
 PgQue rebuilds that battle-tested engine in pure PL/pgSQL, so the zero-bloat queue pattern works anywhere you can run SQL — without adding another distributed system to your stack.
+
+> **Development documentation:** this README and [pgque.dev](https://pgque.dev)
+> follow the `main` branch and its in-development installer in `devel/sql/`.
+> Production users should use the [latest stable release](https://github.com/NikolayS/pgque/releases/latest)
+> and follow the README at that tag, where install paths point to `sql/`.
 
 It is the same engine – PgQ – repackaged for managed Postgres, and provided with client libraries for TypeScript, Python, and Go.
 
@@ -136,10 +142,12 @@ Oban Pro shipped table partitioning to mitigate it; PGMQ ships aggressive autova
 
 **Requirements:** Postgres 14+, and something that calls `pgque.ticker()` periodically. With `pg_cron`, `pgque.start()` schedules a single 1-second `pg_cron` slot that internally re-ticks every **100 ms (10 ticks/sec)** by default — see [Tick rate](#tick-rate) for tuning. `pg_cron` is pre-installed or one-command available on all major managed Postgres providers (RDS, Aurora, Cloud SQL, AlloyDB, Supabase, Neon); on self-managed Postgres, follow the [pg_cron setup guide](https://github.com/citusdata/pg_cron#setting-up-pg_cron). Any external scheduler (system `cron`, systemd, a worker loop in your app) works as an alternative — see below.
 
-> Want to try an upcoming release early? The in-development install lives in
-> [`devel/sql/`](devel/sql/README.md). The steps below install the stable version.
+These steps install the in-development build documented on `main`. For the
+stable build, use the tagged instructions linked in the development notice
+above. The [documentation index](docs/README.md) defines the promotion-time
+path switch explicitly.
 
-Get the source — `\i sql/pgque.sql` resolves relative to the cwd, so run psql from the repo root:
+Get the source — `\i devel/sql/pgque.sql` resolves relative to the cwd, so run psql from the repo root:
 
 ```bash
 git clone https://github.com/NikolayS/pgque
@@ -150,14 +158,14 @@ Inside a psql session:
 
 ```sql
 begin;
-\i sql/pgque.sql
+\i devel/sql/pgque.sql
 commit;
 ```
 
 Or from the shell, same single-transaction guarantee via `psql --single-transaction`:
 
 ```bash
-PAGER=cat psql --no-psqlrc --single-transaction -d mydb -f sql/pgque.sql
+PAGER=cat psql --no-psqlrc --single-transaction -d mydb -f devel/sql/pgque.sql
 ```
 
 With `pg_cron` available in the same database as PgQue, `pgque.start()` creates the default ticker and maintenance jobs. The ticker uses a one-second pg_cron slot and calls `pgque.ticker_loop()`, which ticks every 100 ms by default (10 ticks/sec) with a commit between ticks:
@@ -218,11 +226,11 @@ For sub-second ticking from an external driver, loop `pgque.ticker()` at your ta
 
 **Important:** PgQue does not deliver messages without a working ticker. Enqueueing still works, but consumers will see nothing new because no ticks are created. If you do not use `pg_cron`, run `pgque.ticker()`, `pgque.maint_retry_events()`, and `pgque.maint()` yourself. Skipping `maint_retry_events()` means nack'd events will never be redelivered.
 
-For existing installs, follow the SQL-file upgrade procedure in [docs/installation.md](docs/installation.md#upgrading). To uninstall: `\i sql/pgque_uninstall.sql`.
+For existing installs, follow the SQL-file upgrade procedure in [docs/installation.md](docs/installation.md#upgrading). To uninstall this build: `\i devel/sql/pgque_uninstall.sql`.
 
 ### Optional: install as a [`pg_tle`](https://github.com/aws/pg_tle) extension
 
-This is opt-in. The default `\i sql/pgque.sql` install stays the recommended path; use pg_tle only if you specifically want PgQue managed as a real Postgres extension.
+This is opt-in. The default `\i devel/sql/pgque.sql` install stays the recommended path; use pg_tle only if you specifically want PgQue managed as a real Postgres extension.
 
 What you get with pg_tle: `pg_extension` membership, `alter extension pgque update` for version upgrades, and `drop extension pgque cascade` for atomic uninstall. What you give up: pg_tle is itself a C extension preloaded via `shared_preload_libraries`, which is the dependency the default install avoids. Available on AWS RDS / Aurora and self-hosted Postgres; check your provider's extension list otherwise.
 
@@ -238,11 +246,11 @@ create extension pg_tle;
 Once pg_tle is loaded, register and create PgQue:
 
 ```sql
-\i sql/pgque-tle.sql
+\i devel/sql/pgque-tle.sql
 create extension pgque;
 ```
 
-To uninstall: `\i sql/pgque-tle-uninstall.sql`.
+To uninstall: `\i devel/sql/pgque-tle-uninstall.sql`.
 
 ## Roles and grants
 
@@ -252,14 +260,14 @@ PgQue mirrors upstream PgQ's split: `pgque_reader` (consume) and `pgque_writer` 
 
 | Role | Purpose | Granted access |
 |---|---|---|
-| `pgque_reader` | Consumers, dashboards, metrics, debugging | Read-only info (`get_queue_info`, `get_consumer_info`, `get_batch_info`, `version`, `select` on all tables) **and** the consume API (`subscribe`, `unsubscribe`, `receive`, `ack`, `nack`) plus the underlying PgQ primitives (`next_batch*`, `get_batch_events`, `finish_batch`, `event_retry`, `register_consumer*`, `unregister_consumer`) and the [experimental cooperative consumer functions](docs/reference.md#cooperative-consumers--subconsumers). |
-| `pgque_writer` | Producers | The produce API (`send`, `send_batch`) and the underlying primitive (`insert_event`). Does **not** inherit `pgque_reader` — a producer-only role cannot ack/finish/inspect consumer batches. |
-| `pgque_admin`  | Operators, migrations | Member of both `pgque_reader` and `pgque_writer`, plus full schema/table/sequence access. `uninstall()` is revoked from both `pgque_admin` and PUBLIC (superuser-only — it drops the schema). |
+| `pgque_reader` | Consumers, dashboards, metrics, debugging | Read-only info (`get_queue_info`, `get_consumer_info`, `get_batch_info`, `partition_slot_status`, `version`, `select` on public tables), the consume API (`subscribe`, `unsubscribe`, `receive`, `ack`, `nack`), the [partitioned consume API](docs/partition-keys.md), the underlying PgQ primitives, and the [experimental cooperative consumer functions](docs/reference.md#cooperative-consumers--subconsumers). |
+| `pgque_writer` | Producers | The produce API (`send`, keyed `send`, `send_idem`, `send_batch`) and the underlying primitive (`insert_event`). Does **not** inherit `pgque_reader` — a producer-only role cannot ack/finish/inspect consumer batches. |
+| `pgque_admin`  | Operators, migrations | Member of both `pgque_reader` and `pgque_writer`, plus lifecycle, DDL, DLQ, and schema administration. The internal idempotency table remains owner-only. `uninstall()` is revoked from both `pgque_admin` and PUBLIC (superuser-only — it drops the schema). |
 
 Typical app setup:
 
 ```sql
-\i sql/pgque.sql
+\i devel/sql/pgque.sql
 select pgque.start();                     -- optional pg_cron ticker + maint
 
 -- Produce + consume in the same app: grant BOTH roles.
@@ -291,8 +299,11 @@ The default install stays small; additional APIs live under [`devel/sql/experime
 - [Tutorial](docs/tutorial.md) — a hands-on walkthrough. Start here if you are new.
 - [Installation and operations](docs/installation.md) — install, ticking, role grants, upgrading, uninstall, troubleshooting.
 - [Examples](docs/examples.md) — patterns: fan-out, exactly-once, batch loading, recurring jobs.
+- [Producer idempotency](docs/producer-idempotency.md) — retry-safe sends, key scope, TTL windows, and maintenance.
+- [Partition keys](docs/partition-keys.md) — per-key order, atomic slot setup, leases, poolers, and recovery.
 - [Monitoring and health](docs/monitoring.md) — queue, consumer, and batch info views.
-- [Function reference](docs/reference.md) — every shipped function and role.
+- [Function reference](docs/reference.md) — public SQL signatures, behavior,
+  and role grants.
 - [Latency and tick tuning](docs/latency-and-tuning.md) — latency breakdown, tick-cadence trade-offs, idle tick behavior, and pg_cron logging caveats.
 - [Concepts and heritage](docs/concepts.md) — batch/tick/rotation glossary, the snapshot/diff engine, and where this engine came from.
 
@@ -335,6 +346,24 @@ select pgque.ack(:batch_id);
 ```
 
 Longer walkthrough in the [tutorial](docs/tutorial.md); patterns like fan-out, exactly-once, and recurring jobs in [examples](docs/examples.md).
+
+## Retry-safe publishing and per-key order
+
+`pgque.send_idem()` gives producers a queue-scoped idempotency key and a
+bounded TTL window. A retry with the same `(queue, idem_key)` returns the first
+event id instead of appending again; use an effect-scoped key such as
+`tenant:operation:entity:version`. See [Producer idempotency](docs/producer-idempotency.md)
+for exact semantics, maintenance, and composition with partition keys.
+
+Partition keys preserve order for a key while allowing one logical consumer
+to process independent keys across a fixed set of leased slots. Create every
+slot atomically with `subscribe_partitioned()` before producing, poll every
+slot, and monitor `partition_slot_status`: each slot scans the full stream, so
+`n` slots cost roughly `n` times the reads, and any stopped slot can pin queue
+rotation. Leases are transactional rows and work through transaction-mode
+poolers. The first-party clients do not yet provide partition claim/rebalance
+helpers, so applications use the SQL API directly. See [Partition keys](docs/partition-keys.md)
+for the worker loop, fencing, partial-unsubscribe recovery, and limits.
 
 ## Client libraries
 
@@ -484,8 +513,9 @@ call (Resend, SendGrid), one SMS request, one webhook, or one slow HTTP POST,
 then consumer-side parallelism is what decides whether the backlog melts or
 lingers.
 
-Cooperative consumers ship in the default install but are **experimental in
-0.2** (the functions carry runtime "Experimental in PgQue 0.2" markers). PgQue
+Cooperative consumers ship in the default install but are **experimental**.
+Their names and edge-case behavior may change before the feature is declared
+stable. PgQue
 does not need a second queue to show the effect. One main consumer fetches a
 batch and fans the work out to a pool of subconsumers, each pulling its own
 slice cooperatively. To make the point concrete, the demo harness preloads the
@@ -522,6 +552,8 @@ PgQue keeps PgQ's proven core architecture — snapshot-based batch isolation, t
 | Modern `send`, `receive`, `ack`, `nack` API | ✅ |
 | `send_batch` API | ✅ |
 | Improved `send_batch` performance | ✅ |
+| Producer idempotency (`send_idem`) | ✅ |
+| Partition keys and leased slot consumers | ✅ |
 | Dead-letter queue after retry limit | ✅ |
 | Go library | ✅ |
 | TypeScript library | ✅ |

--- a/build/check-docs-contract.sh
+++ b/build/check-docs-contract.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+IFS=$'\n\t'
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+# Enforce development and stable documentation release-channel invariants.
+
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${PGQUE_DOCS_ROOT:-${default_repo_root}}"
 channel_file="${repo_root}/docs/.release-channel"
 
 fail() {
@@ -10,35 +15,82 @@ fail() {
 }
 
 require_text() {
-  local pattern="$1"
-  local path="$2"
-  grep -Fq -- "${pattern}" "${repo_root}/${path}" \
-    || fail "${path} must contain: ${pattern}"
-}
+  local pattern="${1}"
+  local path="${2}"
+  local grep_status=0
 
-forbid_text() {
-  local pattern="$1"
-  shift
-  if grep -RFn -- "${pattern}" "$@"; then
-    fail "forbidden documentation text found: ${pattern}"
+  grep -Fq -- "${pattern}" "${repo_root}/${path}" || grep_status=$?
+  if [[ "${grep_status}" -eq 1 ]]; then
+    fail "${path} must contain: ${pattern}"
+  elif [[ "${grep_status}" -ne 0 ]]; then
+    fail "documentation scan failed for ${path}"
   fi
 }
 
-[[ -f "${channel_file}" ]] || fail "missing docs/.release-channel"
-channel="$(<"${channel_file}")"
-doc_paths=(
-  "${repo_root}/README.md"
-  "${repo_root}/docs"
-  "${repo_root}/web/src/pages/index.astro"
-)
+forbid_text() {
+  local pattern="${1}"
+  local grep_status=0
 
-case "${channel}" in
+  shift
+  grep -RFn -- "${pattern}" "$@" || grep_status=$?
+  if [[ "${grep_status}" -eq 0 ]]; then
+    fail "forbidden documentation text found: ${pattern}"
+  elif [[ "${grep_status}" -ne 1 ]]; then
+    fail "documentation scan failed while checking: ${pattern}"
+  fi
+}
+
+find_bad_source_links() {
+  local source_pattern="${1}"
+  local allowed_pattern="${2}"
+  local matches
+  local bad_links
+  local grep_status=0
+  local filter_status=0
+
+  matches="$(grep -Eo "${source_pattern}" \
+    "${repo_root}/docs/reference.md")" || grep_status=$?
+  if [[ "${grep_status}" -gt 1 ]]; then
+    fail "documentation scan failed for docs/reference.md"
+  fi
+
+  bad_links="$(printf '%s\n' "${matches}" \
+    | grep -Ev "${allowed_pattern}")" || filter_status=$?
+  if [[ "${filter_status}" -gt 1 ]]; then
+    fail "documentation source-link filter failed"
+  fi
+
+  printf '%s' "${bad_links}"
+}
+
+main() {
+  local channel
+  local release_tag
+  local bad_source_links
+  local reference_banner
+  local -a doc_paths=(
+    "${repo_root}/README.md"
+    "${repo_root}/docs"
+    "${repo_root}/web/src/pages/index.astro"
+  )
+
+  [[ -f "${channel_file}" ]] || fail "missing docs/.release-channel"
+  channel="$(<"${channel_file}")"
+  printf -v reference_banner '%s' \
+    "This is the public API reference for the in-development" \
+    " default install"
+
+  case "${channel}" in
   development)
     require_text "Development documentation:" "README.md"
     require_text "Build contract." "docs/README.md"
-    require_text "This page follows the \`main\` branch's in-development build" "docs/installation.md"
-    require_text "This is the public API reference for the in-development default install" "docs/reference.md"
-    require_text "tutorial follows the \`main\` branch development build" "docs/tutorial.md"
+    require_text \
+      "This page follows the \`main\` branch's in-development build" \
+      "docs/installation.md"
+    require_text "${reference_banner}" "docs/reference.md"
+    require_text \
+      "tutorial follows the \`main\` branch development build" \
+      "docs/tutorial.md"
 
     require_text "\\i devel/sql/pgque.sql" "README.md"
     require_text "\\i devel/sql/pgque.sql" "docs/installation.md"
@@ -48,19 +100,21 @@ case "${channel}" in
     forbid_text "\\i sql/pgque.sql" "${doc_paths[@]}"
     forbid_text "-f sql/pgque.sql" "${doc_paths[@]}"
 
-    bad_source_links="$(
-      grep -Eo 'https://github\.com/NikolayS/pgque/blob/[^ )]+/(devel/)?sql/[^ )]+' \
-        "${repo_root}/docs/reference.md" \
-        | grep -Ev '/blob/main/devel/sql/' \
-        || true
-    )"
-    [[ -z "${bad_source_links}" ]] \
-      || fail "development SQL source links must target blob/main/devel/sql/: ${bad_source_links}"
+    bad_source_links="$(find_bad_source_links \
+      'https://github\.com/NikolayS/pgque/blob/[^ )]+/(devel/)?sql/[^ )]+' \
+      '/blob/main/devel/sql/')"
+    if [[ -n "${bad_source_links}" ]]; then
+      fail "development SQL source links must target blob/main/devel/sql/:" \
+        "${bad_source_links}"
+    fi
     ;;
   stable:*)
     release_tag="${channel#stable:}"
-    [[ "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] \
-      || fail "stable channel must name a release tag, for example stable:v1.2.3"
+    if ! [[ "${release_tag}" \
+      =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+      fail "stable channel must name a release tag," \
+        "for example stable:v1.2.3"
+    fi
 
     forbid_text "devel/sql/" "${doc_paths[@]}"
     forbid_text "Development documentation:" "${doc_paths[@]}"
@@ -74,18 +128,20 @@ case "${channel}" in
     require_text "\\i sql/pgque.sql" "docs/tutorial.md"
     require_text "\\\\i sql/pgque.sql" "web/src/pages/index.astro"
 
-    bad_source_links="$(
-      grep -Eo 'https://github\.com/NikolayS/pgque/blob/[^ )]+/sql/[^ )]+' \
-        "${repo_root}/docs/reference.md" \
-        | grep -Ev "/blob/${release_tag}/sql/" \
-        || true
-    )"
-    [[ -z "${bad_source_links}" ]] \
-      || fail "stable SQL source links must target blob/${release_tag}/sql/: ${bad_source_links}"
+    bad_source_links="$(find_bad_source_links \
+      'https://github\.com/NikolayS/pgque/blob/[^ )]+/sql/[^ )]+' \
+      "/blob/${release_tag}/sql/")"
+    if [[ -n "${bad_source_links}" ]]; then
+      fail "stable SQL source links must target blob/${release_tag}/sql/:" \
+        "${bad_source_links}"
+    fi
     ;;
   *)
     fail "unknown docs release channel: ${channel}"
     ;;
-esac
+  esac
 
-echo "PASS: ${channel} documentation contract"
+  echo "PASS: ${channel} documentation contract"
+}
+
+main "$@"

--- a/build/check-docs-contract.sh
+++ b/build/check-docs-contract.sh
@@ -67,6 +67,7 @@ case "${channel}" in
     forbid_text "Build contract." "${doc_paths[@]}"
     forbid_text "in-development default install" "${doc_paths[@]}"
     forbid_text "main branch development build" "${doc_paths[@]}"
+    forbid_text "main development build" "${doc_paths[@]}"
 
     require_text "\\i sql/pgque.sql" "README.md"
     require_text "\\i sql/pgque.sql" "docs/installation.md"

--- a/build/check-docs-contract.sh
+++ b/build/check-docs-contract.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+channel_file="${repo_root}/docs/.release-channel"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+require_text() {
+  local pattern="$1"
+  local path="$2"
+  rg -q --fixed-strings -- "${pattern}" "${repo_root}/${path}" \
+    || fail "${path} must contain: ${pattern}"
+}
+
+forbid_text() {
+  local pattern="$1"
+  shift
+  if rg -n --fixed-strings -- "${pattern}" "$@"; then
+    fail "forbidden documentation text found: ${pattern}"
+  fi
+}
+
+[[ -f "${channel_file}" ]] || fail "missing docs/.release-channel"
+channel="$(<"${channel_file}")"
+doc_paths=(
+  "${repo_root}/README.md"
+  "${repo_root}/docs"
+  "${repo_root}/web/src/pages/index.astro"
+)
+
+case "${channel}" in
+  development)
+    require_text "Development documentation:" "README.md"
+    require_text "Build contract." "docs/README.md"
+    require_text "This page follows the \`main\` branch's in-development build" "docs/installation.md"
+    require_text "This is the public API reference for the in-development default install" "docs/reference.md"
+    require_text "tutorial follows the \`main\` branch development build" "docs/tutorial.md"
+
+    require_text "\\i devel/sql/pgque.sql" "README.md"
+    require_text "\\i devel/sql/pgque.sql" "docs/installation.md"
+    require_text "\\i devel/sql/pgque.sql" "docs/tutorial.md"
+    require_text "\\\\i devel/sql/pgque.sql" "web/src/pages/index.astro"
+
+    forbid_text "\\i sql/pgque.sql" "${doc_paths[@]}"
+    forbid_text "-f sql/pgque.sql" "${doc_paths[@]}"
+
+    bad_source_links="$(
+      rg -o 'https://github\.com/NikolayS/pgque/blob/[^ )]+/(devel/)?sql/[^ )]+' \
+        "${repo_root}/docs/reference.md" \
+        | rg -v '/blob/main/devel/sql/' \
+        || true
+    )"
+    [[ -z "${bad_source_links}" ]] \
+      || fail "development SQL source links must target blob/main/devel/sql/: ${bad_source_links}"
+    ;;
+  stable:*)
+    release_tag="${channel#stable:}"
+    [[ "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] \
+      || fail "stable channel must name a release tag, for example stable:v1.2.3"
+
+    forbid_text "devel/sql/" "${doc_paths[@]}"
+    forbid_text "Development documentation:" "${doc_paths[@]}"
+    forbid_text "Build contract." "${doc_paths[@]}"
+    forbid_text "in-development default install" "${doc_paths[@]}"
+    forbid_text "main branch development build" "${doc_paths[@]}"
+
+    require_text "\\i sql/pgque.sql" "README.md"
+    require_text "\\i sql/pgque.sql" "docs/installation.md"
+    require_text "\\i sql/pgque.sql" "docs/tutorial.md"
+    require_text "\\\\i sql/pgque.sql" "web/src/pages/index.astro"
+
+    bad_source_links="$(
+      rg -o 'https://github\.com/NikolayS/pgque/blob/[^ )]+/sql/[^ )]+' \
+        "${repo_root}/docs/reference.md" \
+        | rg -v "/blob/${release_tag}/sql/" \
+        || true
+    )"
+    [[ -z "${bad_source_links}" ]] \
+      || fail "stable SQL source links must target blob/${release_tag}/sql/: ${bad_source_links}"
+    ;;
+  *)
+    fail "unknown docs release channel: ${channel}"
+    ;;
+esac
+
+echo "PASS: ${channel} documentation contract"

--- a/build/check-docs-contract.sh
+++ b/build/check-docs-contract.sh
@@ -12,14 +12,14 @@ fail() {
 require_text() {
   local pattern="$1"
   local path="$2"
-  rg -q --fixed-strings -- "${pattern}" "${repo_root}/${path}" \
+  grep -Fq -- "${pattern}" "${repo_root}/${path}" \
     || fail "${path} must contain: ${pattern}"
 }
 
 forbid_text() {
   local pattern="$1"
   shift
-  if rg -n --fixed-strings -- "${pattern}" "$@"; then
+  if grep -RFn -- "${pattern}" "$@"; then
     fail "forbidden documentation text found: ${pattern}"
   fi
 }
@@ -49,9 +49,9 @@ case "${channel}" in
     forbid_text "-f sql/pgque.sql" "${doc_paths[@]}"
 
     bad_source_links="$(
-      rg -o 'https://github\.com/NikolayS/pgque/blob/[^ )]+/(devel/)?sql/[^ )]+' \
+      grep -Eo 'https://github\.com/NikolayS/pgque/blob/[^ )]+/(devel/)?sql/[^ )]+' \
         "${repo_root}/docs/reference.md" \
-        | rg -v '/blob/main/devel/sql/' \
+        | grep -Ev '/blob/main/devel/sql/' \
         || true
     )"
     [[ -z "${bad_source_links}" ]] \
@@ -75,9 +75,9 @@ case "${channel}" in
     require_text "\\\\i sql/pgque.sql" "web/src/pages/index.astro"
 
     bad_source_links="$(
-      rg -o 'https://github\.com/NikolayS/pgque/blob/[^ )]+/sql/[^ )]+' \
+      grep -Eo 'https://github\.com/NikolayS/pgque/blob/[^ )]+/sql/[^ )]+' \
         "${repo_root}/docs/reference.md" \
-        | rg -v "/blob/${release_tag}/sql/" \
+        | grep -Ev "/blob/${release_tag}/sql/" \
         || true
     )"
     [[ -z "${bad_source_links}" ]] \

--- a/devel/sql/README.md
+++ b/devel/sql/README.md
@@ -7,9 +7,11 @@ churn and validate against a throwaway database, not production.
 The released, stable install lives in [`../../sql/`](../../sql/) — use that for
 anything real.
 
-Testing partition keys (ordered per-key processing via slot consumers)? Until
-`docs/` coverage lands, follow
-[`blueprints/partition-keys/SPEC.md`](../../blueprints/partition-keys/SPEC.md).
+For the public APIs in this build, start with the
+[`docs/` index](../../docs/README.md). The guides cover
+[producer idempotency](../../docs/producer-idempotency.md) and
+[partition keys](../../docs/partition-keys.md), including worker leases,
+monitoring, operational limits, and recovery.
 
 Layout:
 

--- a/docs/.release-channel
+++ b/docs/.release-channel
@@ -1,0 +1,1 @@
+development

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,27 +50,3 @@ For the full specification and implementation plan, see
 [`blueprints/SPECx.md`](https://github.com/NikolayS/pgque/blob/main/blueprints/SPECx.md).
 For what ships in the default install vs experimental, see
 [`blueprints/PHASES.md`](https://github.com/NikolayS/pgque/blob/main/blueprints/PHASES.md).
-
-## Maintainer release contract
-
-The build contract is enforced by `build/check-docs-contract.sh` and
-`docs/.release-channel`. Before creating a stable tag, the release change must:
-
-1. Promote the tested `devel/sql/` artifacts into `sql/` atomically.
-2. Change `docs/.release-channel` from `development` to
-   `stable:<release-tag>`.
-3. Switch every user-facing install, upgrade, uninstall, and pg_tle command in
-   `README.md`, `docs/`, and the website landing page from `devel/sql/` to
-   `sql/`.
-4. Pin every SQL source URL in `docs/reference.md` to
-   `blob/<release-tag>/sql/`; no released reference may follow `main`.
-5. Remove the development notices from the root README, docs index,
-   installation, tutorial, and reference, and remove this development-only
-   checklist from the tagged docs. The executable contract remains in the
-   build script.
-6. Run `bash build/check-docs-contract.sh` and `cd web && bun run build`. Both
-   must pass before tagging.
-
-After the tag is cut and `main` advances to new development work, switch the
-channel back to `development`, restore the development notices and
-`devel/sql/` paths, and keep stable users pointed at the tagged release.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,14 @@ description: Tutorial, reference, examples, monitoring, and concepts for PgQue �
 
 Short docs for users, plus a contributor primer.
 
+> **Build contract.** The documentation on the `main` branch and pgque.dev
+> describes the in-development SQL in `devel/sql/`. For the latest stable
+> build, open the [latest stable release](https://github.com/NikolayS/pgque/releases/latest)
+> and use its tagged README and `sql/pgque.sql`. A release promotion copies the
+> tested artifacts into `sql/`, switches documentation install and source paths
+> from `devel/sql/` to `sql/` (with source links pinned to the release tag), and
+> removes this development-build notice before tagging.
+
 ## Get started
 
 - **[Tutorial](tutorial.md)** — a hands-on walkthrough. Send, tick, receive,
@@ -14,8 +22,13 @@ Short docs for users, plus a contributor primer.
 
 - **[Installation and operations](installation.md)** — install, ticking,
   role grants, uninstall, and troubleshooting.
+- **[Producer idempotency](producer-idempotency.md)** — queue-scoped keys,
+  TTL windows, retry behavior, and maintenance.
+- **[Partition keys](partition-keys.md)** — atomic slot setup, worker leases,
+  ordered routing, poolers, operational limits, and recovery.
 - **[Examples](examples.md)** — short patterns: fan-out, exactly-once,
-  batch send, recurring jobs, DLQ inspection, and
+  idempotent sends, partition workers, batch send, recurring jobs, DLQ
+  inspection, and
   [cooperative consumers / subconsumers](examples.md#cooperative-consumers--subconsumers-experimental)
   (experimental).
 - **[Monitoring and health](monitoring.md)** — queue, consumer, and batch
@@ -23,8 +36,8 @@ Short docs for users, plus a contributor primer.
 
 ## Reference
 
-- **[Function reference](reference.md)** — every function, return type, and
-  role grant in the default install.
+- **[Function reference](reference.md)** — the public SQL surface, return
+  types, behavior, and role grants in the development install.
 
 ## Explanation
 
@@ -37,3 +50,27 @@ For the full specification and implementation plan, see
 [`blueprints/SPECx.md`](https://github.com/NikolayS/pgque/blob/main/blueprints/SPECx.md).
 For what ships in the default install vs experimental, see
 [`blueprints/PHASES.md`](https://github.com/NikolayS/pgque/blob/main/blueprints/PHASES.md).
+
+## Maintainer release contract
+
+The build contract is enforced by `build/check-docs-contract.sh` and
+`docs/.release-channel`. Before creating a stable tag, the release change must:
+
+1. Promote the tested `devel/sql/` artifacts into `sql/` atomically.
+2. Change `docs/.release-channel` from `development` to
+   `stable:<release-tag>`.
+3. Switch every user-facing install, upgrade, uninstall, and pg_tle command in
+   `README.md`, `docs/`, and the website landing page from `devel/sql/` to
+   `sql/`.
+4. Pin every SQL source URL in `docs/reference.md` to
+   `blob/<release-tag>/sql/`; no released reference may follow `main`.
+5. Remove the development notices from the root README, docs index,
+   installation, tutorial, and reference, and remove this development-only
+   checklist from the tagged docs. The executable contract remains in the
+   build script.
+6. Run `bash build/check-docs-contract.sh` and `cd web && bun run build`. Both
+   must pass before tagging.
+
+After the tag is cut and `main` advances to new development work, switch the
+channel back to `development`, restore the development notices and
+`devel/sql/` paths, and keep stable users pointed at the tagged release.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -43,7 +43,8 @@ One consequence follows directly: a producer's insert and the tick that should p
 
 ## Cooperative consumers vs fan-out
 
-> **Experimental in PgQue 0.2.** The cooperative-consumer API ships in the default install but is marked experimental; treat it as subject to change.
+> **Experimental.** The cooperative-consumer API ships in the default install;
+> treat its names and edge-case behavior as subject to change.
 
 PgQue offers two different consumer shapes on top of the same shared log. They are easy to confuse because both involve "several workers on one queue", but they distribute events in opposite ways.
 
@@ -172,7 +173,7 @@ Lineage: PgQ (Skype, ISC, © Marko Kreen / Skype Technologies OU) → SkyTools 2
 ## Where to go next
 
 - [tutorial.md](tutorial.md) — a hands-on first queue.
-- [reference.md](reference.md) — every function in the default install.
+- [reference.md](reference.md) — public SQL signatures, behavior, and grants.
 - [examples.md](examples.md) — fan-out, exactly-once, and other patterns.
 - [monitoring.md](monitoring.md) — watching consumer lag and ticker health.
 - [latency-and-tuning.md](latency-and-tuning.md) — tick cadence and delivery latency trade-offs.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,9 +1,12 @@
 ---
 title: Examples
-description: Copy-paste PgQue recipes — fan-out, exactly-once, batch send, recurring jobs, and dead-letter replay.
+description: Copy-paste PgQue recipes — idempotent sends, partition workers, fan-out, exactly-once, batch send, and dead-letter replay.
 ---
 
-Short, copy-paste patterns for common PgQue tasks. Each recipe is goal, SQL, result. For a guided first run see [the tutorial](tutorial.md); for every function signature see [the reference](reference.md). For queue and consumer health see [monitoring](monitoring.md).
+Short, copy-paste patterns for common PgQue tasks. Each recipe is goal, SQL,
+result. For a guided first run see [the tutorial](tutorial.md); for public SQL
+signatures and behavior see [the reference](reference.md). For queue and
+consumer health see [monitoring](monitoring.md).
 
 All psql snippets assume psql autocommit (one statement per transaction). Run them with the pager and startup file disabled so output is verbatim:
 
@@ -39,9 +42,105 @@ Result: all three `receive` calls return the same event, each through its own cu
 
 Late-subscriber caveat: `subscribe` (which calls `register_consumer`) starts the consumer at the most recent tick. A consumer will not see events that were sent before it subscribed. Subscribe each consumer before you start producing.
 
+## Retry a producer send without appending twice
+
+Goal: safely retry an enqueue when the producer timed out before learning
+whether Postgres committed it.
+
+Derive one key for the logical effect and reuse it for every retry of that
+effect:
+
+```sql
+select * from pgque.send_idem(
+  queue_name := 'orders',
+  type_name := 'payment.captured',
+  payload := '{"order_id": 42, "capture": 1}'::jsonb,
+  idem_key := 'tenant-7:order-42:capture:1',
+  ttl := interval '24 hours'
+);
+```
+
+Result: the first accepted call returns `(event_id, false)`. Another call with
+the same `(queue_name, idem_key)` during the window returns the original
+`event_id` with `deduped = true` and appends nothing. The duplicate payload is
+not compared and the window is not extended, so never reuse a live key for
+different work.
+
+`send_idem` is producer deduplication only. Consumers can still see a batch
+again after rollback or crash. See [Producer idempotency](producer-idempotency.md)
+for key design, TTL sizing, partition-key composition, and maintenance.
+
+## Ordered partition worker
+
+Goal: preserve order per account while several workers process different
+accounts concurrently.
+
+Subscribe the complete slot set before producing:
+
+```sql
+select pgque.subscribe_partitioned(
+  queue_name := 'orders',
+  consumer := 'account_projector',
+  n := 8
+);
+
+select pgque.send(
+  queue_name := 'orders',
+  type_name := 'order.updated',
+  payload := '{"order_id": 42}'::jsonb,
+  partition_key := 'tenant-7:account-19'
+);
+```
+
+Each worker repeatedly tries slots `0..7`. A successful claim returns an epoch;
+a live/busy slot returns null, so move to another candidate:
+
+```sql
+select pgque.claim_slot(
+  queue_name := 'orders',
+  consumer := 'account_projector',
+  slot := 3,
+  worker := 'projector-pod-7f3c',
+  ttl := interval '30 seconds'
+);
+
+select * from pgque.receive_partitioned(
+  queue_name := 'orders',
+  consumer := 'account_projector',
+  slot := 3,
+  n := 8,
+  worker := 'projector-pod-7f3c',
+  max_return := 500
+);
+
+select pgque.ack_partitioned(
+  queue_name := 'orders',
+  consumer := 'account_projector',
+  slot := 3,
+  n := 8,
+  worker := 'projector-pod-7f3c'
+);
+```
+
+Use the slot actually claimed; `3` is illustrative and is not necessarily the
+slot for the sample key. Receive and ack renew the stored TTL. Renew explicitly
+with `claim_slot` when external processing may exceed it, and call
+`release_slot` only after the batch is acked.
+
+Run a polling loop for **every** slot. Each slot scans the full stream, so eight
+slots produce about eight times read amplification; a stopped slot also pins
+rotation. Lease state is transactional and works through transaction-mode
+poolers when `worker` is an application instance id rather than a connection
+id. First-party clients do not yet provide this claim/rebalance loop. Read
+[Partition keys](partition-keys.md) for fencing, monitoring, and incomplete-slot
+recovery before using this recipe.
+
 ## Cooperative consumers / subconsumers (experimental)
 
-> **Experimental in PgQue 0.2.** The cooperative-consumer functions ship in the default install but are marked experimental: names, edge-case behavior, and the client API may change before they are stable. Use idempotent handlers and test stale-worker takeover before relying on this as the only path for critical work.
+> **Experimental.** The cooperative-consumer functions ship in the default
+> install, but names, edge-case behavior, and the client API may change before
+> they are stable. Use idempotent handlers and test stale-worker takeover
+> before relying on this as the only path for critical work.
 
 Goal: split *one* subscriber's events across a pool of competing workers, so each event is handled by exactly one worker in the pool — without giving up PgQue's shared-log model.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,6 +12,11 @@ and troubleshoot.
 If you are brand new to PgQue, start with the [tutorial](tutorial.md) for a
 hands-on walkthrough, then come back here to set up a durable install.
 
+This page follows the `main` branch's in-development build in `devel/sql/`.
+For production, use the [latest stable release](https://github.com/NikolayS/pgque/releases/latest)
+and its tagged installation page, whose commands point to `sql/`. The
+[documentation index](README.md) defines the release-promotion switch.
+
 ## Requirements
 
 - Postgres 14 or newer. PgQue uses `xid8`, `pg_snapshot`, and
@@ -34,14 +39,14 @@ From `psql`:
 
 ```sql
 begin;
-\i sql/pgque.sql
+\i devel/sql/pgque.sql
 commit;
 ```
 
 Or as a shell one-liner from the repository root:
 
 ```bash
-PAGER=cat psql --no-psqlrc --single-transaction -d mydb -f sql/pgque.sql
+PAGER=cat psql --no-psqlrc --single-transaction -d mydb -f devel/sql/pgque.sql
 ```
 
 The installer creates the `pgque` schema, all functions and tables, and the
@@ -337,9 +342,9 @@ parent and child — neither inherits the other.
 
 | Role | For | Capabilities |
 | --- | --- | --- |
-| `pgque_reader` | consumers, dashboards | consume API (`subscribe`, `unsubscribe`, `receive`, `ack`, `nack`), read-only info functions, `select` on tables. Cannot produce. |
-| `pgque_writer` | producers | produce API (`send`, `send_batch`, `insert_event`). Cannot consume. |
-| `pgque_admin` | operators, migrations | member of both reader and writer, plus lifecycle and DDL (`create_queue`, `drop_queue`, `start`, `stop`, `maint`, `set_queue_config`). `uninstall()` is owner/superuser-only — revoked from `pgque_admin`. |
+| `pgque_reader` | consumers, dashboards | consume API (`subscribe`, `unsubscribe`, `receive`, `ack`, `nack`), partition subscription/lease/consume API, read-only info functions and `partition_slot_status`. Cannot produce. |
+| `pgque_writer` | producers | produce API (`send`, keyed `send`, `send_idem`, `send_batch`, `insert_event`). Cannot consume. |
+| `pgque_admin` | operators, migrations | member of both reader and writer, plus lifecycle and DDL (`create_queue`, `drop_queue`, `start`, `stop`, `maint`, `maint_idem`, `set_queue_config`). `uninstall()` is owner/superuser-only — revoked from `pgque_admin`. |
 
 Because the roles are siblings, an application that both produces and consumes
 must be granted **both**:
@@ -368,12 +373,12 @@ per queue; see [reference.md](reference.md) for the role-scope details.
 
 ## Upgrading
 
-Upgrades are SQL-file upgrades: re-run [`sql/pgque.sql`](https://github.com/NikolayS/pgque/blob/main/sql/pgque.sql) over the existing install,
+Upgrades of the development build are SQL-file upgrades: re-run [`devel/sql/pgque.sql`](https://github.com/NikolayS/pgque/blob/main/devel/sql/pgque.sql) over the existing install,
 in a single transaction, as the schema owner or a superuser. From the repository
 root:
 
 ```bash
-PAGER=cat psql --no-psqlrc --single-transaction -v ON_ERROR_STOP=1 -d mydb -f sql/pgque.sql
+PAGER=cat psql --no-psqlrc --single-transaction -v ON_ERROR_STOP=1 -d mydb -f devel/sql/pgque.sql
 ```
 
 The installer is idempotent. It preserves queues, consumers, subscriptions, retry
@@ -396,7 +401,7 @@ To remove PgQue, run the uninstall script. It best-effort stops the scheduler
 and drops the `pgque` schema with `cascade`:
 
 ```sql
-\i sql/pgque_uninstall.sql
+\i devel/sql/pgque_uninstall.sql
 ```
 
 The schema and all its data are dropped. The three roles are **not** dropped,
@@ -405,7 +410,7 @@ them yourself if you no longer need them.
 
 ## pg_tle packaging variant
 
-[`sql/pgque-tle.sql`](https://github.com/NikolayS/pgque/blob/main/sql/pgque-tle.sql) installs the same function and table surface wrapped as a
+[`devel/sql/pgque-tle.sql`](https://github.com/NikolayS/pgque/blob/main/devel/sql/pgque-tle.sql) installs the same function and table surface wrapped as a
 [pg_tle](https://github.com/aws/pg_tle) trusted-language extension, so PgQue
 appears in `pg_available_extensions` and is managed with `create extension` /
 `drop extension`. It trades the zero-dependency `\i` install for a `pg_tle`
@@ -429,17 +434,17 @@ create extension pg_tle;
 With `pg_tle` loaded, register and create PgQue:
 
 ```sql
-\i sql/pgque-tle.sql
+\i devel/sql/pgque-tle.sql
 create extension pgque;
 ```
 
 Uninstall the TLE variant with:
 
 ```sql
-\i sql/pgque-tle-uninstall.sql
+\i devel/sql/pgque-tle-uninstall.sql
 ```
 
-If you have no specific reason to use `pg_tle`, prefer the plain [`sql/pgque.sql`](https://github.com/NikolayS/pgque/blob/main/sql/pgque.sql)
+If you have no specific reason to use `pg_tle`, prefer the plain [`devel/sql/pgque.sql`](https://github.com/NikolayS/pgque/blob/main/devel/sql/pgque.sql)
 install above.
 
 ## Troubleshooting

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -438,6 +438,22 @@ With `pg_tle` loaded, register and create PgQue:
 create extension pgque;
 ```
 
+To upgrade an existing pg_tle installation without dropping queue data, load
+the target wrapper first, then apply the update path it registered:
+
+```sql
+\i devel/sql/pgque-tle.sql
+alter extension pgque update;
+```
+
+Loading the wrapper only registers the target version and its tested update
+path; it does not change the active extension. The data migration runs only
+when `alter extension` succeeds. If the wrapper reports that no tested path
+exists from the installed version, leave the extension installed and consult
+the target release notes. Do **not** uninstall and reinstall to force an
+upgrade: `drop extension pgque cascade` removes the PgQue schema and queue
+data.
+
 Uninstall the TLE variant with:
 
 ```sql

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,7 +46,11 @@ commit;
 Or as a shell one-liner from the repository root:
 
 ```bash
-PAGER=cat psql --no-psqlrc --single-transaction -d mydb -f devel/sql/pgque.sql
+PAGER=cat psql \
+  --no-psqlrc \
+  --single-transaction \
+  --dbname=mydb \
+  --file=devel/sql/pgque.sql
 ```
 
 The installer creates the `pgque` schema, all functions and tables, and the
@@ -378,7 +382,12 @@ in a single transaction, as the schema owner or a superuser. From the repository
 root:
 
 ```bash
-PAGER=cat psql --no-psqlrc --single-transaction -v ON_ERROR_STOP=1 -d mydb -f devel/sql/pgque.sql
+PAGER=cat psql \
+  --no-psqlrc \
+  --single-transaction \
+  --set=ON_ERROR_STOP=1 \
+  --dbname=mydb \
+  --file=devel/sql/pgque.sql
 ```
 
 The installer is idempotent. It preserves queues, consumers, subscriptions, retry

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -8,8 +8,9 @@ explains the columns that matter operationally, the one failure mode you must
 catch early — a stuck consumer that blocks table rotation — and the queries to
 wire into your monitoring.
 
-All of the `get_*_info` functions and `pgque.version()` are granted to
-`pgque_reader`, so a read-only monitoring role can run everything here.
+All of the `get_*_info` functions, `pgque.version()`, and the
+`pgque.partition_slot_status` view are granted to `pgque_reader`, so a
+read-only monitoring role can run the operational queries here.
 `pgque.status()` is admin-only. For role setup see
 [Installation and operations](installation.md); for vocabulary see
 [Concepts](concepts.md).
@@ -99,6 +100,39 @@ select queue_name, consumer_name, lag, seq_start, seq_end
 from pgque.get_batch_info(12345);
 ```
 
+### Partitioned consumers
+
+`pgque.partition_slot_status` returns one row for every expected slot of every
+partitioned consumer, including a slot whose engine subscription is missing:
+
+```sql
+select queue_name, consumer, slot, n, subscribed, lease_owner,
+       lease_until, epoch, last_tick, pending_events
+from pgque.partition_slot_status
+order by queue_name, consumer, slot;
+```
+
+| column | meaning | watch for |
+|---|---|---|
+| `subscribed` | whether the slot's engine subscription exists | `false` means incomplete setup; `last_tick` and `pending_events` are null because lag is unknown |
+| `lease_owner` | current live owner; expired owners are shown as null | null while an always-on worker pool should own every slot |
+| `lease_until` | stored expiry, including an expired lease | repeatedly expires during normal work when TTL/renewal is too short |
+| `epoch` | fencing counter incremented on takeover | rapid growth indicates worker churn or repeated expiry |
+| `last_tick` | this slot's independent cursor | freezes while the queue's latest tick advances when polling stops |
+| `pending_events` | pre-hash-filter event-sequence lag | sustained growth means the slot is behind; zero means caught up exactly |
+
+`pending_events` counts the queue stream before the slot's hash filter, so it
+overstates the slot's own routed share by approximately `n`. Use it for trends
+and zero/nonzero state, not as an exact number of messages the worker will
+receive.
+
+Every slot must advance. Each is an independent subscription over the full
+stream, and one unpolled slot pins table rotation even when all other slots are
+caught up. The first-party clients do not yet run or monitor the claim loop;
+applications must cover all `0..n-1` slots themselves. See
+[Partition keys](partition-keys.md) for lease renewal, fencing, pooler behavior,
+and incomplete-slot recovery.
+
 ## What to alert on
 
 ### The critical one: a stuck consumer blocks rotation
@@ -137,6 +171,13 @@ select pgque.unsubscribe('orders', 'dead_consumer');
 tearing the queue down.) A dead consumer that you do not intend to restart must
 be unsubscribed, or it will hold the queue's storage forever.
 
+For a partitioned consumer, recover or replace the worker and resume polling
+the same slot. Do not use `unsubscribe_slot` as an alert response: it leaves the
+logical consumer incomplete, removes slot-owned retry/DLQ state, and a later
+repair cannot recover history ticked while the subscription was missing. Use
+controlled teardown/recreation only with the recovery rules in the
+[partition guide](partition-keys.md#incomplete-setup-and-recovery).
+
 ### Threshold table
 
 Frame these relatively — PgQue ships no SLA. Alert on trends across several
@@ -148,6 +189,8 @@ your own tick rate and traffic.
 | ticker lag | `get_queue_info.ticker_lag` | climbs and stays above `ticker_idle_period` (default 1 minute) across intervals | ticker not running → no batches → no delivery |
 | consumer lag | `get_consumer_info.lag` / `pending_events` | `lag` and `pending_events` keep growing across intervals | a consumer is falling behind real-time |
 | stuck consumer | `get_consumer_info.last_seen` + frozen `last_tick` | `last_seen` grows while `last_tick` stays put and the queue's `last_tick_id` advances | pins the lowest tick → blocks `TRUNCATE` rotation → event tables grow unbounded (the critical one) |
+| partition slot | `partition_slot_status` | `subscribed = false`, or one slot's `last_tick` freezes and `pending_events` grows | incomplete/unpolled slot misses its key class or pins queue rotation |
+| lease churn | `partition_slot_status.lease_until` / `epoch` | leases repeatedly expire or epochs climb during ordinary processing | TTL is too short, renewals are not committing, or workers are unstable |
 | DLQ depth | `dlq_inspect` row count / `pgque.dead_letter` | the dead-letter backlog grows or is non-empty when you expect zero | events are exhausting retries; a downstream is failing |
 
 ### Dead-letter depth
@@ -198,6 +241,18 @@ from pgque.get_consumer_info()
 order by last_seen desc nulls last;
 ```
 
+Partitioned slots needing attention:
+
+```sql
+select queue_name, consumer, slot, n, subscribed, lease_owner,
+       lease_until, epoch, last_tick, pending_events
+from pgque.partition_slot_status
+where not subscribed
+   or pending_events > 0
+order by subscribed, pending_events desc nulls first,
+         queue_name, consumer, slot;
+```
+
 Stuck-consumer hunt — join consumer position against the queue's latest tick so
 a frozen `last_tick` stands out against an advancing `last_tick_id`:
 
@@ -226,3 +281,7 @@ order by dlq_depth desc;
 - [Latency and tuning](latency-and-tuning.md) — how `tick_period_ms` and the ticker thresholds trade latency against overhead.
 - [Reference](reference.md) — full signatures, return columns, and role grants.
 - [Examples](examples.md) — DLQ replay, fan-out, and exactly-once patterns.
+- [Partition keys](partition-keys.md) — slot lifecycle, leases, operational
+  limits, and recovery.
+- [Producer idempotency](producer-idempotency.md) — deduplication maintenance
+  and claim-table sizing.

--- a/docs/partition-keys.md
+++ b/docs/partition-keys.md
@@ -1,0 +1,206 @@
+---
+title: Partition keys
+description: Preserve per-key order while scaling a PgQue consumer across leased partition slots.
+---
+
+Partition keys split one logical consumer into a fixed number of hash slots.
+Events with the same non-null key always route to the same slot, so that slot
+preserves their stream order while different slots can be processed in
+parallel.
+
+This is a SQL-first API. The first-party clients do not yet provide partition
+worker helpers, automatic claim loops, or rebalance logic. Applications call
+the functions below through their Postgres driver and own the loop across all
+slots.
+
+## Set up every slot before producing
+
+Create the whole logical consumer atomically:
+
+```sql
+select pgque.create_queue('orders');
+select pgque.subscribe_partitioned(
+  queue_name := 'orders',
+  consumer := 'workers',
+  n := 4
+);
+```
+
+`subscribe_partitioned` pins `n` for `(queue_name, consumer)` and creates all
+`n` engine subscriptions plus their lease rows at one shared starting tick.
+The call is transactional: it creates the complete set or nothing. Repeating
+the call with the same `n` is idempotent and does not reposition any cursor.
+Changing `n` is rejected.
+
+Run this setup before any event that the consumer must see is produced. A
+subscription starts at the latest tick; creating or repairing a slot later
+cannot recover events already covered by earlier ticks.
+
+## Publish keyed events
+
+The four-argument text and JSON `send` overloads accept a partition key:
+
+```sql
+select pgque.send(
+  queue_name := 'orders',
+  type_name := 'order.updated',
+  payload := '{"order_id": 42}'::jsonb,
+  partition_key := 'tenant-7:order-42'
+);
+```
+
+`send_idem` accepts the same optional `partition_key`, so retry-safe publishing
+and per-key ordering compose. See [Producer idempotency](producer-idempotency.md).
+
+For a pinned slot count `n`, PgQue computes the slot as:
+
+```sql
+((hashtextextended(partition_key, 0) % n) + n) % n
+```
+
+The normalization keeps the result in `0..n-1` even when the hash is negative.
+A null partition key routes to slot 0. Keyless `send` overloads therefore
+remain visible to a partitioned consumer, but can concentrate load on slot 0.
+
+Partition keys use the inherited event column `ev_extra1`. They are supported
+for events published through `send` / `send_idem`; PgQue's change-data-capture
+triggers already use `ev_extra1` for the table name and are not a partition-key
+source.
+
+## Claim and process a slot
+
+Each live worker needs a stable, process-instance-unique id. Claim a slot
+before receiving from it:
+
+```sql
+select pgque.claim_slot(
+  queue_name := 'orders',
+  consumer := 'workers',
+  slot := 2,
+  worker := 'orders-worker-7f3c',
+  ttl := interval '30 seconds'
+);
+```
+
+The call returns the slot's fencing epoch when the claim succeeds, or null when
+another live worker owns the slot or its row is busy. A worker claim loop should
+try other slots rather than block on one busy slot. Claiming again as the same
+owner renews the lease without changing the epoch.
+
+Receive and finish work with the same `(queue, consumer, slot, n, worker)`:
+
+```sql
+select *
+from pgque.receive_partitioned(
+  queue_name := 'orders',
+  consumer := 'workers',
+  slot := 2,
+  n := 4,
+  worker := 'orders-worker-7f3c',
+  max_return := 500
+);
+
+-- On a per-message failure, before acknowledging the batch:
+select pgque.nack_partitioned(
+  queue_name := 'orders',
+  consumer := 'workers',
+  slot := 2,
+  n := 4,
+  worker := 'orders-worker-7f3c',
+  msg := :message,
+  retry_after := interval '60 seconds',
+  reason := 'downstream timeout'
+);
+
+select pgque.ack_partitioned(
+  queue_name := 'orders',
+  consumer := 'workers',
+  slot := 2,
+  n := 4,
+  worker := 'orders-worker-7f3c'
+);
+
+select pgque.release_slot(
+  queue_name := 'orders',
+  consumer := 'workers',
+  slot := 2,
+  worker := 'orders-worker-7f3c'
+);
+```
+
+`receive_partitioned`, `nack_partitioned`, and `ack_partitioned` verify the
+lease owner and renew the stored TTL. `release_slot` is optional during normal
+polling and succeeds only for the owner. It is allowed only at a batch boundary:
+ack the open batch first. A crashed worker should not release; expiry is the
+recovery path.
+
+As with normal `receive`, `max_return` limits rows returned, but
+`ack_partitioned` finishes the whole underlying tick batch. Use a value at least
+as large as `ticker_max_count` (500 by default), or otherwise guarantee that
+the full batch was returned, before acknowledging it.
+
+## Lease expiry, renewal, and fencing
+
+The default lease TTL is 30 seconds and the minimum accepted TTL is one second.
+Choose a TTL longer than ordinary batch processing, or renew it by calling
+`claim_slot` again as the same worker in a committed transaction while work is
+still running. Receiving and acknowledging also renew, but a long external
+side effect between those calls can outlive the lease.
+
+After expiry, another worker may take over and the slot epoch increments. The
+old worker is then fenced: its next receive, nack, or ack raises because its
+worker id no longer owns the lease. Make downstream effects idempotent because
+fencing prevents stale queue acknowledgements, not an external request already
+sent before takeover.
+
+Leases are rows updated by normal transactions; there is no advisory lock or
+connection-local state. The API therefore works through transaction-mode
+poolers such as PgBouncer and Supavisor. Do not use a backend PID or pooled
+connection identity as `worker`; use an application process/instance id that
+stays stable across transactions and is unique among live workers.
+
+## Poll every slot and budget for amplification
+
+Slots are independent engine consumers named internally as
+`<consumer>#<slot>/<n>`. Each one advances its own cursor over the full event
+stream and applies the hash filter server-side. This has two operational
+consequences:
+
+- Steady-state reads are approximately `n` times the queue stream, even though
+  each event is returned by only one slot. Choose the smallest `n` that meets
+  the required parallelism.
+- Every subscribed slot must be polled. A stopped slot retains an old cursor,
+  pins table rotation for the queue, and can cause event-table growth even when
+  all other slots are caught up.
+
+An empty `receive_partitioned` result may mean that the current tick window had
+no events for that hash class. PgQue advances that empty filtered window
+automatically; keep polling.
+
+Monitor all expected slots through `pgque.partition_slot_status`; see
+[Monitoring and health](monitoring.md#partitioned-consumers).
+
+## Incomplete setup and recovery
+
+`unsubscribe_slot(queue_name, consumer, slot)` removes one slot. It can leave
+the logical consumer incomplete, and it also removes that engine subscription's
+retry and dead-letter state. Drain and ack work before controlled teardown.
+
+An incomplete consumer is visible as `subscribed = false` in
+`pgque.partition_slot_status`; its `last_tick` and `pending_events` are null
+because its lag is unknowable. `subscribe_partitioned` rejects an incomplete
+existing setup instead of silently moving a cursor.
+
+`subscribe_slot(queue_name, consumer, slot, n)` exists for explicit repair. Use
+it only when you have proved no required events were ticked while the slot was
+missing. If history may have been missed, a late repair cannot reconstruct it:
+replay or compensate from an application source of truth. Unsubscribing every
+remaining slot and calling `subscribe_partitioned` again is safe only before
+new required events are produced; it creates a new cursor at the latest tick.
+
+To change `n`, fully remove the old logical consumer and atomically subscribe a
+new one during a controlled production pause. Repartitioning changes the hash
+mapping, so do not run old and new slot counts as one logical ordered consumer.
+
+For all signatures, defaults, and grants, see the
+[Function reference](reference.md#partitioned-consumers).

--- a/docs/producer-idempotency.md
+++ b/docs/producer-idempotency.md
@@ -1,0 +1,144 @@
+---
+title: Producer idempotency
+description: Safely retry PgQue sends with queue-scoped idempotency keys and bounded deduplication windows.
+---
+
+`pgque.send_idem()` lets a producer retry an enqueue after a timeout or lost
+response without appending the same logical effect twice. The first call
+appends an event and returns its id. Calls with the same queue and idempotency
+key during the live TTL window return that original id without appending.
+
+Producer idempotency prevents duplicate **sends**. It does not change PgQue's
+at-least-once delivery contract, so consumers must still make external side
+effects idempotent or commit database side effects and the batch ack in one
+transaction.
+
+## Send with an idempotency key
+
+The text and JSON overloads have the same named signature:
+
+```text
+pgque.send_idem(queue_name, type_name, payload, idem_key,
+                ttl default '1 hour', partition_key default null)
+```
+
+Use an explicit `::jsonb` cast when you want JSON validation and canonical
+storage:
+
+```sql
+select *
+from pgque.send_idem(
+  queue_name := 'orders',
+  type_name := 'order.created',
+  payload := '{"order_id": 42}'::jsonb,
+  idem_key := 'tenant-7:order-42:create:v1',
+  ttl := interval '24 hours'
+);
+```
+
+The first accepted call returns one row with `deduped = false`. A duplicate
+during the same window returns the first call's `event_id` with
+`deduped = true`:
+
+```text
+ event_id | deduped
+----------+---------
+       17 | f
+
+ event_id | deduped
+----------+---------
+       17 | t
+```
+
+The claim and append happen in the caller's transaction. If the transaction
+rolls back, both roll back, so a failed send never leaves a key claimed without
+an event. Concurrent producers racing on the same key serialize to one append.
+
+## Key and TTL semantics
+
+Deduplication is an exact match on `(queue_name, idem_key)`:
+
+- The same key may be used independently on different queues.
+- PgQue does not compare event type, payload, TTL, or partition key on a
+  duplicate. Reusing a live key with different content still returns the first
+  event id and suppresses the new event.
+- Choose a key for the intended effect, not only the entity. Include the tenant,
+  operation, entity id, and an operation version where appropriate, for example
+  `tenant-7:order-42:capture:v2`.
+- `idem_key` must be non-null. `ttl` must be a positive interval and defaults
+  to one hour.
+- The window starts with the accepted send. Duplicate attempts do not extend
+  it. After expiry, the same key can append a new event and start a new window.
+
+The TTL is a retry-deduplication window, not a rate limiter. Use a new key for a
+new logical effect even when it targets the same entity.
+
+## Compose with partition keys
+
+`partition_key` is optional and independent from deduplication. Supplying it
+routes the accepted event through a partitioned consumer while the idempotency
+key still controls whether the event is appended:
+
+```sql
+select *
+from pgque.send_idem(
+  queue_name := 'orders',
+  type_name := 'order.updated',
+  payload := '{"order_id": 42}'::jsonb,
+  idem_key := 'tenant-7:order-42:update:8',
+  ttl := interval '6 hours',
+  partition_key := 'tenant-7:order-42'
+);
+```
+
+See [Partition keys](partition-keys.md) for the required consumer setup and
+worker loop.
+
+## Maintenance and capacity
+
+The first idempotent send on a queue registers `pgque.maint_idem` as an
+extra-maintenance hook for that queue. A normal `pgque.maint()` schedule removes
+expired rows in bounded batches. Expired keys are also reclaimable by a new
+send immediately; maintenance controls table size, not correctness.
+
+Operators can run cleanup directly:
+
+```sql
+select pgque.maint_idem('orders'); -- one queue
+select pgque.maint_idem();         -- all queues
+```
+
+Both forms return `1` when they deleted a full 10,000-row batch and should be
+called again, otherwise `0`. They require `pgque_admin`; `send_idem` requires
+`pgque_writer`.
+
+Live claim-table size is approximately the idempotent send rate multiplied by
+the TTL. Keep the TTL only as long as producers can legitimately retry, run
+`pgque.maint()` regularly, and monitor unexpectedly long windows or rapid key
+growth.
+
+The claim table is internal and is revoked from application roles, including
+`pgque_admin`. The schema/install owner can inspect aggregate size without
+exposing keys or payloads:
+
+```sql
+select q.queue_name, count(*) as claim_rows,
+       min(i.expires_at) as next_expiry,
+       max(i.expires_at) as last_expiry
+from pgque.idem i
+join pgque.queue q on q.queue_id = i.queue_id
+group by q.queue_name
+order by claim_rows desc;
+```
+
+## Failure checklist
+
+- Treat a lost response as unknown and retry with the **same** key.
+- Treat a new logical effect as new work and use a **new** key.
+- Persist or deterministically derive keys so a process restart does not invent
+  a replacement key for the same effect.
+- Keep producer retries inside the TTL window you selected.
+- Keep consumer handlers idempotent; producer deduplication cannot fence an
+  external side effect after consumer redelivery.
+
+For exact overloads and grants, see the [Function reference](reference.md#producer-idempotency).

--- a/docs/producer-idempotency.md
+++ b/docs/producer-idempotency.md
@@ -65,8 +65,8 @@ Deduplication is an exact match on `(queue_name, idem_key)`:
 - Choose a key for the intended effect, not only the entity. Include the tenant,
   operation, entity id, and an operation version where appropriate, for example
   `tenant-7:order-42:capture:v2`.
-- `idem_key` must be non-null. `ttl` must be a positive interval and defaults
-  to one hour.
+- `idem_key` must be non-null. `ttl` must be a positive finite interval and
+  defaults to one hour.
 - The window starts with the accepted send. Duplicate attempts do not extend
   it. After expiry, the same key can append a new event and start a new window.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,9 +1,15 @@
 ---
 title: Function reference
-description: Every function and type in the default PgQue install — signature, return type, behavior, and role grant.
+description: Public functions, views, and types in PgQue's in-development default install — signatures, behavior, and role grants.
 ---
 
-Every function shipped in the default install (`\i sql/pgque.sql`). Each entry lists the signature, return type, the role it is granted to, and the source file. A short code example appears where the signature alone leaves the call ambiguous.
+This is the public API reference for the in-development default install
+(`\i devel/sql/pgque.sql`). It follows the SQL on `main`; stable users should
+use the reference at the [latest stable release](https://github.com/NikolayS/pgque/releases/latest).
+Each entry lists the signature, return type, role grant, and development source.
+At release promotion, those source links are pinned to the release tag and
+switched from `devel/sql/` to `sql/` as defined in the
+[documentation contract](README.md).
 
 If you are new to PgQue, start with [tutorial.md](tutorial.md) — it walks the end-to-end `send` / `receive` / `ack` loop. For task-oriented patterns see [examples.md](examples.md), and for tick-rate and delivery-latency tuning see [latency-and-tuning.md](latency-and-tuning.md). Use this page as the lookup table.
 
@@ -16,7 +22,8 @@ Each entry takes this form:
 One-line description. Optional second line with a caveat.
 Grant: `role_name`. Source: `sql/<path>`.
 
-Functions shipped outside the default install are in the [Experimental](#experimental-not-in-default-install) section.
+Functions shipped outside this development install are in the
+[Experimental](#experimental-not-in-default-install) section.
 
 ## Publishing
 
@@ -32,6 +39,9 @@ Argument names are part of the SQL API because Postgres supports named calls (`a
 | `type_name` | `text` | Application event type stored in `ev_type` (`'default'` for 2-arg `send`). Free-form text such as `order.created`; this is not a Postgres type. |
 | `payload` | `text` or `jsonb` | Single event payload. `text` is opaque/verbatim; `jsonb` validates and stores canonical JSON text. |
 | `payloads` | `text[]` or `jsonb[]` | Batch payload array. Result array positions correspond to input positions. |
+| `partition_key` | `text` | Optional routing key for a partitioned consumer. Equal non-null keys route to the same slot; null routes to slot 0. |
+| `idem_key` | `text` | Queue-scoped producer idempotency key for one logical effect. |
+| `ttl` | `interval` | Positive deduplication window for `send_idem`; defaults to one hour. |
 
 Available publishing overloads:
 
@@ -39,6 +49,8 @@ Available publishing overloads:
 |----------|--------------|--------|
 | `send(queue_name, payload)` | `text` or `jsonb` | `bigint` event id |
 | `send(queue_name, type_name, payload)` | `text` or `jsonb` | `bigint` event id |
+| `send(queue_name, type_name, payload, partition_key)` | `text` or `jsonb` | `bigint` event id |
+| `send_idem(queue_name, type_name, payload, idem_key [, ttl [, partition_key]])` | `text` or `jsonb` | one `(event_id bigint, deduped boolean)` row |
 | `send_batch(queue_name, payloads)` | `text[]` or `jsonb[]` | `bigint[]` event ids, event type `'default'` |
 | `send_batch(queue_name, type_name, payloads)` | `text[]` or `jsonb[]` | `bigint[]` event ids |
 
@@ -73,6 +85,19 @@ select pgque.send('orders', 'order.created', '{"order_id": 42}'::jsonb);
 
 Fast-path send with explicit event type. Returns the event id.
 Grant: `pgque_writer`. Source: [`devel/sql/pgque-api/send.sql`](https://github.com/NikolayS/pgque/blob/main/devel/sql/pgque-api/send.sql).
+
+#### `pgque.send(queue_name text, type_name text, payload jsonb, partition_key text) → bigint`
+
+Keyed JSON send. Stores `partition_key` in `extra1`; partitioned consumers hash
+it to a slot. Equal non-null keys with the same pinned slot count route to the
+same ordered slot. Grant: `pgque_writer`. Source:
+[`devel/sql/pgque-api/partition_keys.sql`](https://github.com/NikolayS/pgque/blob/main/devel/sql/pgque-api/partition_keys.sql).
+
+#### `pgque.send(queue_name text, type_name text, payload text, partition_key text) → bigint`
+
+Keyed text fast path. Payload bytes are stored verbatim; routing is identical to
+the JSON overload. Grant: `pgque_writer`. Source:
+[`devel/sql/pgque-api/partition_keys.sql`](https://github.com/NikolayS/pgque/blob/main/devel/sql/pgque-api/partition_keys.sql).
 
 #### `pgque.send_batch(queue_name text, payloads jsonb[]) → bigint[]`
 
@@ -111,13 +136,50 @@ Grant: `pgque_writer`. Source: [`devel/sql/pgque-api/send.sql`](https://github.c
 **Not directly callable by API roles.** Internal set-based primitive used by `send_batch`: resolves the queue/table once, allocates ids from the queue sequence, inserts all payloads with one `INSERT … SELECT`, and returns ids aligned to input order. It is `SECURITY DEFINER` so the public wrappers can use it, but EXECUTE is revoked from public API roles (including `pgque_admin`) to keep callers on the stable `send_batch` surface. The schema owner/superuser can still call it for install/debug work.
 Grant: none (internal). Source: [`devel/sql/pgque-api/send.sql`](https://github.com/NikolayS/pgque/blob/main/devel/sql/pgque-api/send.sql).
 
+## Producer idempotency
+
+Deduplication is an exact match on `(queue_name, idem_key)` for a bounded TTL
+window. It suppresses duplicate producer appends, not consumer redelivery. The
+first accepted send returns its new event id with `deduped = false`; another
+call with the same live key returns that original id with `deduped = true`,
+without comparing or replacing the payload. Duplicate calls do not extend the
+window. See the [producer-idempotency guide](producer-idempotency.md) for key
+design, transaction behavior, and capacity planning.
+
+#### `pgque.send_idem(queue_name text, type_name text, payload jsonb, idem_key text, ttl interval default '1 hour', partition_key text default null) → table(event_id bigint, deduped boolean)`
+
+JSON producer-idempotency send. `idem_key` must be non-null and `ttl` must be
+positive. `partition_key` composes with partition routing when supplied. Grant:
+`pgque_writer`. Source:
+[`devel/sql/pgque-api/send_idem.sql`](https://github.com/NikolayS/pgque/blob/main/devel/sql/pgque-api/send_idem.sql).
+
+#### `pgque.send_idem(queue_name text, type_name text, payload text, idem_key text, ttl interval default '1 hour', partition_key text default null) → table(event_id bigint, deduped boolean)`
+
+Text fast path with the same deduplication contract. Untyped string literals
+resolve to this overload. Grant: `pgque_writer`. Source:
+[`devel/sql/pgque-api/send_idem.sql`](https://github.com/NikolayS/pgque/blob/main/devel/sql/pgque-api/send_idem.sql).
+
+#### `pgque.maint_idem(queue_name text) → integer`
+
+Deletes up to 10,000 expired claims for one queue. Returns `1` when the batch
+was full and another pass is requested, otherwise `0`. `send_idem` registers
+this form as a queue extra-maintenance hook automatically. Grant:
+`pgque_admin`. Source:
+[`devel/sql/pgque-api/send_idem.sql`](https://github.com/NikolayS/pgque/blob/main/devel/sql/pgque-api/send_idem.sql).
+
+#### `pgque.maint_idem() → integer`
+
+Same bounded cleanup across all queues, for direct operator scheduling. Grant:
+`pgque_admin`. Source:
+[`devel/sql/pgque-api/send_idem.sql`](https://github.com/NikolayS/pgque/blob/main/devel/sql/pgque-api/send_idem.sql).
+
 ## Consuming
 
 The consume API wraps `pgque.next_batch`, `pgque.get_batch_events`, `pgque.finish_batch`, and `pgque.event_retry`. Typical loop: `receive` → process → `ack` (or `nack` on failure).
 
 All consume-side functions (`receive`, `ack`, `nack`, `subscribe`, `unsubscribe`) are granted to `pgque_reader`, mirroring upstream PgQ's producer/consumer role split. Apps that both produce and consume must hold both `pgque_reader` and `pgque_writer` — `pgque_writer` does not inherit `pgque_reader`.
 
-<a id="snapshot-rule"></a>**Snapshot rule.** `pgque.send` → `pgque.ticker` → `pgque.receive` must each run in its own committed transaction (the ticker's snapshot must be taken after `send` commits; `receive` only sees what committed before it). Same for `pgque.maint_retry_events` → `pgque.ticker` → `pgque.receive`. Each call must be its own committed transaction; never wrap producer and consumer calls together in one transaction. See [concepts.md#snapshot-rule](concepts.md#snapshot-rule).
+<a id="snapshot-rule"></a>**Snapshot rule.** `pgque.send` → `pgque.ticker` → `pgque.receive` must each run in its own committed transaction (the ticker's snapshot must be taken after `send` commits; `receive` only sees what committed before it). Same for `pgque.maint_retry_events` → `pgque.ticker` → `pgque.receive`. Each call must be its own committed transaction; never wrap producer and consumer calls together in one transaction. See [concepts.md#the-snapshot-rule](concepts.md#the-snapshot-rule).
 
 #### `pgque.receive(queue text, consumer text, max_return int default 100) → setof pgque.message`
 
@@ -148,9 +210,107 @@ Grant: `pgque_reader`. Source: [`devel/sql/pgque-api/receive.sql`](https://githu
 perform pgque.nack(msg.batch_id, msg, interval '5 minutes', 'validation failed');
 ```
 
+## Partitioned consumers
+
+Partitioned consumers preserve per-key order while different hash slots run in
+parallel. Every slot is an independent PgQ subscription and must be polled; it
+scans the full stream with a server-side hash filter, producing approximately
+`n` times read amplification. Slot leases are transactional rows, so the API
+works with transaction-mode poolers. The first-party clients do not yet wrap
+this API. Start with the [partition-keys guide](partition-keys.md) for the
+worker loop, fencing, monitoring, and recovery rules.
+
+#### `pgque.subscribe_partitioned(queue_name text, consumer text, n int) → void`
+
+Atomically pins `n` and creates all slots `0..n-1` at one shared starting tick.
+Repeating a complete setup with the same `n` is idempotent and does not move
+cursors. An existing incomplete setup or a different `n` raises. Call before
+producing any events this consumer must see. Grant: `pgque_reader`. Source:
+[`devel/sql/pgque-api/partition_keys.sql`](https://github.com/NikolayS/pgque/blob/main/devel/sql/pgque-api/partition_keys.sql).
+
+#### `pgque.subscribe_slot(queue_name text, consumer text, slot int, n int) → void`
+
+Repairs or explicitly creates one slot after validating the pinned `n`. This is
+not the normal setup path: a late slot begins at the latest tick and cannot
+recover already-ticked history. Grant: `pgque_reader`. Source:
+[`devel/sql/pgque-api/partition_keys.sql`](https://github.com/NikolayS/pgque/blob/main/devel/sql/pgque-api/partition_keys.sql).
+
+#### `pgque.unsubscribe_slot(queue_name text, consumer text, slot int) → void`
+
+Removes one engine subscription and lease row. This may leave the logical
+consumer incomplete and removes retry/dead-letter state owned by that slot.
+Removing the final remaining subscription also removes the pinned-`n` row.
+Grant: `pgque_reader`. Source:
+[`devel/sql/pgque-api/partition_keys.sql`](https://github.com/NikolayS/pgque/blob/main/devel/sql/pgque-api/partition_keys.sql).
+
+#### `pgque.claim_slot(queue_name text, consumer text, slot int, worker text, ttl interval default '30 seconds') → bigint`
+
+Claims a free/expired slot or renews the same worker's lease. Returns the
+current fencing epoch on success and null when another live owner holds the
+slot or its row is busy. `worker` must be non-empty and unique per live worker;
+`ttl` must be finite and at least one second. A takeover increments the epoch.
+Grant: `pgque_reader`. Source:
+[`devel/sql/pgque-api/partition_keys.sql`](https://github.com/NikolayS/pgque/blob/main/devel/sql/pgque-api/partition_keys.sql).
+
+#### `pgque.release_slot(queue_name text, consumer text, slot int, worker text) → boolean`
+
+Clears the lease at a batch boundary. Returns true only for the current owner,
+false for a non-owner/unleased slot, and raises if the owner still has an open
+batch. Crash recovery uses lease expiry instead. Grant: `pgque_reader`. Source:
+[`devel/sql/pgque-api/partition_keys.sql`](https://github.com/NikolayS/pgque/blob/main/devel/sql/pgque-api/partition_keys.sql).
+
+#### `pgque.receive_partitioned(queue_name text, consumer text, slot int, n int, worker text, max_return int default 100) → setof pgque.message`
+
+Validates the pinned `n`, fences and renews the lease, then returns the current
+batch's events whose normalized `hashtextextended(partition_key, 0)` maps to
+`slot`; null keys map to slot 0. Empty filtered batches are finished
+automatically. As with `receive`, `max_return` limits returned rows while
+`ack_partitioned` finishes the whole underlying batch, so use
+`max_return >= ticker_max_count` unless the full batch is otherwise guaranteed.
+Grant: `pgque_reader`. Source:
+[`devel/sql/pgque-api/partition_keys.sql`](https://github.com/NikolayS/pgque/blob/main/devel/sql/pgque-api/partition_keys.sql).
+
+#### `pgque.ack_partitioned(queue_name text, consumer text, slot int, n int, worker text) → integer`
+
+Fences and renews the owner, then finishes the slot's open batch. Returns `1`
+when a batch was finished and `0` when none was open. Grant: `pgque_reader`.
+Source: [`devel/sql/pgque-api/partition_keys.sql`](https://github.com/NikolayS/pgque/blob/main/devel/sql/pgque-api/partition_keys.sql).
+
+#### `pgque.nack_partitioned(queue_name text, consumer text, slot int, n int, worker text, msg pgque.message, retry_after interval default '60 seconds', reason text default null) → integer`
+
+Lease-fenced per-message retry/DLQ operation for a partitioned batch. Retried
+events retain their partition key and return to the same slot. Raises when the
+slot has no open batch. Grant: `pgque_reader`. Source:
+[`devel/sql/pgque-api/partition_keys.sql`](https://github.com/NikolayS/pgque/blob/main/devel/sql/pgque-api/partition_keys.sql).
+
+### `pgque.partition_slot_status` view
+
+One row for every expected slot, including missing subscriptions. Columns:
+
+| Column | Type | Meaning |
+|---|---|---|
+| `queue_name` | `text` | Queue name. |
+| `consumer` | `text` | Logical partitioned consumer. |
+| `slot` | `integer` | Slot number in `0..n-1`. |
+| `n` | `integer` | Pinned slot count. |
+| `subscribed` | `boolean` | Whether the engine subscription exists. |
+| `lease_owner` | `text` | Current live owner; null when free or expired. |
+| `lease_until` | `timestamptz` | Stored lease expiry, including an expired lease. |
+| `epoch` | `bigint` | Monotonic fencing epoch. |
+| `last_tick` | `bigint` | Slot cursor; null when unsubscribed. |
+| `pending_events` | `bigint` | Pre-filter event-sequence lag; null when unsubscribed. |
+
+`pending_events` over-counts one slot's routed share by approximately `n`, but
+zero means caught up exactly and sustained growth identifies a stalled slot.
+Grant: `select` to `pgque_reader` and `pgque_admin`. Source:
+[`devel/sql/pgque-api/partition_keys.sql`](https://github.com/NikolayS/pgque/blob/main/devel/sql/pgque-api/partition_keys.sql).
+
 ## Cooperative consumers / subconsumers
 
-> **Experimental in PgQue 0.2.** Function names, edge-case behavior, and client API shape may change before this feature is marked stable. Do not use this as the only processing path for critical workloads without idempotent handlers and stale-worker takeover tests.
+> **Experimental.** Function names, edge-case behavior, and client API shape
+> may change before this feature is marked stable. Do not use this as the only
+> processing path for critical workloads without idempotent handlers and
+> stale-worker takeover tests.
 
 For a usage walkthrough see the [cooperative-consumers recipe](examples.md#cooperative-consumers--subconsumers-experimental); for when to choose it over fan-out see [concepts](concepts.md#cooperative-consumers-vs-fan-out).
 
@@ -604,8 +764,14 @@ PgQue roles are coarse **database-level** roles. They are intended for trusted a
 
 **What this means in practice:**
 
-- `pgque_reader` gets `select` on **all** tables in the `pgque` schema — it can read events from any queue. It can also call `receive`, `ack`, and `nack` on **any** queue with **any** consumer name. A reader granted for queue A can call `pgque.ack(batch_id)` on a batch opened by a consumer on queue B.
-- `pgque_writer` can produce to **any** queue (`pgque.send`, `pgque.send_batch`, `pgque.insert_event`).
+- `pgque_reader` gets `select` on the public engine and status tables in the
+  `pgque` schema (internal idempotency and partition lease tables are revoked;
+  use `partition_slot_status`). It can call `receive`, `ack`, `nack`, and the
+  partitioned consume API on **any** queue with **any** consumer name. A reader
+  granted for queue A can call `pgque.ack(batch_id)` on a batch opened by a
+  consumer on queue B.
+- `pgque_writer` can produce to **any** queue (`pgque.send`,
+  `pgque.send_idem`, `pgque.send_batch`, `pgque.insert_event`).
 - There is **no per-queue ACL** and no per-tenant isolation built into PgQue. Queue names and consumer names are plain strings — any role with the matching grant can interact with them.
 
 This is intentional, by design. The batch-ID-based primitives (`ack`, `nack`, `event_retry`) operate on IDs and do not enforce ownership; the producer/consumer split closes only the producer-vs-consumer boundary, not the consumer-vs-consumer one.
@@ -616,11 +782,11 @@ This is intentional, by design. The batch-ID-based primitives (`ack`, `nack`, `e
 - Use separate databases per tenant and connect each tenant's application to its own database.
 - Wrap the PgQue API in app-owned stored functions that enforce tenant ownership before delegating to `pgque.*`, and grant only those wrapper functions to tenant roles.
 
-| Role           | Functions granted (direct)                                                                                                                                                                                                                                              |
-|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `pgque_reader` | `get_queue_info()`, `get_queue_info(text)`, `get_consumer_info()`, `get_consumer_info(text)`, `get_consumer_info(text, text)`, `get_batch_info(bigint)`, `version()`, `dlq_inspect(text, int)`; `select` on all tables incl. `pgque.dead_letter`; consumer primitives (`register_consumer`, `register_consumer_at`, `unregister_consumer`, `next_batch`, `next_batch_info`, `next_batch_custom`, `get_batch_events`, `finish_batch`, `event_retry` int + timestamptz); modern consume API (`subscribe`, `unsubscribe`, `receive`, `ack`, `nack`); experimental cooperative API (`register_subconsumer`, `unregister_subconsumer`, `subscribe_subconsumer`, `unsubscribe_subconsumer`, cooperative `next_batch`, cooperative `next_batch_custom`, `receive_coop`, `touch_subconsumer`)                        |
-| `pgque_writer` | `insert_event` (3, 7), all `send*`, all `send_batch*`, `dlq_replay`, `dlq_replay_all`. **Does not inherit `pgque_reader`** — a producer-only role cannot ack/finish/inspect consumer batches. |
-| `pgque_admin`  | Member of both `pgque_reader` and `pgque_writer`, plus `event_dead`, `dlq_purge`, `all` on `pgque` schema, `all` on all tables and sequences, `execute` on all functions — **except** `uninstall()` and internal `insert_event_bulk()` which are explicitly revoked                                                            |
+| Role | Functions granted directly |
+|---|---|
+| `pgque_reader` | Read-only info functions and public tables/views; normal consume API; partition setup, lease, consume API and `partition_slot_status`; consumer primitives; experimental cooperative API. Internal partition/lease tables and `pgque.idem` are not directly readable. |
+| `pgque_writer` | `insert_event` overloads, all `send` / `send_idem` / `send_batch` overloads, `dlq_replay`, and `dlq_replay_all`. **Does not inherit `pgque_reader`** — a producer-only role cannot ack, finish, or inspect consumer batches. |
+| `pgque_admin` | Member of both reader and writer, plus lifecycle, maintenance including `maint_idem`, DDL, DLQ administration, schema/table/sequence administration, and internal helpers — except `uninstall()` and `insert_event_bulk()`, which are explicitly revoked. Direct access to `pgque.idem` is also revoked. |
 
 `pgque.uninstall()` is revoked from both `pgque_admin` (explicitly) and PUBLIC (via the schema-wide blanket revoke). Internal `pgque.insert_event_bulk()` is also revoked from `pgque_admin`; callers must use `send_batch()` wrappers. Only the schema/install owner (typically a superuser) can run `uninstall()` or the internal primitive directly. All other functions not listed in the table above retain `execute` only for `pgque_admin` (the schema-wide blanket revoke from PUBLIC applies, and `pgque_admin` is granted `execute on all functions`) — notably the lifecycle helpers `start`, `stop`, `status`, `maint`, `maint_retry_events`, `ticker`, `force_next_tick` (and its alias `force_tick`), and the queue-management helpers `create_queue`, `drop_queue`, `set_queue_config`. Grant these explicitly to additional roles if your policy demands it.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -148,9 +148,9 @@ design, transaction behavior, and capacity planning.
 
 #### `pgque.send_idem(queue_name text, type_name text, payload jsonb, idem_key text, ttl interval default '1 hour', partition_key text default null) → table(event_id bigint, deduped boolean)`
 
-JSON producer-idempotency send. `idem_key` must be non-null and `ttl` must be
-positive. `partition_key` composes with partition routing when supplied. Grant:
-`pgque_writer`. Source:
+JSON producer-idempotency send. `idem_key` must be non-null. `ttl` must be a
+positive finite interval. `partition_key` composes with partition routing when
+supplied. Grant: `pgque_writer`. Source:
 [`devel/sql/pgque-api/send_idem.sql`](https://github.com/NikolayS/pgque/blob/main/devel/sql/pgque-api/send_idem.sql).
 
 #### `pgque.send_idem(queue_name text, type_name text, payload text, idem_key text, ttl interval default '1 hour', partition_key text default null) → table(event_id bigint, deduped boolean)`

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,17 +1,26 @@
 ---
 title: Tutorial
-description: A hands-on PgQue walkthrough — install, send, tick, receive, retry, dead-letter, and health checks, end to end.
+description: A hands-on PgQue walkthrough — install, send, receive, retry, dead-letter, idempotency, partition keys, and health checks.
 ---
 
-A guided, hands-on walkthrough. With `psql` access to a Postgres 14+ database and about ten minutes, you can follow every step end to end. You will type SQL, see what comes back, and build an intuition for how PgQue moves messages through an order-processing queue.
+A guided, hands-on walkthrough. With `psql` access to a Postgres 14+ database
+and about fifteen minutes, you can follow every step end to end. You will type
+SQL, see what comes back, and build an intuition for how PgQue moves messages
+through an order-processing queue.
 
-By the end you will have a working `orders` queue with a `processor` consumer, a happy-path delivery, a retry that reappears after a delay, a message driven all the way to the dead-letter queue, and a health check.
+By the end you will have a working `orders` queue with a `processor` consumer,
+a happy-path delivery, a retry that reappears after a delay, a message driven
+all the way to the dead-letter queue, a health check, and a retry-safe keyed
+event consumed through a leased partition slot.
 
 Prerequisites: Postgres 14 or newer, a database to install into, and `psql` (the tutorial uses `\i` and `\gset`, which are psql meta-commands). `pg_cron` is recommended for production but not required here — this tutorial drives the ticker by hand, so it works on any managed or self-managed Postgres.
 
 Each step shows the exact SQL and the expected output. Your `msg_id` / `batch_id` / `ev_new` numbers will differ from the examples — each `pgque.force_next_tick` call advances the event sequence by a large amount, so exact numeric output depends on when you call it. Treat the numbers as illustrative. Where transaction boundaries matter — and they matter, because PgQue is snapshot-based — the text calls that out.
 
-For reproducible output, run psql with `--no-psqlrc` and `PAGER=cat`. Start from the cloned repo so `\i sql/pgque.sql` resolves:
+For reproducible output, run psql with `--no-psqlrc` and `PAGER=cat`. This
+tutorial follows the `main` branch development build; start from the cloned
+repo so `\i devel/sql/pgque.sql` resolves. For the stable build, use the
+[latest release's tagged tutorial](https://github.com/NikolayS/pgque/releases/latest).
 
 ```bash
 cd /path/to/pgque
@@ -26,7 +35,7 @@ PgQue is a single SQL file. Install it inside a transaction so a failure leaves 
 
 ```sql
 begin;
-\i sql/pgque.sql
+\i devel/sql/pgque.sql
 commit;
 ```
 
@@ -37,13 +46,17 @@ select pgque.version();
 ```
 
 ```
-   version
--------------
- 0.2.0
+ version
+---------
+ <installed development version>
 (1 row)
 ```
 
-The install creates the `pgque` schema, three roles (`pgque_reader`, `pgque_writer`, `pgque_admin`), and every function you call in the rest of this tutorial. The roles are siblings, not parent and child: `pgque_writer` produces (`send`, `send_batch`); `pgque_reader` consumes (`subscribe`, `receive`, `ack`, `nack`); `pgque_admin` is a member of both.
+The install creates the `pgque` schema, three roles (`pgque_reader`,
+`pgque_writer`, `pgque_admin`), and every function you call in the rest of this
+tutorial. The roles are siblings, not parent and child: `pgque_writer` produces
+(`send`, `send_idem`, `send_batch`); `pgque_reader` owns the normal and
+partitioned consume APIs; `pgque_admin` is a member of both.
 
 Following along as the install owner needs no extra grants — skip the next snippet. In production you grant the roles to your own app roles. An app that both produces and consumes needs both roles:
 
@@ -342,7 +355,7 @@ select * from pgque.status();
  component    | status      | detail
 --------------+-------------+----------------------------------------------------------
  postgresql   | info        | PostgreSQL 17.2 on ...
- pgque        | info        | 0.2.0
+ pgque        | info        | <installed development version>
  scheduler    | manual      | ticker_job_id=NULL, maint_job_id=NULL, tick_period_ms=100 (10.00 ticks/sec)
  ticker       | stopped     | not scheduled (tick_period_ms=100)
  maintenance  | stopped     | not scheduled
@@ -354,6 +367,117 @@ select * from pgque.status();
 ```
 
 `status()` is the one-stop health check. Here it reflects manual ticking: with no scheduler, the `scheduler` row reads `manual` and the `ticker`/`maintenance` rows read `stopped`. With `pg_cron` installed and `pgque.start()` run, the `scheduler` row would show `pg_cron` with job ids and the ticker/maintenance rows would flip to `scheduled`.
+
+## Step 10: Try retry-safe keyed publishing
+
+The basic consumer above sees the whole stream. This final exercise combines
+the two SQL-first scaling features: producer idempotency prevents a retry from
+appending twice, while a partition key routes the accepted event to one leased
+slot and preserves order for that key.
+
+Create every slot before producing. The atomic setup gives all four slots the
+same starting tick:
+
+```sql
+select pgque.create_queue('keyed_orders');
+select pgque.subscribe_partitioned(
+  queue_name := 'keyed_orders',
+  consumer := 'workers',
+  n := 4
+);
+```
+
+Send the same logical effect twice with the same idempotency key:
+
+```sql
+select * from pgque.send_idem(
+  queue_name := 'keyed_orders',
+  type_name := 'order.created',
+  payload := '{"order_id": 99}'::jsonb,
+  idem_key := 'tutorial:order-99:create:v1',
+  ttl := interval '1 hour',
+  partition_key := 'customer-42'
+);
+
+select * from pgque.send_idem(
+  queue_name := 'keyed_orders',
+  type_name := 'order.created',
+  payload := '{"order_id": 99}'::jsonb,
+  idem_key := 'tutorial:order-99:create:v1',
+  ttl := interval '1 hour',
+  partition_key := 'customer-42'
+);
+```
+
+The first row has `deduped = false`; the second has `deduped = true` and the
+same `event_id`. The TTL is a deduplication window for this effect, not a rate
+limit. Different work needs a different key.
+
+Calculate the destination slot, claim it with a process-instance worker id,
+then tick and receive. These are still separate psql autocommit transactions:
+
+```sql
+select ((hashtextextended('customer-42', 0) % 4 + 4) % 4)::int as customer_slot \gset
+
+select pgque.claim_slot(
+  queue_name := 'keyed_orders',
+  consumer := 'workers',
+  slot := :customer_slot,
+  worker := 'tutorial-worker',
+  ttl := interval '2 minutes'
+);
+
+select pgque.force_next_tick('keyed_orders');
+select pgque.ticker();
+
+select msg_id, batch_id, type, payload, extra1 as partition_key
+from pgque.receive_partitioned(
+  queue_name := 'keyed_orders',
+  consumer := 'workers',
+  slot := :customer_slot,
+  n := 4,
+  worker := 'tutorial-worker',
+  max_return := 500
+);
+```
+
+One row returns, not two. Capture and ack the same batch, then release the slot
+at the batch boundary:
+
+```sql
+select batch_id
+from pgque.receive_partitioned(
+  queue_name := 'keyed_orders',
+  consumer := 'workers',
+  slot := :customer_slot,
+  n := 4,
+  worker := 'tutorial-worker',
+  max_return := 500
+)
+limit 1 \gset
+
+select pgque.ack_partitioned(
+  queue_name := 'keyed_orders',
+  consumer := 'workers',
+  slot := :customer_slot,
+  n := 4,
+  worker := 'tutorial-worker'
+);
+
+select pgque.release_slot(
+  queue_name := 'keyed_orders',
+  consumer := 'workers',
+  slot := :customer_slot,
+  worker := 'tutorial-worker'
+);
+```
+
+Production workers repeat that lifecycle across **every** slot. A stopped slot
+pins rotation, and each slot scans the full stream, so four slots mean roughly
+four times the reads. Leases use transactional rows and work through
+transaction-mode poolers, but the first-party clients do not yet implement the
+claim/rebalance loop. See [Partition keys](partition-keys.md) and
+[Producer idempotency](producer-idempotency.md) before deploying this pattern.
 
 ## Where to go from here
 
@@ -371,7 +495,12 @@ Next:
 
 - [Installation & operations](installation.md) — `pg_cron` setup, the production ticker cadence, roles, and teardown.
 - [Latency & tick tuning](latency-and-tuning.md) — how `tick_period_ms` trades latency against overhead.
-- [Reference](reference.md) — every function with signatures, return types, and role grants.
+- [Reference](reference.md) — public SQL signatures, return types, behavior,
+  and role grants.
 - [Examples](examples.md) — patterns: fan-out, exactly-once consumption, batch loading, recurring jobs.
 - [Concepts](concepts.md) — glossary of event, batch, tick, rotation, and the consumer loop.
 - [Monitoring](monitoring.md) — health metrics and what to alert on.
+- [Producer idempotency](producer-idempotency.md) — key scope, TTL behavior,
+  maintenance, and failure handling.
+- [Partition keys](partition-keys.md) — worker leases, fencing, poolers,
+  monitoring, read amplification, and recovery.

--- a/tests/test_docs_contract.sh
+++ b/tests/test_docs_contract.sh
@@ -30,6 +30,7 @@ write_development_fixture() {
     'This is the public API reference for the in-development default install' \
     'https://github.com/NikolayS/pgque/blob/main/devel/sql/pgque.sql' \
     > "${root}/docs/reference.md"
+  # shellcheck disable=SC2016 # Fixture contains literal Markdown backticks.
   printf '%s\n' \
     'tutorial follows the `main` branch development build' \
     '\i devel/sql/pgque.sql' > "${root}/docs/tutorial.md"
@@ -79,6 +80,7 @@ main() {
   fi
 
   mkdir "${workdir}/bin"
+  # shellcheck disable=SC2016 # Stub receives positional parameters later.
   printf '%s\n' \
     '#!/usr/bin/env bash' \
     'if [[ "${1:-}" == -RFn ]]; then exit 2; fi' \

--- a/tests/test_docs_contract.sh
+++ b/tests/test_docs_contract.sh
@@ -53,12 +53,24 @@ write_stable_fixture() {
   printf '%s\n' '\\i sql/pgque.sql' > "${root}/web/src/pages/index.astro"
 }
 
+assert_finite_ttl_wording() {
+  local file
+
+  for file in docs/reference.md docs/producer-idempotency.md; do
+    if ! grep -Fq 'positive finite interval' "${file}"; then
+      echo "FAIL: ${file} must document a positive finite TTL interval" >&2
+      exit 1
+    fi
+  done
+}
+
 main() {
   local development_root
   local stable_root
   local output
 
   cd "${repo_root}"
+  assert_finite_ttl_wording
   workdir="$(mktemp -d)"
   trap cleanup EXIT
 

--- a/tests/test_docs_contract.sh
+++ b/tests/test_docs_contract.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+# Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+# Exercise both documentation channels and fail-closed scan behavior.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+workdir=
+
+cleanup() {
+  if [[ -n "${workdir}" ]]; then
+    rm -rf -- "${workdir}"
+  fi
+}
+
+write_development_fixture() {
+  local root="${1}"
+
+  mkdir -p "${root}/docs" "${root}/web/src/pages"
+  printf '%s\n' development > "${root}/docs/.release-channel"
+  printf '%s\n' \
+    'Development documentation:' \
+    '\i devel/sql/pgque.sql' > "${root}/README.md"
+  printf '%s\n' 'Build contract.' > "${root}/docs/README.md"
+  printf '%s\n' \
+    "This page follows the \`main\` branch's in-development build" \
+    '\i devel/sql/pgque.sql' > "${root}/docs/installation.md"
+  printf '%s\n' \
+    'This is the public API reference for the in-development default install' \
+    'https://github.com/NikolayS/pgque/blob/main/devel/sql/pgque.sql' \
+    > "${root}/docs/reference.md"
+  printf '%s\n' \
+    'tutorial follows the `main` branch development build' \
+    '\i devel/sql/pgque.sql' > "${root}/docs/tutorial.md"
+  printf '%s\n' '\\i devel/sql/pgque.sql' \
+    > "${root}/web/src/pages/index.astro"
+}
+
+write_stable_fixture() {
+  local root="${1}"
+
+  mkdir -p "${root}/docs" "${root}/web/src/pages"
+  printf '%s\n' 'stable:v1.2.3' > "${root}/docs/.release-channel"
+  printf '%s\n' '\i sql/pgque.sql' > "${root}/README.md"
+  : > "${root}/docs/README.md"
+  printf '%s\n' '\i sql/pgque.sql' > "${root}/docs/installation.md"
+  printf '%s\n' \
+    'https://github.com/NikolayS/pgque/blob/v1.2.3/sql/pgque.sql' \
+    > "${root}/docs/reference.md"
+  printf '%s\n' '\i sql/pgque.sql' > "${root}/docs/tutorial.md"
+  printf '%s\n' '\\i sql/pgque.sql' > "${root}/web/src/pages/index.astro"
+}
+
+main() {
+  local development_root
+  local stable_root
+  local output
+
+  cd "${repo_root}"
+  workdir="$(mktemp -d)"
+  trap cleanup EXIT
+
+  development_root="${workdir}/development"
+  write_development_fixture "${development_root}"
+  PGQUE_DOCS_ROOT="${development_root}" \
+    bash build/check-docs-contract.sh >/dev/null
+
+  stable_root="${workdir}/stable"
+  write_stable_fixture "${stable_root}"
+  PGQUE_DOCS_ROOT="${stable_root}" \
+    bash build/check-docs-contract.sh >/dev/null
+
+  printf '%s\n' 'devel/sql/pgque.sql' >> "${stable_root}/README.md"
+  if PGQUE_DOCS_ROOT="${stable_root}" \
+    bash build/check-docs-contract.sh >/dev/null 2>&1; then
+    echo "FAIL: stable contract accepted a development path" >&2
+    exit 1
+  fi
+
+  mkdir "${workdir}/bin"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'if [[ "${1:-}" == -RFn ]]; then exit 2; fi' \
+    'exec /usr/bin/grep "$@"' > "${workdir}/bin/grep"
+  chmod +x "${workdir}/bin/grep"
+  if output=$(PATH="${workdir}/bin:${PATH}" \
+    PGQUE_DOCS_ROOT="${development_root}" \
+    bash build/check-docs-contract.sh 2>&1); then
+    echo "FAIL: documentation scan error was treated as no match" >&2
+    exit 1
+  fi
+  grep -Fq 'documentation scan failed' <<<"${output}"
+
+  echo "PASS: development and stable documentation contracts fail closed"
+}
+
+main "$@"

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -106,6 +106,8 @@ export default defineConfig({
           label: 'Guides',
           items: [
             { label: 'Installation and operations', slug: 'docs/installation' },
+            { label: 'Producer idempotency', slug: 'docs/producer-idempotency' },
+            { label: 'Partition keys', slug: 'docs/partition-keys' },
             { label: 'Examples', slug: 'docs/examples' },
             { label: 'Monitoring and health', slug: 'docs/monitoring' },
           ],

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -9,7 +9,7 @@ import '@fontsource/ibm-plex-sans/500.css';
 import '@fontsource/ibm-plex-sans/600.css';
 
 const installSql = `-- one file, any Postgres 14+, managed or self-hosted
-\\i sql/pgque.sql
+\\i devel/sql/pgque.sql
 select pgque.start();              -- pg_cron ticks 10x/sec
 
 select pgque.create_queue('orders');
@@ -335,8 +335,8 @@ const platformGroups = [
           </div>
           <div class="install">
             <span class="install-prompt">$</span>
-            <code>\i sql/pgque.sql</code>
-            <span class="install-note">then <code>select pgque.start();</code></span>
+            <code>\i devel/sql/pgque.sql</code>
+            <span class="install-note">main development build; then <code>select pgque.start();</code></span>
           </div>
         </div>
         <figure class="hero-visual">


### PR DESCRIPTION
## Summary

- document the 0.3 producer-idempotency and partition-key APIs end to end
- make `main` documentation explicitly track `devel/sql/`, while directing stable users to tagged docs
- add an executable documentation release-channel contract and run it in website CI/deployment
- expand reference, tutorial, examples, monitoring, installation, and website navigation
- fix a stale internal documentation anchor

## Verification

- documentation contract, shellcheck, actionlint, and diff checks
- frozen Bun install and Astro/Starlight production build (12 routes)
- every generated internal path/anchor checked across 22 HTML pages
- every local Markdown target and all 15 development SQL source targets checked
- fresh PostgreSQL 18 install with exact catalog signature/default assertions
- live atomic slot setup, idempotent retry, partition routing, claim/receive/ack/release, status, incomplete setup, and repair flows

This is intentionally stacked on #339 so the documented named-argument contract matches the final SQL signatures.

Fixes #327