### PR TITLE
fix(send-idem): reject non-finite dedup ttl

### DIFF
--- a/devel/sql/pgque-api/send_idem.sql
+++ b/devel/sql/pgque-api/send_idem.sql
@@ -63,8 +63,10 @@ begin
     if i_idem_key is null then
         raise exception 'idem_key must not be null';
     end if;
-    if i_ttl is null or i_ttl <= interval '0' then
-        raise exception 'ttl must be a positive interval';
+    /* isfinite() guards interval 'infinity' (PG 17+): a non-finite ttl would
+       create a dedup key that never expires and is never reaped by maint_idem. */
+    if i_ttl is null or i_ttl <= interval '0' or not isfinite(i_ttl) then
+        raise exception 'dedup ttl must be a positive finite interval, got %', i_ttl;
     end if;
 
     select q.queue_id, q.queue_extra_maint

--- a/devel/sql/pgque-tle.sql
+++ b/devel/sql/pgque-tle.sql
@@ -7958,8 +7958,10 @@ begin
     if i_idem_key is null then
         raise exception 'idem_key must not be null';
     end if;
-    if i_ttl is null or i_ttl <= interval '0' then
-        raise exception 'ttl must be a positive interval';
+    /* isfinite() guards interval 'infinity' (PG 17+): a non-finite ttl would
+       create a dedup key that never expires and is never reaped by maint_idem. */
+    if i_ttl is null or i_ttl <= interval '0' or not isfinite(i_ttl) then
+        raise exception 'dedup ttl must be a positive finite interval, got %', i_ttl;
     end if;
 
     select q.queue_id, q.queue_extra_maint

--- a/devel/sql/pgque.sql
+++ b/devel/sql/pgque.sql
@@ -7868,8 +7868,10 @@ begin
     if i_idem_key is null then
         raise exception 'idem_key must not be null';
     end if;
-    if i_ttl is null or i_ttl <= interval '0' then
-        raise exception 'ttl must be a positive interval';
+    /* isfinite() guards interval 'infinity' (PG 17+): a non-finite ttl would
+       create a dedup key that never expires and is never reaped by maint_idem. */
+    if i_ttl is null or i_ttl <= interval '0' or not isfinite(i_ttl) then
+        raise exception 'dedup ttl must be a positive finite interval, got %', i_ttl;
     end if;
 
     select q.queue_id, q.queue_extra_maint

--- a/tests/test_send_idem.sql
+++ b/tests/test_send_idem.sql
@@ -183,6 +183,32 @@ exception when others then
     'unexpected null idem_key error: ' || sqlerrm;
 end $$;
 
+-- send_idem rejects a non-finite dedup ttl. interval 'infinity' (PG 17+)
+-- passes a plain "> 0" check but would create a dedup key that never expires
+-- and is never reaped by maint_idem -- unbounded pgque.idem growth. The docs
+-- promise "a positive finite interval"; enforce it. Gated: infinite intervals
+-- exist only on PG 17+ (older servers reject the literal at parse time).
+do $$
+declare
+  v_pg int := current_setting('server_version_num')::int;
+begin
+  if v_pg < 170000 then
+    raise notice 'SKIP: infinite intervals require PG 17+ (server %)', v_pg;
+    return;
+  end if;
+  begin
+    perform 1
+    from pgque.send_idem(
+      'test_idem', 'migrate', '{}', 'inf:k1', 'infinity'::interval);
+    raise exception 'send_idem(infinity ttl) should fail';
+  exception when others then
+    assert sqlerrm like '%positive finite interval%',
+      'infinite dedup ttl must be rejected naming the requirement, got: '
+      || sqlerrm;
+  end;
+  raise notice 'PASS: send_idem rejects a non-finite dedup ttl';
+end $$;
+
 -- Roles: send_idem is a producer surface (pgque_writer); the pgque.idem
 -- claim table is internal -- no app role may touch it directly
 do $$


### PR DESCRIPTION
## Summary

`pgque.send_idem()` validated the dedup TTL with only a `> 0` check. On
PostgreSQL 17+, `interval 'infinity'` passes that check, creating a dedup
key that **never expires** and is never reaped by `maint_idem` — unbounded
`pgque.idem` table growth.

This adds an `isfinite()` guard to the TTL validation (same pattern used by
`claim_slot`'s lease TTL). All `send_idem` overloads reduce to the text
overload, so the single guard covers both the text and jsonb variants.

The guard makes the documented contract — a dedup TTL must be **a positive
finite interval** — actually enforced.

## Change

- `devel/sql/pgque-api/send_idem.sql`: guard becomes
  `i_ttl is null or i_ttl <= interval '0' or not isfinite(i_ttl)`, with a
  clear message: `dedup ttl must be a positive finite interval, got %`.
- Regenerated the devel assembly (`devel/sql/pgque.sql`, `pgque-tle.sql`).
- `tests/test_send_idem.sql`: new red/green test. Gated to PG 17+, where
  infinite intervals exist (older servers reject the literal at parse time).

## Validation

Fresh install of `devel/sql/pgque.sql` on PostgreSQL 18.3.

Red (before the fix): the new test fails — the infinite TTL is accepted.
```
NOTICE: PASS: jsonb overload dedups like the text overload
ERROR: infinite dedup ttl must be rejected naming the requirement, got: send_idem(infinity ttl) should fail
```

Green (after the fix):
```
NOTICE: PASS: send_idem rejects a non-finite dedup ttl
```

Both suites green on a fresh install:
- `tests/test_send_idem.sql` — 13/13 PASS
- `tests/acceptance/us13_producer_idempotency.sql` — US-13: PASSED

Commands:
```
PAGER=cat psql --no-psqlrc --single-transaction -d DB -f devel/sql/pgque.sql
PAGER=cat psql --no-psqlrc -v ON_ERROR_STOP=1 -d DB -f tests/test_send_idem.sql
PAGER=cat psql --no-psqlrc -v ON_ERROR_STOP=1 -d DB -f tests/acceptance/us13_producer_idempotency.sql
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)