### PR TITLE
docs(web): remove playback implementation copy

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -550,7 +550,6 @@ const platformGroups = [
             </div>
             <div class="media-links">
               <a href="https://postgres.fm/episodes/pgque" target="_blank" rel="noopener">Episode notes<span class="ext-arrow" aria-hidden="true">↗</span></a>
-              <span>No YouTube tracking until you press play</span>
             </div>
           </article>
 


### PR DESCRIPTION
## Summary

- remove the visitor-facing YouTube implementation note

## Validation

- `bun run build`
- audited visible site copy for similar tracking/privacy/loading language

Follow-up to #353.
