### PR TITLE
docs: add agent model-tiering rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,8 +154,7 @@ pgque/
 ## Agentic Engineering Rules
 
 - Use red/green TDD for new code: write the failing test first, then the implementation.
-- Delegate collection and legwork to the cheapest capable agent tier (Haiku
-  for mechanical fetch/check tasks, Sonnet for structured research sweeps);
+- Delegate collection and legwork to the cheapest capable agent tier;
   reserve top-tier models for adversarial verification and synthesis.
 - Keep changes surgical: one logical fix or feature per PR.
 - Preserve PgQ core behavior unless the change is intentional, documented, and tested.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,9 @@ pgque/
 ## Agentic Engineering Rules
 
 - Use red/green TDD for new code: write the failing test first, then the implementation.
+- Delegate collection and legwork to the cheapest capable agent tier (Haiku
+  for mechanical fetch/check tasks, Sonnet for structured research sweeps);
+  reserve top-tier models for adversarial verification and synthesis.
 - Keep changes surgical: one logical fix or feature per PR.
 - Preserve PgQ core behavior unless the change is intentional, documented, and tested.
 - Keep the default install managed-Postgres-compatible: no C extension, no `shared_preload_libraries`, no restart requirement.


### PR DESCRIPTION
Adds one rule to CLAUDE.md's Agentic Engineering Rules, per maintainer request: delegate collection and legwork to the cheapest capable agent tier (Haiku for mechanical fetch/check tasks, Sonnet for structured research sweeps), reserving top-tier models for adversarial verification and synthesis.

Docs-only change; no code affected. Verification: none needed beyond reading the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCMG7UUT17a8xKco9owbDe

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCMG7UUT17a8xKco9owbDe)_