### PR TITLE
docs(web): move community section lower

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -405,56 +405,6 @@ const platformGroups = [
         </div>
       </section>
 
-      <section class="community reveal" id="community">
-        <h2 class="section-title anchored"><a class="anchor-link" href="#community" aria-label="Link to this section">#</a>PgQue in the community</h2>
-        <p class="section-sub">Independent analysis, conversations, and coverage of PgQue in 2026.</p>
-        <div class="community-grid">
-          <article class="media-card">
-            <div class="media-shell" data-video-id="bBNcR14Ts4U">
-              <a class="media-facade" href="https://www.youtube.com/watch?v=bBNcR14Ts4U" target="_blank" rel="noopener" aria-label="Play Postgres.fm: PgQue on YouTube">
-                <span class="media-signal" aria-hidden="true">
-                  <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
-                </span>
-                <span class="media-play" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" width="30" height="30"><path fill="currentColor" d="M8 5v14l11-7z" /></svg>
-                </span>
-                <span class="media-show">Postgres.fm</span>
-                <span class="media-title">PgQue: a zero-bloat queue for Postgres</span>
-                <span class="media-meta">Nikolay Samokhvalov · Michael Christofides · 2026</span>
-              </a>
-            </div>
-            <div class="media-links">
-              <a href="https://postgres.fm/episodes/pgque" target="_blank" rel="noopener">Episode notes<span class="ext-arrow" aria-hidden="true">↗</span></a>
-              <span>Loads YouTube only when played</span>
-            </div>
-          </article>
-
-          <div class="coverage-list">
-            <a class="coverage-card" href="https://thebuild.com/blog/2026/05/03/pgque-two-snapshots-and-a-diff/" target="_blank" rel="noopener">
-              <span class="coverage-source">Christophe Pettus · 2026</span>
-              <strong>PgQue: Two Snapshots and a Diff</strong>
-              <span>An independent technical walk-through of how PgQue avoids row locks and dead-tuple bloat.</span>
-              <span class="coverage-arrow" aria-hidden="true">↗</span>
-            </a>
-            <a class="coverage-card" href="https://www.scalingpostgres.com/episodes/416-zero-bloat-postgres-queue/" target="_blank" rel="noopener">
-              <span class="coverage-source">Scaling Postgres · 2026</span>
-              <strong>Zero Bloat Postgres Queue</strong>
-              <span>PgQue highlighted as the lead story in episode 416.</span>
-              <span class="coverage-arrow" aria-hidden="true">↗</span>
-            </a>
-            <a class="coverage-card" href="https://postgresweekly.com/issues/645" target="_blank" rel="noopener">
-              <span class="coverage-source">Postgres Weekly · 2026</span>
-              <strong>A Kafka-like pure SQL queue for Postgres</strong>
-              <span>PgQue featured as the headline of issue 645.</span>
-              <span class="coverage-arrow" aria-hidden="true">↗</span>
-            </a>
-          </div>
-        </div>
-        <p class="community-more">
-          <a href="/docs/concepts#further-learning">See all talks, articles, and historical background →</a>
-        </p>
-      </section>
-
       <section class="band" id="compare">
         <div class="band-inner reveal">
           <h2 class="section-title anchored"><a class="anchor-link" href="#compare" aria-label="Link to this section">#</a>How it compares</h2>
@@ -578,6 +528,56 @@ const platformGroups = [
             </div>
           ))}
         </div>
+      </section>
+
+      <section class="community reveal" id="community">
+        <h2 class="section-title anchored"><a class="anchor-link" href="#community" aria-label="Link to this section">#</a>PgQue in the community</h2>
+        <p class="section-sub">Independent analysis, conversations, and coverage of PgQue in 2026.</p>
+        <div class="community-grid">
+          <article class="media-card">
+            <div class="media-shell" data-video-id="bBNcR14Ts4U">
+              <a class="media-facade" href="https://www.youtube.com/watch?v=bBNcR14Ts4U" target="_blank" rel="noopener" aria-label="Play Postgres.fm: PgQue on YouTube">
+                <span class="media-signal" aria-hidden="true">
+                  <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+                </span>
+                <span class="media-play" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" width="30" height="30"><path fill="currentColor" d="M8 5v14l11-7z" /></svg>
+                </span>
+                <span class="media-show">Postgres.fm</span>
+                <span class="media-title">PgQue: a zero-bloat queue for Postgres</span>
+                <span class="media-meta">Nikolay Samokhvalov · Michael Christofides · 2026</span>
+              </a>
+            </div>
+            <div class="media-links">
+              <a href="https://postgres.fm/episodes/pgque" target="_blank" rel="noopener">Episode notes<span class="ext-arrow" aria-hidden="true">↗</span></a>
+              <span>No YouTube tracking until you press play</span>
+            </div>
+          </article>
+
+          <div class="coverage-list">
+            <a class="coverage-card" href="https://thebuild.com/blog/2026/05/03/pgque-two-snapshots-and-a-diff/" target="_blank" rel="noopener">
+              <span class="coverage-source">Christophe Pettus · 2026</span>
+              <strong>PgQue: Two Snapshots and a Diff</strong>
+              <span>An independent technical walk-through of how PgQue avoids row locks and dead-tuple bloat.</span>
+              <span class="coverage-arrow" aria-hidden="true">↗</span>
+            </a>
+            <a class="coverage-card" href="https://www.scalingpostgres.com/episodes/416-zero-bloat-postgres-queue/" target="_blank" rel="noopener">
+              <span class="coverage-source">Scaling Postgres · 2026</span>
+              <strong>Zero Bloat Postgres Queue</strong>
+              <span>PgQue highlighted as the lead story in episode 416.</span>
+              <span class="coverage-arrow" aria-hidden="true">↗</span>
+            </a>
+            <a class="coverage-card" href="https://postgresweekly.com/issues/645" target="_blank" rel="noopener">
+              <span class="coverage-source">Postgres Weekly · 2026</span>
+              <strong>A Kafka-like pure SQL queue for Postgres</strong>
+              <span>PgQue featured as the headline of issue 645.</span>
+              <span class="coverage-arrow" aria-hidden="true">↗</span>
+            </a>
+          </div>
+        </div>
+        <p class="community-more">
+          <a href="/docs/concepts#further-learning">See all talks, articles, and historical background →</a>
+        </p>
       </section>
 
       <section class="cta-final reveal" id="install">


### PR DESCRIPTION
## Summary

- move “PgQue in the community” below Client libraries
- keep community proof immediately before the final install CTA
- replace the robotic YouTube loading note with privacy-focused copy

## Verification

- `bun install --frozen-lockfile`
- `bun run build`
- verified generated homepage section order
- `git diff --check`
