### PR TITLE
fix(registration): prevent deadlocks and first-create races

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,11 @@ jobs:
           PGPASSWORD=pgque_test psql -h localhost -U postgres -d pgque_test \
             -v ON_ERROR_STOP=1 -f tests/run_all.sql
 
+      - name: Run registration concurrency regressions
+        env:
+          PGQUE_TEST_DSN: postgresql://postgres:pgque_test@localhost/pgque_test
+        run: bash tests/two_session_registration_locks.sh
+
       - name: Run experimental tests
         run: |
           # devel/sql/experimental/*.sql is not part of devel/sql/pgque.sql;

--- a/build/transform.sh
+++ b/build/transform.sh
@@ -506,6 +506,57 @@ mv "${TICKER_FILE}.tmp" "${TICKER_FILE}"
 
 echo "PASS: pg_notify injected into ticker function (2 injection points verified)"
 
+# PgQ's register_consumer_at uses SELECT ... FOR UPDATE followed by a plain
+# INSERT when no consumer row exists. The stronger lock conflicts with FK
+# triggers' FOR KEY SHARE locks, and a missing row gives concurrent first
+# registrars nothing to serialize on. Keep this as a transform patch rather
+# than modifying the pinned upstream PgQ submodule.
+REGISTER_CONSUMER_FILE="${OUTPUT_DIR}/functions/pgque.register_consumer.sql"
+if ! awk '
+/^    -- get consumer and create if new$/ {
+  print "    -- Get or create the consumer. NO KEY UPDATE still serializes"
+  print "    -- registrars, while remaining compatible with FK checks that take"
+  print "    -- KEY SHARE. ON CONFLICT closes the missing-row creation race."
+  print "    select co_id into x_consumer_id from pgque.consumer"
+  print "        where co_name = x_consumer_name"
+  print "        for no key update;"
+  print "    if not found then"
+  print "        insert into pgque.consumer (co_name) values (x_consumer_name)"
+  print "            on conflict (co_name) do nothing;"
+  print "        select co_id into x_consumer_id from pgque.consumer"
+  print "            where co_name = x_consumer_name"
+  print "            for no key update;"
+  print "        if not found then"
+  print "            raise exception '\''pgque.register_consumer_at: failed to create consumer %'\'', x_consumer_name;"
+  print "        end if;"
+  print "    end if;"
+  replacing = 1
+  replacements++
+  next
+}
+replacing {
+  if (/^    end if;$/) {
+    replacing = 0
+  }
+  next
+}
+{ print }
+END {
+  if (replacements != 1 || replacing) {
+    printf "ERROR: register_consumer_at acquisition patch matched %d times (expected 1)\n", \
+      replacements > "/dev/stderr"
+    exit 1
+  }
+}
+' "${REGISTER_CONSUMER_FILE}" > "${REGISTER_CONSUMER_FILE}.tmp"; then
+  rm -f "${REGISTER_CONSUMER_FILE}.tmp"
+  echo "FAIL: register_consumer_at acquisition patch did not apply" >&2
+  exit 1
+fi
+mv "${REGISTER_CONSUMER_FILE}.tmp" "${REGISTER_CONSUMER_FILE}"
+
+echo "PASS: register_consumer_at uses race-safe, FK-compatible consumer acquisition"
+
 CREATE_QUEUE_FILE="${OUTPUT_DIR}/functions/pgque.create_queue.sql"
 if ! awk '
 /^    if i_queue_name is null then$/ {

--- a/build/transform.sh
+++ b/build/transform.sh
@@ -514,9 +514,11 @@ echo "PASS: pg_notify injected into ticker function (2 injection points verified
 REGISTER_CONSUMER_FILE="${OUTPUT_DIR}/functions/pgque.register_consumer.sql"
 if ! awk '
 /^    -- get consumer and create if new$/ {
-  print "    -- Get or create the consumer. NO KEY UPDATE still serializes"
-  print "    -- registrars, while remaining compatible with FK checks that take"
-  print "    -- KEY SHARE. ON CONFLICT closes the missing-row creation race."
+  print "    /*"
+  print "     * NO KEY UPDATE serializes registrations without conflicting with"
+  print "     * subscription FK checks. The upsert/re-read path serializes"
+  print "     * concurrent creation when there is no row to lock."
+  print "     */"
   print "    select co_id into x_consumer_id from pgque.consumer"
   print "        where co_name = x_consumer_name"
   print "        for no key update;"

--- a/devel/sql/pgque-api/cooperative_consumers.sql
+++ b/devel/sql/pgque-api/cooperative_consumers.sql
@@ -529,15 +529,26 @@ begin
         raise exception 'Event queue not created yet';
     end if;
 
+    -- NO KEY UPDATE serializes registrations without conflicting with the
+    -- KEY SHARE lock used by subscription's consumer FK. The upsert/re-read
+    -- path also serializes concurrent creation when there is no row to lock.
     select co_id
     into v_main_consumer_id
     from pgque.consumer
     where co_name = i_consumer
-    for update;
+    for no key update;
     if not found then
         insert into pgque.consumer (co_name)
         values (i_consumer)
-        returning co_id into v_main_consumer_id;
+        on conflict (co_name) do nothing;
+        select co_id
+        into v_main_consumer_id
+        from pgque.consumer
+        where co_name = i_consumer
+        for no key update;
+        if not found then
+            raise exception 'pgque.register_subconsumer: failed to create consumer %', i_consumer;
+        end if;
     end if;
 
     select *
@@ -594,15 +605,24 @@ begin
         raise exception 'consumer % on queue % is not a cooperative main consumer', i_consumer, i_queue;
     end if;
 
+    -- Use the same acquisition protocol for the cooperative member row.
     select co_id
     into v_member_consumer_id
     from pgque.consumer
     where co_name = v_member_name
-    for update;
+    for no key update;
     if not found then
         insert into pgque.consumer (co_name)
         values (v_member_name)
-        returning co_id into v_member_consumer_id;
+        on conflict (co_name) do nothing;
+        select co_id
+        into v_member_consumer_id
+        from pgque.consumer
+        where co_name = v_member_name
+        for no key update;
+        if not found then
+            raise exception 'pgque.register_subconsumer: failed to create consumer %', v_member_name;
+        end if;
     end if;
 
     select *

--- a/devel/sql/pgque-api/cooperative_consumers.sql
+++ b/devel/sql/pgque-api/cooperative_consumers.sql
@@ -529,9 +529,11 @@ begin
         raise exception 'Event queue not created yet';
     end if;
 
-    -- NO KEY UPDATE serializes registrations without conflicting with the
-    -- KEY SHARE lock used by subscription's consumer FK. The upsert/re-read
-    -- path also serializes concurrent creation when there is no row to lock.
+    /*
+     * NO KEY UPDATE serializes registrations without conflicting with the
+     * KEY SHARE lock used by subscription's consumer FK. The upsert/re-read
+     * path also serializes concurrent creation when there is no row to lock.
+     */
     select co_id
     into v_main_consumer_id
     from pgque.consumer

--- a/devel/sql/pgque-tle.sql
+++ b/devel/sql/pgque-tle.sql
@@ -1908,13 +1908,21 @@ begin
         raise exception 'Event queue not created yet';
     end if;
 
-    -- get consumer and create if new
+    -- Get or create the consumer. NO KEY UPDATE still serializes
+    -- registrars, while remaining compatible with FK checks that take
+    -- KEY SHARE. ON CONFLICT closes the missing-row creation race.
     select co_id into x_consumer_id from pgque.consumer
         where co_name = x_consumer_name
-        for update;
+        for no key update;
     if not found then
-        insert into pgque.consumer (co_name) values (x_consumer_name);
-        x_consumer_id := currval('pgque.consumer_co_id_seq');
+        insert into pgque.consumer (co_name) values (x_consumer_name)
+            on conflict (co_name) do nothing;
+        select co_id into x_consumer_id from pgque.consumer
+            where co_name = x_consumer_name
+            for no key update;
+        if not found then
+            raise exception 'pgque.register_consumer_at: failed to create consumer %', x_consumer_name;
+        end if;
     end if;
 
     -- if particular tick was requested, check if it exists
@@ -6160,15 +6168,26 @@ begin
         raise exception 'Event queue not created yet';
     end if;
 
+    -- NO KEY UPDATE serializes registrations without conflicting with the
+    -- KEY SHARE lock used by subscription's consumer FK. The upsert/re-read
+    -- path also serializes concurrent creation when there is no row to lock.
     select co_id
     into v_main_consumer_id
     from pgque.consumer
     where co_name = i_consumer
-    for update;
+    for no key update;
     if not found then
         insert into pgque.consumer (co_name)
         values (i_consumer)
-        returning co_id into v_main_consumer_id;
+        on conflict (co_name) do nothing;
+        select co_id
+        into v_main_consumer_id
+        from pgque.consumer
+        where co_name = i_consumer
+        for no key update;
+        if not found then
+            raise exception 'pgque.register_subconsumer: failed to create consumer %', i_consumer;
+        end if;
     end if;
 
     select *
@@ -6225,15 +6244,24 @@ begin
         raise exception 'consumer % on queue % is not a cooperative main consumer', i_consumer, i_queue;
     end if;
 
+    -- Use the same acquisition protocol for the cooperative member row.
     select co_id
     into v_member_consumer_id
     from pgque.consumer
     where co_name = v_member_name
-    for update;
+    for no key update;
     if not found then
         insert into pgque.consumer (co_name)
         values (v_member_name)
-        returning co_id into v_member_consumer_id;
+        on conflict (co_name) do nothing;
+        select co_id
+        into v_member_consumer_id
+        from pgque.consumer
+        where co_name = v_member_name
+        for no key update;
+        if not found then
+            raise exception 'pgque.register_subconsumer: failed to create consumer %', v_member_name;
+        end if;
     end if;
 
     select *

--- a/devel/sql/pgque-tle.sql
+++ b/devel/sql/pgque-tle.sql
@@ -6168,9 +6168,11 @@ begin
         raise exception 'Event queue not created yet';
     end if;
 
-    -- NO KEY UPDATE serializes registrations without conflicting with the
-    -- KEY SHARE lock used by subscription's consumer FK. The upsert/re-read
-    -- path also serializes concurrent creation when there is no row to lock.
+    /*
+     * NO KEY UPDATE serializes registrations without conflicting with the
+     * KEY SHARE lock used by subscription's consumer FK. The upsert/re-read
+     * path also serializes concurrent creation when there is no row to lock.
+     */
     select co_id
     into v_main_consumer_id
     from pgque.consumer

--- a/devel/sql/pgque-tle.sql
+++ b/devel/sql/pgque-tle.sql
@@ -1908,9 +1908,11 @@ begin
         raise exception 'Event queue not created yet';
     end if;
 
-    -- Get or create the consumer. NO KEY UPDATE still serializes
-    -- registrars, while remaining compatible with FK checks that take
-    -- KEY SHARE. ON CONFLICT closes the missing-row creation race.
+    /*
+     * NO KEY UPDATE serializes registrations without conflicting with
+     * subscription FK checks. The upsert/re-read path serializes
+     * concurrent creation when there is no row to lock.
+     */
     select co_id into x_consumer_id from pgque.consumer
         where co_name = x_consumer_name
         for no key update;

--- a/devel/sql/pgque.sql
+++ b/devel/sql/pgque.sql
@@ -1818,13 +1818,21 @@ begin
         raise exception 'Event queue not created yet';
     end if;
 
-    -- get consumer and create if new
+    -- Get or create the consumer. NO KEY UPDATE still serializes
+    -- registrars, while remaining compatible with FK checks that take
+    -- KEY SHARE. ON CONFLICT closes the missing-row creation race.
     select co_id into x_consumer_id from pgque.consumer
         where co_name = x_consumer_name
-        for update;
+        for no key update;
     if not found then
-        insert into pgque.consumer (co_name) values (x_consumer_name);
-        x_consumer_id := currval('pgque.consumer_co_id_seq');
+        insert into pgque.consumer (co_name) values (x_consumer_name)
+            on conflict (co_name) do nothing;
+        select co_id into x_consumer_id from pgque.consumer
+            where co_name = x_consumer_name
+            for no key update;
+        if not found then
+            raise exception 'pgque.register_consumer_at: failed to create consumer %', x_consumer_name;
+        end if;
     end if;
 
     -- if particular tick was requested, check if it exists
@@ -6070,15 +6078,26 @@ begin
         raise exception 'Event queue not created yet';
     end if;
 
+    -- NO KEY UPDATE serializes registrations without conflicting with the
+    -- KEY SHARE lock used by subscription's consumer FK. The upsert/re-read
+    -- path also serializes concurrent creation when there is no row to lock.
     select co_id
     into v_main_consumer_id
     from pgque.consumer
     where co_name = i_consumer
-    for update;
+    for no key update;
     if not found then
         insert into pgque.consumer (co_name)
         values (i_consumer)
-        returning co_id into v_main_consumer_id;
+        on conflict (co_name) do nothing;
+        select co_id
+        into v_main_consumer_id
+        from pgque.consumer
+        where co_name = i_consumer
+        for no key update;
+        if not found then
+            raise exception 'pgque.register_subconsumer: failed to create consumer %', i_consumer;
+        end if;
     end if;
 
     select *
@@ -6135,15 +6154,24 @@ begin
         raise exception 'consumer % on queue % is not a cooperative main consumer', i_consumer, i_queue;
     end if;
 
+    -- Use the same acquisition protocol for the cooperative member row.
     select co_id
     into v_member_consumer_id
     from pgque.consumer
     where co_name = v_member_name
-    for update;
+    for no key update;
     if not found then
         insert into pgque.consumer (co_name)
         values (v_member_name)
-        returning co_id into v_member_consumer_id;
+        on conflict (co_name) do nothing;
+        select co_id
+        into v_member_consumer_id
+        from pgque.consumer
+        where co_name = v_member_name
+        for no key update;
+        if not found then
+            raise exception 'pgque.register_subconsumer: failed to create consumer %', v_member_name;
+        end if;
     end if;
 
     select *

--- a/devel/sql/pgque.sql
+++ b/devel/sql/pgque.sql
@@ -6078,9 +6078,11 @@ begin
         raise exception 'Event queue not created yet';
     end if;
 
-    -- NO KEY UPDATE serializes registrations without conflicting with the
-    -- KEY SHARE lock used by subscription's consumer FK. The upsert/re-read
-    -- path also serializes concurrent creation when there is no row to lock.
+    /*
+     * NO KEY UPDATE serializes registrations without conflicting with the
+     * KEY SHARE lock used by subscription's consumer FK. The upsert/re-read
+     * path also serializes concurrent creation when there is no row to lock.
+     */
     select co_id
     into v_main_consumer_id
     from pgque.consumer

--- a/devel/sql/pgque.sql
+++ b/devel/sql/pgque.sql
@@ -1818,9 +1818,11 @@ begin
         raise exception 'Event queue not created yet';
     end if;
 
-    -- Get or create the consumer. NO KEY UPDATE still serializes
-    -- registrars, while remaining compatible with FK checks that take
-    -- KEY SHARE. ON CONFLICT closes the missing-row creation race.
+    /*
+     * NO KEY UPDATE serializes registrations without conflicting with
+     * subscription FK checks. The upsert/re-read path serializes
+     * concurrent creation when there is no row to lock.
+     */
     select co_id into x_consumer_id from pgque.consumer
         where co_name = x_consumer_name
         for no key update;

--- a/tests/two_session_registration_locks.sh
+++ b/tests/two_session_registration_locks.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+# Regression coverage for consumer registration lock ordering and first-create races.
+# Copyright 2026 Nikolay Samokhvalov. Apache-2.0 license.
+# Includes code derived from PgQ (ISC license, Marko Kreen / Skype Technologies OU).
+set -Eeuo pipefail
+
+# Usage:
+#   PGQUE_TEST_DSN=postgresql://postgres:***@localhost/pgque_test \
+#     tests/two_session_registration_locks.sh
+#
+# The target database must already have devel/sql/pgque.sql installed.
+
+if [[ -z "${PGQUE_TEST_DSN:-}" ]]; then
+  echo "PGQUE_TEST_DSN is required" >&2
+  exit 2
+fi
+
+psql_base=(psql --no-psqlrc -v ON_ERROR_STOP=1 "${PGQUE_TEST_DSN}")
+suffix="${$}_$(date +%s)"
+race_queue="registration_race_${suffix}"
+coop_queue="registration_coop_race_${suffix}"
+lock_queue="registration_lock_edge_${suffix}"
+race_consumer="race_${suffix}"
+coop_consumer="coop_${suffix}"
+lock_consumer="lock_${suffix}"
+trigger_name="registration_race_barrier_${$}"
+trigger_function="registration_race_barrier_${$}"
+workdir="$(mktemp -d)"
+
+cleanup() {
+  "${psql_base[@]}" -qAtc "
+    drop trigger if exists ${trigger_name} on pgque.consumer;
+    drop function if exists pgque.${trigger_function}();
+    select pgque.drop_queue('${race_queue}', true);
+    select pgque.drop_queue('${coop_queue}', true);
+    select pgque.unsubscribe_slot('${lock_queue}', '${lock_consumer}', 0);
+    select pgque.unsubscribe_slot('${lock_queue}', '${lock_consumer}', 1);
+    select pgque.drop_queue('${lock_queue}', true);
+  " >/dev/null 2>&1 || true
+  rm -rf "${workdir}"
+}
+trap cleanup EXIT
+
+print_debug() {
+  for f in "${workdir}"/*; do
+    [[ -f "${f}" ]] || continue
+    echo "--- $(basename "${f}") ---" >&2
+    cat "${f}" >&2 || true
+  done
+}
+
+wait_for_advisory_waiters() {
+  local app_prefix="$1"
+  local expected="$2"
+  local count
+
+  for _ in $(seq 1 50); do
+    count="$("${psql_base[@]}" -qAtc "
+      select count(*)
+      from pg_stat_activity
+      where application_name like '${app_prefix}%'
+        and wait_event_type = 'Lock'
+        and wait_event = 'advisory'
+    ")"
+    if (( count >= expected )); then
+      return 0
+    fi
+    sleep 0.1
+  done
+
+  echo "FAIL: expected ${expected} ${app_prefix} sessions at the registration barrier, saw ${count}" >&2
+  print_debug
+  return 1
+}
+
+run_barrier_locker() {
+  local lock_key="$1"
+  local app_name="$2"
+
+  PGAPPNAME="${app_name}" "${psql_base[@]}" -qAt >"${workdir}/${app_name}.out" 2>"${workdir}/${app_name}.err" <<SQL &
+select pg_advisory_lock(${lock_key});
+select pg_sleep(5);
+select pg_advisory_unlock(${lock_key});
+SQL
+  barrier_locker_pid=$!
+}
+
+# A test-only trigger puts every matching consumer INSERT behind an advisory
+# barrier. Both callers therefore complete their initial "row not found"
+# lookup before either INSERT can commit.
+"${psql_base[@]}" >"${workdir}/setup.out" 2>"${workdir}/setup.err" <<SQL
+select pgque.create_queue('${race_queue}');
+select pgque.create_queue('${coop_queue}');
+select pgque.create_queue('${lock_queue}');
+
+create function pgque.${trigger_function}()
+returns trigger
+language plpgsql
+as \$\$
+begin
+  if new.co_name like 'race_${suffix}%'
+     or new.co_name like 'coop_${suffix}%' then
+    perform pg_advisory_xact_lock(
+      case
+        when new.co_name like 'race_${suffix}%' then 357001
+        else 357002
+      end
+    );
+  end if;
+  return new;
+end
+\$\$;
+
+create trigger ${trigger_name}
+before insert on pgque.consumer
+for each row execute function pgque.${trigger_function}();
+SQL
+
+# Case 1: two ordinary first registrations must not collide.
+run_barrier_locker 357001 race_locker
+locker_pid="${barrier_locker_pid}"
+sleep 0.2
+race_pids=()
+for worker in $(seq 1 8); do
+  PGAPPNAME="race_worker_${worker}_${suffix}" \
+    "${psql_base[@]}" -qAtc \
+      "select pgque.register_consumer('${race_queue}', '${race_consumer}')" \
+      >"${workdir}/race_worker_${worker}.out" \
+      2>"${workdir}/race_worker_${worker}.err" &
+  race_pids+=("$!")
+done
+wait_for_advisory_waiters "race_worker_%_${suffix}" 8
+
+set +e
+race_status=0
+for pid in "${race_pids[@]}"; do
+  wait "${pid}" || race_status=$?
+done
+wait "${locker_pid}"; locker_status=$?
+set -e
+if (( race_status != 0 || locker_status != 0 )); then
+  echo "FAIL: concurrent first registration raised an error" >&2
+  print_debug
+  exit 1
+fi
+fresh_total="$(
+  awk '/^[01]$/ { sum += $1 } END { print sum + 0 }' "${workdir}"/race_worker_*.out
+)"
+if (( fresh_total != 1 )); then
+  echo "FAIL: exactly one ordinary registration must be fresh, got ${fresh_total}" >&2
+  print_debug
+  exit 1
+fi
+
+# Case 2: register_consumer_at racing register_subconsumer must safely form
+# one cooperative main plus the requested member.
+run_barrier_locker 357002 coop_locker
+locker_pid="${barrier_locker_pid}"
+sleep 0.2
+PGAPPNAME="coop_anchor_${suffix}" \
+  "${psql_base[@]}" -qAtc "
+    select pgque.register_consumer_at(
+      '${coop_queue}',
+      '${coop_consumer}',
+      (
+        select min(t.tick_id)
+        from pgque.tick t
+        join pgque.queue q on q.queue_id = t.tick_queue
+        where q.queue_name = '${coop_queue}'
+      )
+    )
+  " >"${workdir}/coop_anchor.out" 2>"${workdir}/coop_anchor.err" &
+coop_anchor_pid=$!
+coop_member_pids=()
+for member in $(seq 1 4); do
+  PGAPPNAME="coop_member_${member}_${suffix}" \
+    "${psql_base[@]}" -qAtc \
+      "select pgque.register_subconsumer('${coop_queue}', '${coop_consumer}', 'm${member}', true)" \
+      >"${workdir}/coop_member_${member}.out" 2>"${workdir}/coop_member_${member}.err" &
+  coop_member_pids+=("$!")
+done
+wait_for_advisory_waiters "coop_%_${suffix}" 5
+
+set +e
+wait "${coop_anchor_pid}"; coop_anchor_status=$?
+coop_member_status=0
+for pid in "${coop_member_pids[@]}"; do
+  wait "${pid}" || coop_member_status=$?
+done
+wait "${locker_pid}"; coop_locker_status=$?
+set -e
+if (( coop_anchor_status != 0 || coop_member_status != 0 || coop_locker_status != 0 )); then
+  echo "FAIL: concurrent cooperative group formation raised an error" >&2
+  print_debug
+  exit 1
+fi
+"${psql_base[@]}" -qAt >"${workdir}/coop_assert.out" 2>"${workdir}/coop_assert.err" <<SQL
+do \$\$
+declare
+  v_main_count integer;
+  v_member_count integer;
+  v_main_role text;
+begin
+  select count(*) into v_main_count
+  from pgque.consumer
+  where co_name = '${coop_consumer}';
+  assert v_main_count = 1, format('expected one cooperative main consumer row, got %s', v_main_count);
+
+  select count(*) into v_member_count
+  from pgque.consumer
+  where co_name like '${coop_consumer}.m%';
+  assert v_member_count = 4, format('expected four cooperative member consumer rows, got %s', v_member_count);
+
+  select s.sub_role into v_main_role
+  from pgque.subscription s
+  join pgque.consumer c on c.co_id = s.sub_consumer
+  join pgque.queue q on q.queue_id = s.sub_queue
+  where q.queue_name = '${coop_queue}'
+    and c.co_name = '${coop_consumer}';
+  assert v_main_role = 'coop_main', format('expected coop_main role, got %s', v_main_role);
+end
+\$\$;
+SQL
+
+# Case 3: an open registrar transaction may serialize other registrars, but it
+# must not block the FK trigger's FOR KEY SHARE during receive_partitioned's
+# empty-batch finish path.
+"${psql_base[@]}" >"${workdir}/lock_setup.out" 2>"${workdir}/lock_setup.err" <<SQL
+select pgque.register_consumer('${lock_queue}', '${lock_consumer}#0/2');
+select pgque.register_consumer('${lock_queue}', '${lock_consumer}#1/2');
+select pgque.subscribe_slot('${lock_queue}', '${lock_consumer}', 0, 2);
+select pgque.subscribe_slot('${lock_queue}', '${lock_consumer}', 1, 2);
+select pgque.claim_slot('${lock_queue}', '${lock_consumer}', 0, 'w0', interval '60 seconds');
+
+with keys as (
+  select key
+  from (
+    select 'k' || s as key
+    from generate_series(1, 64) s
+  ) candidates
+  where ((hashtextextended(key, 0) % 2) + 2) % 2 = 1
+  limit 5
+)
+select pgque.insert_event('${lock_queue}', 't', '{}', key, null, null, null)
+from keys;
+select pgque.force_tick('${lock_queue}');
+select pgque.ticker('${lock_queue}');
+SQL
+
+PGAPPNAME="registration_holder_${suffix}" \
+  "${psql_base[@]}" >"${workdir}/registration_holder.out" 2>"${workdir}/registration_holder.err" <<SQL &
+begin;
+select pgque.register_consumer_at('${lock_queue}', '${lock_consumer}#0/2', null);
+select pg_sleep(5);
+rollback;
+SQL
+registration_holder_pid=$!
+
+holder_ready=0
+for _ in $(seq 1 50); do
+  if "${psql_base[@]}" -qAtc "
+    select 1
+    from pg_stat_activity
+    where application_name = 'registration_holder_${suffix}'
+      and state = 'active'
+      and wait_event_type = 'Timeout'
+      and wait_event = 'PgSleep'
+      and query like 'select pg_sleep(%'
+  " | grep -q 1; then
+    holder_ready=1
+    break
+  fi
+  sleep 0.1
+done
+if (( holder_ready != 1 )); then
+  echo "FAIL: registration holder did not reach pg_sleep" >&2
+  print_debug
+  exit 1
+fi
+
+set +e
+"${psql_base[@]}" >"${workdir}/receiver.out" 2>"${workdir}/receiver.err" <<SQL
+set statement_timeout = '3s';
+do \$\$
+declare
+  v_count integer;
+begin
+  select count(*) into v_count
+  from pgque.receive_partitioned(
+    '${lock_queue}',
+    '${lock_consumer}',
+    0,
+    2,
+    'w0',
+    50
+  );
+  assert v_count = 0, format('expected an empty filtered batch, got %s events', v_count);
+end
+\$\$;
+SQL
+receiver_status=$?
+wait "${registration_holder_pid}"
+holder_status=$?
+set -e
+if (( receiver_status != 0 || holder_status != 0 )); then
+  echo "FAIL: open registration blocked the partition receive/finish path" >&2
+  print_debug
+  exit 1
+fi
+
+echo "PASS: first registrations serialize without unique violations; registration locks remain compatible with partition receive FK checks"

--- a/tests/two_session_registration_locks.sh
+++ b/tests/two_session_registration_locks.sh
@@ -25,21 +25,95 @@ coop_consumer="coop_${suffix}"
 lock_consumer="lock_${suffix}"
 trigger_name="registration_race_barrier_${$}"
 trigger_function="registration_race_barrier_${$}"
+barrier_table="registration_barrier_${$}"
+race_lock_key=$((357000000 + ($$ % 100000) * 2))
+coop_lock_key=$((race_lock_key + 1))
 workdir="$(mktemp -d)"
+locker_start_delay="${PGQUE_TEST_LOCKER_START_DELAY:-0}"
+
+if [[ ! "${locker_start_delay}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+  echo "PGQUE_TEST_LOCKER_START_DELAY must be a non-negative number" >&2
+  exit 2
+fi
 
 cleanup() {
+  local cleanup_status=0
+  local residue
+
+  set +e
   "${psql_base[@]}" -qAtc "
-    drop trigger if exists ${trigger_name} on pgque.consumer;
-    drop function if exists pgque.${trigger_function}();
-    select pgque.drop_queue('${race_queue}', true);
-    select pgque.drop_queue('${coop_queue}', true);
-    select pgque.unsubscribe_slot('${lock_queue}', '${lock_consumer}', 0);
-    select pgque.unsubscribe_slot('${lock_queue}', '${lock_consumer}', 1);
-    select pgque.drop_queue('${lock_queue}', true);
-  " >/dev/null 2>&1 || true
+    select pg_terminate_backend(pid)
+    from pg_stat_activity
+    where pid <> pg_backend_pid()
+      and application_name like '%${suffix}';
+  " >/dev/null 2>&1 || cleanup_status=1
+  "${psql_base[@]}" -qAtc \
+    "drop trigger if exists ${trigger_name} on pgque.consumer" \
+    >/dev/null 2>&1 || cleanup_status=1
+  "${psql_base[@]}" -qAtc \
+    "drop function if exists pgque.${trigger_function}()" \
+    >/dev/null 2>&1 || cleanup_status=1
+  for member in $(seq 1 4); do
+    "${psql_base[@]}" -qAtc \
+      "select pgque.unregister_subconsumer('${coop_queue}', '${coop_consumer}', 'm${member}')" \
+      >/dev/null 2>&1 || cleanup_status=1
+  done
+  "${psql_base[@]}" -qAtc \
+    "select pgque.drop_queue('${race_queue}', true)" \
+    >/dev/null 2>&1 || cleanup_status=1
+  "${psql_base[@]}" -qAtc \
+    "select pgque.drop_queue('${coop_queue}', true)" \
+    >/dev/null 2>&1 || cleanup_status=1
+  for slot in 0 1; do
+    "${psql_base[@]}" -qAtc \
+      "select pgque.unsubscribe_slot('${lock_queue}', '${lock_consumer}', ${slot})" \
+      >/dev/null 2>&1 || cleanup_status=1
+  done
+  "${psql_base[@]}" -qAtc \
+    "select pgque.drop_queue('${lock_queue}', true)" \
+    >/dev/null 2>&1 || cleanup_status=1
+  "${psql_base[@]}" -qAtc \
+    "drop table if exists pgque.${barrier_table}" \
+    >/dev/null 2>&1 || cleanup_status=1
+
+  residue="$("${psql_base[@]}" -qAtc "
+    select
+      (
+        select count(*)
+        from pg_trigger
+        where tgname = '${trigger_name}'
+          and not tgisinternal
+      )
+      + (
+        select count(*)
+        from pg_proc
+        where pronamespace = 'pgque'::regnamespace
+          and proname = '${trigger_function}'
+      )
+      + (
+        select count(*)
+        from pgque.queue
+        where queue_name in ('${race_queue}', '${coop_queue}', '${lock_queue}')
+      )
+      + (
+        select count(*)
+        from pg_class
+        where relnamespace = 'pgque'::regnamespace
+          and relname = '${barrier_table}'
+      )
+  " 2>/dev/null)"
+  if [[ "${residue}" != "0" ]]; then
+    echo "FAIL: registration concurrency cleanup left ${residue:-unknown} database objects" >&2
+    cleanup_status=1
+  fi
   rm -rf "${workdir}"
+  set -e
+  return "${cleanup_status}"
 }
 trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
 
 print_debug() {
   for f in "${workdir}"/*; do
@@ -73,17 +147,77 @@ wait_for_advisory_waiters() {
   return 1
 }
 
+wait_for_locker_ready() {
+  local lock_key="$1"
+  local ready
+
+  for _ in $(seq 1 100); do
+    ready="$("${psql_base[@]}" -qAtc "
+      select ready
+      from pgque.${barrier_table}
+      where lock_key = ${lock_key}
+    ")"
+    if [[ "${ready}" == "t" ]]; then
+      return 0
+    fi
+    sleep 0.1
+  done
+
+  echo "FAIL: advisory barrier ${lock_key} was not acquired" >&2
+  print_debug
+  return 1
+}
+
+release_barrier() {
+  local lock_key="$1"
+
+  "${psql_base[@]}" -qAtc "
+    update pgque.${barrier_table}
+    set release = true
+    where lock_key = ${lock_key}
+  " >/dev/null
+}
+
 run_barrier_locker() {
   local lock_key="$1"
   local app_name="$2"
 
   PGAPPNAME="${app_name}" "${psql_base[@]}" -qAt >"${workdir}/${app_name}.out" 2>"${workdir}/${app_name}.err" <<SQL &
+select pg_sleep(${locker_start_delay});
 select pg_advisory_lock(${lock_key});
-select pg_sleep(5);
+insert into pgque.${barrier_table} (lock_key, ready, release)
+values (${lock_key}, true, false);
+do \$\$
+declare
+  v_release boolean;
+begin
+  for i in 1..600 loop
+    select release
+    into v_release
+    from pgque.${barrier_table}
+    where lock_key = ${lock_key};
+    exit when v_release;
+    perform pg_sleep(0.05);
+  end loop;
+  if not v_release then
+    raise exception 'timed out waiting to release advisory barrier ${lock_key}';
+  end if;
+end
+\$\$;
 select pg_advisory_unlock(${lock_key});
 SQL
   barrier_locker_pid=$!
 }
+
+# Installing a trigger on pgque.consumer is only appropriate in a disposable
+# test database. Allow an explicit override for unusual local naming schemes.
+database_name="$("${psql_base[@]}" -qAtc "select current_database()")"
+if [[ ! "${database_name}" =~ (^|_)test($|_) ]] \
+   && [[ "${PGQUE_ALLOW_TEST_MUTATION:-}" != "1" ]]; then
+  echo "FAIL: refusing to install a test trigger in database '${database_name}'" >&2
+  echo "      use a database name containing 'test' or set PGQUE_ALLOW_TEST_MUTATION=1" >&2
+  exit 2
+fi
 
 # A test-only trigger puts every matching consumer INSERT behind an advisory
 # barrier. Both callers therefore complete their initial "row not found"
@@ -92,6 +226,12 @@ SQL
 select pgque.create_queue('${race_queue}');
 select pgque.create_queue('${coop_queue}');
 select pgque.create_queue('${lock_queue}');
+
+create table pgque.${barrier_table} (
+  lock_key bigint primary key,
+  ready boolean not null,
+  release boolean not null
+);
 
 create function pgque.${trigger_function}()
 returns trigger
@@ -102,8 +242,8 @@ begin
      or new.co_name like 'coop_${suffix}%' then
     perform pg_advisory_xact_lock(
       case
-        when new.co_name like 'race_${suffix}%' then 357001
-        else 357002
+        when new.co_name like 'race_${suffix}%' then ${race_lock_key}
+        else ${coop_lock_key}
       end
     );
   end if;
@@ -117,9 +257,9 @@ for each row execute function pgque.${trigger_function}();
 SQL
 
 # Case 1: two ordinary first registrations must not collide.
-run_barrier_locker 357001 race_locker
+run_barrier_locker "${race_lock_key}" race_locker
 locker_pid="${barrier_locker_pid}"
-sleep 0.2
+wait_for_locker_ready "${race_lock_key}"
 race_pids=()
 for worker in $(seq 1 8); do
   PGAPPNAME="race_worker_${worker}_${suffix}" \
@@ -130,6 +270,7 @@ for worker in $(seq 1 8); do
   race_pids+=("$!")
 done
 wait_for_advisory_waiters "race_worker_%_${suffix}" 8
+release_barrier "${race_lock_key}"
 
 set +e
 race_status=0
@@ -154,9 +295,9 @@ fi
 
 # Case 2: register_consumer_at racing register_subconsumer must safely form
 # one cooperative main plus the requested member.
-run_barrier_locker 357002 coop_locker
+run_barrier_locker "${coop_lock_key}" coop_locker
 locker_pid="${barrier_locker_pid}"
-sleep 0.2
+wait_for_locker_ready "${coop_lock_key}"
 PGAPPNAME="coop_anchor_${suffix}" \
   "${psql_base[@]}" -qAtc "
     select pgque.register_consumer_at(
@@ -180,6 +321,7 @@ for member in $(seq 1 4); do
   coop_member_pids+=("$!")
 done
 wait_for_advisory_waiters "coop_%_${suffix}" 5
+release_barrier "${coop_lock_key}"
 
 set +e
 wait "${coop_anchor_pid}"; coop_anchor_status=$?
@@ -238,7 +380,8 @@ with keys as (
     select 'k' || s as key
     from generate_series(1, 64) s
   ) candidates
-  where ((hashtextextended(key, 0) % 2) + 2) % 2 = 1
+  /* Keep this predicate aligned with partition_keys.sql's slot routing. */
+  where ((pg_catalog.hashtextextended(key, 0) % 2) + 2) % 2 = 1
   limit 5
 )
 select pgque.insert_event('${lock_queue}', 't', '{}', key, null, null, null)
@@ -308,4 +451,9 @@ if (( receiver_status != 0 || holder_status != 0 )); then
   exit 1
 fi
 
+if ! cleanup; then
+  trap - EXIT INT TERM HUP
+  exit 1
+fi
+trap - EXIT INT TERM HUP
 echo "PASS: first registrations serialize without unique violations; registration locks remain compatible with partition receive FK checks"


### PR DESCRIPTION
## Summary

- acquire existing consumer rows with `FOR NO KEY UPDATE`, preserving registrar serialization without conflicting with subscription FK checks
- create missing ordinary, cooperative-main, and cooperative-member rows with `INSERT ... ON CONFLICT DO NOTHING` followed by a locking re-read
- add deterministic multi-session regressions for ordinary first-registration races, mixed cooperative group formation, and the partition receive/finish lock edge
- run the concurrency regression across the supported PostgreSQL CI matrix

Fixes https://github.com/NikolayS/PgQue/issues/357

## Why

`FOR UPDATE` conflicts with the `FOR KEY SHARE` lock taken by the
`subscription.sub_consumer -> consumer.co_id` foreign-key trigger. Together
with partition-slot lease renewal, that creates the registration/receive
AB-BA deadlock observed by Wave.

The old `SELECT ... FOR UPDATE; if not found INSERT` protocol also had no row
to lock during first registration, so concurrent creators could collide on
`consumer_name_uq`.

## Testing

- Red: deterministic advisory-barrier test reproduced `consumer_name_uq` on unmodified `main`
- Green: `tests/two_session_registration_locks.sh` passes with:
  - 8 simultaneous first registrations of one ordinary consumer
  - `register_consumer_at` racing 4 cooperative members for one new group
  - an open registrar transaction concurrent with an empty filtered `receive_partitioned` batch
- PostgreSQL 17: `tests/run_all.sql`
- PostgreSQL 17: `tests/acceptance/run_acceptance.sql`
- `bash build/transform.sh`
- `git diff --check`
